### PR TITLE
Added cache/logs custom path

### DIFF
--- a/src/classes/Context/Answer.ts
+++ b/src/classes/Context/Answer.ts
@@ -44,7 +44,7 @@ import { IViewInfo } from '../../types/view.types';
 
 export class Answer {
   private readonly scopeController: ScopeController = new ScopeController();
-  readonly api: Api = new Api(this.token);
+  readonly api: Api = new Api(this.token, this.handler.cachePath);
 
   constructor(
     private readonly token: string,

--- a/src/classes/Helpers/FileLogger.ts
+++ b/src/classes/Helpers/FileLogger.ts
@@ -3,11 +3,17 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 
 export class FileLogger {
-  nestgramInfoDirPath: string = path.resolve(process.cwd(), 'nestgram');
-  logsFilePath: string = path.resolve(this.nestgramInfoDirPath, 'logs.md');
+  nestgramInfoDirPath: string;
+  logsFilePath: string;
 
-  constructor(private readonly limit: number) {
-    this.setupLogsFile();
+  constructor(private readonly limit: number,
+              private readonly isFileLoggingEnabled: boolean,
+              private readonly cachePath?: string) {
+    if (isFileLoggingEnabled) {
+      this.nestgramInfoDirPath = path.resolve(cachePath || process.cwd(), 'nestgram');
+      this.logsFilePath = path.resolve(this.nestgramInfoDirPath, 'logs.md');
+      this.setupLogsFile();
+    }
   }
 
   private async setupLogsFile(): Promise<void> {

--- a/src/classes/Launch/Handler.ts
+++ b/src/classes/Launch/Handler.ts
@@ -55,7 +55,7 @@ import { scopeStore } from '../Scope/ScopeStore';
 import { stateStore } from '../State/StateStore';
 
 export class Handler {
-  fileLogger: FileLogger = new FileLogger(this.fileLoggingLimit);
+  fileLogger: FileLogger = new FileLogger(this.fileLoggingLimit, this.fileLogging, this.cachePath);
   handlers: IHandler[] = [];
   scopes: IHandler[] = [];
 
@@ -65,6 +65,7 @@ export class Handler {
     private readonly logging?: boolean,
     private readonly fileLogging?: boolean,
     private readonly fileLoggingLimit?: number,
+    public cachePath?: string,
   ) {
     this.handlers = allHandlers.filter((handler: IHandler): boolean => !handler.scope) || [];
     this.scopes = allHandlers.filter((handler: IHandler): boolean => !!handler.scope) || [];

--- a/src/classes/Launch/Polling.ts
+++ b/src/classes/Launch/Polling.ts
@@ -4,13 +4,14 @@ import { Handler } from './Handler';
 import { Api } from '../Api';
 
 export class Polling {
-  api: Api = new Api(this.token);
+  api: Api = new Api(this.token, this.cachePath);
   handler: Handler = new Handler(
     this.token,
     this.handlers,
     this.logging,
     this.fileLogging,
     this.fileLoggingLimit,
+    this.cachePath,
   );
 
   constructor(
@@ -20,6 +21,7 @@ export class Polling {
     private readonly logging?: boolean,
     private readonly fileLogging?: boolean,
     private readonly fileLoggingLimit?: number,
+    private readonly cachePath?: string,
   ) {
     if (!this.token) throw error(`You can't run bot without token`);
   }
@@ -39,7 +41,7 @@ export class Polling {
     }
   }
 
-  private async *updateGetter(): AsyncIterableIterator<Promise<any>> {
+  private async* updateGetter(): AsyncIterableIterator<Promise<any>> {
     while (true) {
       const updates = await this.api.call<IUpdate, IPollingConfig>(
         this.token,

--- a/src/classes/Launch/Webhook.ts
+++ b/src/classes/Launch/Webhook.ts
@@ -7,7 +7,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import * as http from 'http';
 
 export class Webhook {
-  api: Api = new Api(this.token);
+  api: Api = new Api(this.token, this.cachePath);
   server: http.Server;
 
   handler: Handler = new Handler(
@@ -16,6 +16,7 @@ export class Webhook {
     this.logging,
     this.fileLogging,
     this.fileLoggingLimit,
+    this.cachePath,
   );
 
   constructor(
@@ -25,6 +26,7 @@ export class Webhook {
     private readonly logging?: boolean,
     private readonly fileLogging?: boolean,
     private readonly fileLoggingLimit?: number,
+    private readonly cachePath?: string,
   ) {
     if (!this.token) throw error(`You can't run bot without token`);
     this.api.setWebhook(this.config);

--- a/src/classes/Media/MediaCache.ts
+++ b/src/classes/Media/MediaCache.ts
@@ -4,11 +4,13 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 
 export class MediaCache {
-  nestgramInfoDirPath: string = path.resolve(process.cwd(), 'nestgram');
-  mediaKeeperFilePath: string = path.resolve(this.nestgramInfoDirPath, 'media.json');
+  nestgramInfoDirPath: string;
+  mediaKeeperFilePath: string;
   file: editJsonFile.JsonEditor;
 
-  constructor() {
+  constructor(private readonly cachePath?: string) {
+    this.nestgramInfoDirPath = path.resolve(cachePath || process.cwd(), 'nestgram');
+    this.mediaKeeperFilePath = path.resolve(this.nestgramInfoDirPath, 'media.json');
     this.getJSONFile();
   }
 
@@ -38,4 +40,4 @@ export class MediaCache {
   }
 }
 
-export const mediaCache = new MediaCache();
+export default MediaCache;

--- a/src/nest-gram.ts
+++ b/src/nest-gram.ts
@@ -28,7 +28,7 @@ export class NestGram {
   handlers: IHandler[] = [];
   info: IUser;
 
-  api: Api = new Api(this.token);
+  api: Api = new Api(this.token, this.runConfig.cachePath);
   polling?: Polling;
   webhook?: Webhook;
 
@@ -159,7 +159,7 @@ export class NestGram {
    * @param token Bot token you want to get property class
    * */
   to(token: string): Api {
-    return new Api(token);
+    return new Api(token, this.runConfig.cachePath);
   }
 
   /**
@@ -188,6 +188,7 @@ export class NestGram {
         this.runConfig.logging,
         this.runConfig.fileLogging,
         this.runConfig.fileLoggingLimit,
+        this.runConfig.cachePath,
       );
 
       // start polling
@@ -205,6 +206,7 @@ export class NestGram {
         this.runConfig.logging,
         this.runConfig.fileLogging,
         this.runConfig.fileLoggingLimit,
+        this.runConfig.cachePath,
       );
     }
 

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -37,6 +37,7 @@ export interface IRunConfig extends IGlobalWebhookConfig {
   port?: number;
   fileLogging?: boolean;
   fileLoggingLimit?: number;
+  cachePath?: string;
 }
 
 export interface IDeleteWebhookConfig extends IGlobalWebhookConfig {}


### PR DESCRIPTION
This improvement is adding a possibility to configure a custom cache and logs directory instead of './nestgram'. This is important if the library is deployed to a read-only filesystem and there is no access to './' directory. With this improvement, it can be remapped.