### PR TITLE
feat: run several bots from one app (multi-bot)

### DIFF
--- a/docs/commands-and-keyboards.md
+++ b/docs/commands-and-keyboards.md
@@ -144,6 +144,31 @@ the `buy` press — and carrying typed data in a button (`buy:42`-style)
 without magic strings — is the next page,
 [Callbacks →](/docs/callbacks).
 
+### Colouring buttons
+
+Telegram lets a button carry a `style`: `primary` (blue), `success` (green) or
+`danger` (red). A colour modifier styles the **next** button only, so it reads
+like a label on the button it precedes:
+
+:::code[confirm.router.ts]{mark="2,4"}
+
+```ts
+const keyboard = new InlineKeyboard()
+  .success()
+  .text('Confirm', 'confirm')
+  .danger()
+  .text('Cancel', 'cancel')
+  .text('Later', 'later'); // no modifier → the app's default style
+```
+
+:::
+
+The modifier is one-shot (`Later` above stays default) and is consumed even
+when the button is hidden — so a conditional button never leaks its colour onto
+the next one: `.danger().text('Delete', 'del', !canDelete)` simply drops when
+`canDelete` is false. The same `.primary()`/`.success()`/`.danger()` work on a
+`ReplyKeyboard`.
+
 ## Reply keyboards
 
 Same builder shape, for the custom keyboard under the input field:

--- a/docs/multiple-bots.md
+++ b/docs/multiple-bots.md
@@ -177,16 +177,134 @@ This holds for the built-in per-conversation key. A custom `key` you pass to
 isolation — read `ctx.bot.name`.
 :::
 
-## Transport: polling today
+## Transport: polling or webhook
 
-Each bot runs its own long-polling loop — they poll independently, no
-coordination needed. Webhook is supported for a **single** bot (the top-level
-`token` + `webhook` config); a webhook bot inside a `bots: []` fleet isn't routed
-automatically yet, because one HTTPS endpoint has to fan inbound updates out to
-the right bot.
+Each bot has its own transport. **Polling** is the simplest — give each bot
+`polling` and it runs its own long-polling loop, no coordination needed.
 
-:::warn[Multi-bot is polling]
-In a `bots: []` app, give each bot `polling`. A fleet bot configured for
-`webhook` is skipped at startup with a warning — it won't receive updates until
-you wire a custom update source for it. Single-bot webhook is unchanged.
+**Webhook** takes one more step. A Telegram update carries no bot identity, so a
+multi-bot app has to know which bot an inbound POST is for. Two ready-made
+controllers cover that; both are opt-in (you add them to a module's
+`controllers`), and you can always write your own.
+
+### A URL per bot — `MultiBotWebhookController`
+
+Each bot gets its own route, `…/telegram/webhook/:botName`. Build the matching
+`setWebhook` URL with `webhookUrl(origin, name)` so the registered URL can't
+drift from the served route, and add the controller:
+
+:::code[app.module.ts]{mark="19,35"}
+
+```ts
+import { Module } from '@nestjs/common';
+import {
+  NestgramModule,
+  MultiBotWebhookController,
+  webhookUrl,
+} from 'nestgram';
+import { Bots } from './bots';
+
+const origin = process.env.WEBHOOK_ORIGIN ?? '';
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      bots: [
+        {
+          name: Bots.Support,
+          token: process.env.SUPPORT_TOKEN ?? '',
+          webhook: {
+            url: webhookUrl(origin, Bots.Support),
+            secretToken: process.env.SUPPORT_SECRET ?? '',
+          },
+          default: true,
+        },
+        {
+          name: Bots.Sales,
+          token: process.env.SALES_TOKEN ?? '',
+          webhook: {
+            url: webhookUrl(origin, Bots.Sales),
+            secretToken: process.env.SALES_SECRET ?? '',
+          },
+        },
+      ],
+    }),
+  ],
+  controllers: [MultiBotWebhookController],
+})
+export class AppModule {}
+```
+
 :::
+
+The `:botName` path is public, so give each webhook bot its own `secretToken` —
+the controller verifies the incoming secret against that bot before delivering.
+
+### One URL for all bots — `SharedWebhookController`
+
+Point every bot at the same `webhookUrl(origin)` (no name) and register
+`SharedWebhookController` instead. With no `:botName` to go on, it routes by the
+secret token: the bot whose `secretToken` matches the incoming header gets the
+update, falling back to the default bot.
+
+:::warn[Distinct secrets required]
+A shared endpoint can only tell the bots apart by their secret, so give each a
+**distinct** `secretToken` (the config is rejected at boot if two collide).
+Without distinct secrets every update lands on the default bot.
+:::
+
+### Write your own
+
+When neither shape fits — a bespoke route, extra receipt-time logic, your own
+auth — inject the `WEBHOOK_SOURCES` array and route however you like. Each entry
+carries the bot's `source` (with `name`, `verifySecret`/`ownsSecret`, and
+`deliver`) and whether it is the default:
+
+:::code[my-webhook.controller.ts]{mark="21"}
+
+```ts
+import {
+  Body,
+  Controller,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Post,
+} from '@nestjs/common';
+import {
+  Providers,
+  SECRET_HEADER,
+  RawUpdate,
+  WebhookSourceEntry,
+} from 'nestgram';
+
+@Controller('telegram')
+export class MyWebhookController {
+  constructor(
+    @Inject(Providers.WEBHOOK_SOURCES)
+    private readonly bots: WebhookSourceEntry[],
+  ) {}
+
+  @Post('hook/:botName')
+  @HttpCode(HttpStatus.OK)
+  handle(
+    @Param('botName') name: string,
+    @Body() update: RawUpdate,
+    @Headers(SECRET_HEADER) secret?: string,
+  ): void {
+    const bot = this.bots.find((entry) => entry.source.name === name);
+    if (bot?.source.verifySecret(secret)) {
+      void bot.source.deliver(update);
+    }
+  }
+}
+```
+
+:::
+
+`NestgramModule` is global, so `WEBHOOK_SOURCES` resolves wherever you register
+the controller. Single-bot webhook is unchanged — there it's one bot, so the
+ready-made `WebhookController` (or `createWebhookController(path)`) is all you
+need.

--- a/docs/multiple-bots.md
+++ b/docs/multiple-bots.md
@@ -1,0 +1,192 @@
+---
+title: Multiple bots
+description: Run several bots from one app — declare them in bots[], inject one by name with @InjectBot, reach the current one with @Bot, and scope a router with @ForBot.
+sidebar:
+  group: Multiple bots
+  order: 90
+---
+
+One app, several bots — a support bot and a sales bot, a bot per brand, a fleet
+of white-label bots. Each has its own token and its own pipeline, but they share
+your routers, services, and the one engine. A single bot stays exactly as it was
+(`forRoot({ token })`); multiplicity is just a list.
+
+## Declaring the bots
+
+Pass a `bots: []` instead of a top-level `token`. Each entry is an independent
+bot with its own token, transport, and pipeline flags:
+
+:::code[app.module.ts]{mark="12,18"}
+
+```ts
+import { Module } from '@nestjs/common';
+import { NestgramModule, ParseMode } from 'nestgram';
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      bots: [
+        {
+          name: 'support',
+          token: process.env.SUPPORT_TOKEN ?? '',
+          polling: true,
+          default: true,
+        },
+        {
+          name: 'sales',
+          token: process.env.SALES_TOKEN ?? '',
+          polling: true,
+          parseMode: ParseMode.MarkdownV2,
+        },
+      ],
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+:::
+
+`parseMode` on `sales` is that bot's alone — every flag (`parseMode`, `throttle`,
+`richMessages`, …) is per-bot, because each bot gets its **own interceptor
+pipeline**.
+
+The `default: true` bot is the one a bare `BotService` injection (and
+`@InjectBot()` with no name) resolves to. With a single bot it's implicit; with
+several, mark exactly one — or none, and then a bare `BotService` is ambiguous
+and unavailable (reach each bot by name instead). Co-equal bots with no primary
+(white-label tenants) are a valid setup.
+
+## Name them once
+
+A bot's name is a plain string you choose, repeated across the config and the
+decorators. Extract it once so a typo can't drift them apart:
+
+:::code[bots.ts]
+
+```ts
+export enum Bots {
+  Support = 'support',
+  Sales = 'sales',
+}
+```
+
+:::
+
+:::tip
+Then use `Bots.Support` everywhere — `{ name: Bots.Support }`,
+`@InjectBot(Bots.Sales)`, `@ForBot(Bots.Support)`. One source of truth, no magic
+strings. The framework imposes no naming — any string works.
+:::
+
+## Reach a specific bot — `@InjectBot`
+
+To send through a particular bot from a service (a proactive notification, a
+cross-bot message), inject it by name:
+
+:::code[alerts.service.ts]{mark="7"}
+
+```ts
+import { Injectable } from '@nestjs/common';
+import { BotService, InjectBot } from 'nestgram';
+import { Bots } from './bots';
+
+@Injectable()
+export class Alerts {
+  constructor(@InjectBot(Bots.Sales) private readonly sales: BotService) {}
+
+  shipped(chatId: number) {
+    return this.sales.sendMessage(chatId, 'Your order shipped 📦');
+  }
+}
+```
+
+:::
+
+`@InjectBot(name)` resolves the bot declared under that name at compile time, so
+the name must be statically known. `@InjectBot()` with no name gives the default
+bot — the same instance a bare `BotService` injects.
+
+## The current update's bot — `@Bot`
+
+In a shared handler, `message.answer(...)` already replies through whichever bot
+received the update — you rarely need anything else. When a handler genuinely
+needs the bot object — its identity, a deep link, handing it to a service — take
+it with `@Bot()`:
+
+:::code[whoami.router.ts]{mark="6"}
+
+```ts
+import { Router, Command, Bot, Message, BotService } from 'nestgram';
+
+@Router()
+export class WhoAmIRouter {
+  @Command('whoami')
+  whoami(message: Message, @Bot() bot: BotService) {
+    return `You're chatting with @${bot.username}.`;
+  }
+}
+```
+
+:::
+
+`@Bot()` is the bot that delivered THIS update, carried per-update; `bot.name`
+identifies it.
+
+:::note
+For behaviour that **differs** per bot, reach for `@ForBot` (below) to split it
+into per-bot handlers — not a `bot.name === …` branch in a shared handler.
+Branching on `@Bot()` is for the rare case where one handler legitimately serves
+several bots with a small variation; routing is the cleaner tool when the logic
+itself diverges.
+:::
+
+## Scope a router to a bot — `@ForBot`
+
+By default a router serves every bot. `@ForBot('name')` narrows it — on the class
+for the whole router, or on a single handler. An update for another bot falls
+through to the next matching route, just like any predicate:
+
+:::code[support.router.ts]{mark="5"}
+
+```ts
+import { Router, Command, ForBot, Message } from 'nestgram';
+import { Bots } from './bots';
+
+@Router()
+@ForBot(Bots.Support)
+export class SupportRouter {
+  @Command('ticket')
+  ticket(message: Message) {
+    return 'Opening a support ticket…'; // only the support bot reaches here
+  }
+}
+```
+
+:::
+
+## State stays per bot
+
+Sessions and FSM are keyed by the bot too, so the same user in the same chat has
+a separate session and flow on each bot — `support`'s counter never bleeds into
+`sales`. Nothing to configure; the default conversation key includes the bot.
+
+:::note
+This holds for the built-in per-conversation key. A custom `key` you pass to
+`SessionModule`/`FsmModule` should keep the bot in scope if you rely on the
+isolation — read `ctx.bot.name`.
+:::
+
+## Transport: polling today
+
+Each bot runs its own long-polling loop — they poll independently, no
+coordination needed. Webhook is supported for a **single** bot (the top-level
+`token` + `webhook` config); a webhook bot inside a `bots: []` fleet isn't routed
+automatically yet, because one HTTPS endpoint has to fan inbound updates out to
+the right bot.
+
+:::warn[Multi-bot is polling]
+In a `bots: []` app, give each bot `polling`. A fleet bot configured for
+`webhook` is skipped at startup with a warning — it won't receive updates until
+you wire a custom update source for it. Single-bot webhook is unchanged.
+:::

--- a/lib/api/bot.module.spec.ts
+++ b/lib/api/bot.module.spec.ts
@@ -10,7 +10,7 @@ import { RichMessagesInterceptor } from '../builtins/rich-messages';
 import { ThrottleInterceptor } from '../builtins/throttle';
 import { TokenValidationInterceptor } from '../builtins/token-validation';
 
-@Module({ imports: [BotModule.forRoot({ token: '1:T' })] })
+@Module({ imports: [BotModule.forBot('default', { token: '1:T' })] })
 class DefaultApp {}
 
 class CustomThrottler implements ApiInterceptor {
@@ -20,14 +20,18 @@ class CustomThrottler implements ApiInterceptor {
 }
 
 @Module({
-  imports: [BotModule.forRoot({ token: '1:T', throttler: CustomThrottler })],
+  imports: [
+    BotModule.forBot('default', { token: '1:T', throttler: CustomThrottler }),
+  ],
 })
 class CustomApp {}
 
+// API_INTERCEPTORS is private to the per-bot module now (only the BotService
+// token is exported), so reach it non-strictly across modules.
 function interceptors(app: {
-  get: (token: string) => unknown;
+  get: (token: string, options: { strict: false }) => unknown;
 }): ApiInterceptor[] {
-  return app.get(API_INTERCEPTORS) as ApiInterceptor[];
+  return app.get(API_INTERCEPTORS, { strict: false }) as ApiInterceptor[];
 }
 
 describe('BotModule interceptor wiring', () => {

--- a/lib/api/bot.module.ts
+++ b/lib/api/bot.module.ts
@@ -103,7 +103,14 @@ export class BotModule {
           options.apiInterceptors ?? [],
           options.throttler,
         ),
-        { provide: getBotToken(name), useClass: BotService },
+        {
+          provide: getBotToken(name),
+          useFactory: (
+            options: BotOptions,
+            pipeline: ApiPipeline,
+          ): BotService => new BotService(options, pipeline, name),
+          inject: [Providers.BOT_OPTIONS, ApiPipeline],
+        },
       ],
       exports: [getBotToken(name)],
     };
@@ -120,7 +127,14 @@ export class BotModule {
           options.apiInterceptors ?? [],
           options.throttler,
         ),
-        { provide: getBotToken(name), useClass: BotService },
+        {
+          provide: getBotToken(name),
+          useFactory: (
+            options: BotOptions,
+            pipeline: ApiPipeline,
+          ): BotService => new BotService(options, pipeline, name),
+          inject: [Providers.BOT_OPTIONS, ApiPipeline],
+        },
       ],
       exports: [getBotToken(name)],
     };

--- a/lib/api/bot.module.ts
+++ b/lib/api/bot.module.ts
@@ -1,10 +1,10 @@
-import { DynamicModule, Global, Module, Provider, Type } from '@nestjs/common';
+import { DynamicModule, Module, Provider, Type } from '@nestjs/common';
 
 import { BotService } from './bot.service';
 
 import { BotAsyncOptions, BotOptions } from './bot-options';
 import { NestgramConfigError } from '../exceptions';
-import { Providers } from '../providers';
+import { getBotToken, Providers } from '../providers';
 import { API_INTERCEPTORS, ApiInterceptor, ApiPipeline } from './request';
 // Import the send built-ins by feature subpath, not the '../builtins' barrel:
 // the barrel also re-exports the handler-side auto-answer interceptor, which
@@ -17,38 +17,34 @@ import {
   RichMessagesSettings,
   resolveRichMessagesSettings,
 } from '../builtins/rich-messages';
-import { ThrottleInterceptor, ThrottleModule } from '../builtins/throttle';
+import { ThrottleInterceptor, throttleProviders } from '../builtins/throttle';
 import { TokenValidationInterceptor } from '../builtins/token-validation';
 
-@Global()
-@Module({})
+/**
+ * Builds ONE bot — its own `BotService` reachable under `getBotToken(name)`, on
+ * its own interceptor pipeline. A static factory (not an `@Module` itself):
+ * `NestgramModule` calls `forBot` once per configured bot, so multiple bots each
+ * get an ISOLATED pipeline. The isolation comes from giving every bot its own
+ * generated module class with a PRIVATE `BOT_OPTIONS` — the interceptors and the
+ * spliced throttle providers resolve THAT bot's options, so `parseMode`,
+ * `throttle`, etc. are per-bot and each bot has its own throttle state. Only the
+ * `getBotToken(name)` provider is exported (globally); the pipeline stays private.
+ */
 export class BotModule {
   /**
-   * Providers for the outbound API interceptor pipeline. `API_INTERCEPTORS` is
-   * the ordered array `ApiPipeline` composes into a Nest-style onion, outermost
-   * first: token validation (its constructor also fail-fasts on a missing
-   * configured token at boot), ignore-not-modified (a response-side catch that
-   * turns the edit no-op into a success — inert unless opted in), rich-messages
-   * rewrite (before parse-mode, so an
-   * injected default `parse_mode` can't read as explicit formatting intent;
-   * inert unless the `richMessages` option set its settings), default
-   * parse-mode, any user-supplied interceptors, then the throttler innermost
-   * (closest to the wire, so it reads `chat_id` after the mutators). The
-   * built-ins are ordinary `ApiInterceptor`s — no privileged core; a user can
-   * add, reorder, or replace them.
-   *
-   * Built as an explicit array via `useFactory`, not a `multi`-provider token:
-   * Nest has no generic `multi: true` aggregation (a `multi` token collapses to a
-   * single, last-wins instance — `APP_*` enhancers are special-cased separately),
-   * so the factory injects every interceptor and returns them as the array.
-   *
-   * The throttle slot is `throttler ?? ThrottleInterceptor` — a user swaps the
-   * rate-limiter with one key (e.g. a Redis-backed distributed one); the default
-   * self-disables on `throttle: false`. The default `ThrottleInterceptor` is
-   * provided (with its collaborators) by the imported {@link ThrottleModule}, so
-   * only a custom throttler is provided here.
+   * The outbound API interceptor pipeline for one bot. `API_INTERCEPTORS` is the
+   * ordered array `ApiPipeline` composes into a Nest-style onion, outermost
+   * first: token validation, ignore-not-modified, rich-messages rewrite (before
+   * parse-mode, so an injected default `parse_mode` can't read as explicit
+   * formatting intent), default parse-mode, any user interceptors, then the
+   * throttler innermost. Built as an explicit array via `useFactory` — Nest has
+   * no generic `multi: true` aggregation (a `multi` token collapses to a single,
+   * last-wins instance), so the factory injects every interceptor and returns the
+   * array. The default throttler's collaborators are spliced in via
+   * {@link throttleProviders} (resolving this bot's `BOT_OPTIONS`); a custom
+   * `throttler` replaces them.
    */
-  private static interceptorProviders(
+  private static pipelineProviders(
     userInterceptors: Type<ApiInterceptor>[],
     throttler: Type<ApiInterceptor> | undefined,
   ): Provider[] {
@@ -65,17 +61,16 @@ export class BotModule {
     return [
       ...leading,
       // Resolved from the `richMessages` option (or `null` when omitted) — the
-      // RichMessagesInterceptor in `leading` reads this and stays a passthrough
-      // when it's null. Mirrors how ThrottleModule resolves THROTTLE_SETTINGS.
+      // RichMessagesInterceptor reads this and stays a passthrough when null.
       {
         provide: RICH_MESSAGES_SETTINGS,
         useFactory: (options: BotOptions): RichMessagesSettings | null =>
           resolveRichMessagesSettings(options.richMessages),
         inject: [Providers.BOT_OPTIONS],
       },
-      // The default ThrottleInterceptor comes from the imported ThrottleModule;
-      // only a custom throttler is provided here.
-      ...(throttler ? [throttler] : []),
+      // The default throttler's providers are spliced (not imported) so they
+      // resolve THIS bot's BOT_OPTIONS; a custom throttler replaces them.
+      ...(throttler ? [throttler] : throttleProviders()),
       {
         provide: API_INTERCEPTORS,
         useFactory: (...interceptors: ApiInterceptor[]): ApiInterceptor[] =>
@@ -87,57 +82,47 @@ export class BotModule {
   }
 
   /**
-   * The default throttler lives in {@link ThrottleModule} (its composition root),
-   * so import it unless the user swapped in their own `throttler` (which brings
-   * its own wiring).
+   * A fresh module class per bot, so two bots are distinct Nest modules with
+   * separate provider scopes (rather than one class re-imported, which Nest may
+   * dedupe — collapsing the per-bot `BOT_OPTIONS`). Marked `global` via the
+   * DynamicModule so the exported `getBotToken` is app-wide for `@InjectBot`.
    */
-  private static throttleImports(
-    throttler: Type<ApiInterceptor> | undefined,
-  ): NonNullable<DynamicModule['imports']> {
-    return throttler ? [] : [ThrottleModule];
+  private static moduleClass(): Type {
+    class NestgramBotModule {}
+    Module({})(NestgramBotModule);
+    return NestgramBotModule;
   }
 
-  static forRoot(options: BotOptions): DynamicModule {
+  static forBot(name: string, options: BotOptions): DynamicModule {
     return {
-      module: BotModule,
-      imports: this.throttleImports(options.throttler),
+      module: this.moduleClass(),
+      global: true,
       providers: [
-        {
-          provide: Providers.BOT_OPTIONS,
-          useValue: options,
-        },
-        ...this.interceptorProviders(
+        { provide: Providers.BOT_OPTIONS, useValue: options },
+        ...this.pipelineProviders(
           options.apiInterceptors ?? [],
           options.throttler,
         ),
-        {
-          provide: BotService,
-          useClass: BotService,
-        },
+        { provide: getBotToken(name), useClass: BotService },
       ],
-      exports: [Providers.BOT_OPTIONS, BotService],
+      exports: [getBotToken(name)],
     };
   }
 
-  static forRootAsync(options: BotAsyncOptions): DynamicModule {
+  static forBotAsync(name: string, options: BotAsyncOptions): DynamicModule {
     return {
-      module: BotModule,
-      imports: [
-        ...(options.imports ?? []),
-        ...this.throttleImports(options.throttler),
-      ],
+      module: this.moduleClass(),
+      global: true,
+      imports: options.imports ?? [],
       providers: [
         ...this.createAsyncProviders(options),
-        ...this.interceptorProviders(
+        ...this.pipelineProviders(
           options.apiInterceptors ?? [],
           options.throttler,
         ),
-        {
-          provide: BotService,
-          useClass: BotService,
-        },
+        { provide: getBotToken(name), useClass: BotService },
       ],
-      exports: [Providers.BOT_OPTIONS, BotService],
+      exports: [getBotToken(name)],
     };
   }
 
@@ -155,7 +140,7 @@ export class BotModule {
     const optionsClass = options.useClass ?? options.useExisting;
     if (!optionsClass) {
       throw new NestgramConfigError(
-        'BotModule.forRootAsync requires one of useFactory, useClass or useExisting',
+        'BotModule.forBotAsync requires one of useFactory, useClass or useExisting',
       );
     }
 

--- a/lib/api/bot.service.ts
+++ b/lib/api/bot.service.ts
@@ -7,7 +7,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { defer, from } from 'rxjs';
 
 import { BotOptions } from './bot-options';
-import { Providers } from '../providers';
+import { DEFAULT_BOT_NAME, Providers } from '../providers';
 import { ApiException, NestgramError } from '../exceptions';
 import { deepLink as createDeepLink, DeepLinkParams } from '../deep-links';
 import type { User } from '../events/user';
@@ -43,6 +43,12 @@ export class BotService extends GeneratedBotMethods {
   constructor(
     @Inject(Providers.BOT_OPTIONS) options: BotOptions,
     private readonly pipeline: ApiPipeline,
+    /**
+     * This bot's configured name — the `@InjectBot(name)` / `@ForBot(name)` key,
+     * `'default'` for the sole/default bot. Lets a handler tell which bot it is
+     * serving (`ctx.bot.name`, `@ForBot`).
+     */
+    readonly name: string = DEFAULT_BOT_NAME,
   ) {
     super();
     this.token = options.token;

--- a/lib/builtins/rich-messages/rich-messages.integration.spec.ts
+++ b/lib/builtins/rich-messages/rich-messages.integration.spec.ts
@@ -34,7 +34,7 @@ describe('richMessages option', () => {
   it('feeds its settings into the pipeline interceptor when set', async () => {
     @Module({
       imports: [
-        BotModule.forRoot({
+        BotModule.forBot('default', {
           token: '1:T',
           richMessages: { dialect: 'markdown' },
         }),
@@ -46,7 +46,7 @@ describe('richMessages option', () => {
       logger: false,
     });
     try {
-      const interceptor = app.get(RichMessagesInterceptor);
+      const interceptor = app.get(RichMessagesInterceptor, { strict: false });
       const { ctx, request } = sendMessageRequest();
       interceptor.intercept(ctx, noop);
       expect(request.method).toBe('sendRichMessage');
@@ -61,7 +61,7 @@ describe('richMessages option', () => {
 
   it('stays opt-in: without the option the interceptor is a passthrough', async () => {
     @Module({
-      imports: [BotModule.forRoot({ token: '1:T' })],
+      imports: [BotModule.forBot('default', { token: '1:T' })],
     })
     class PlainAppModule {}
 
@@ -69,7 +69,7 @@ describe('richMessages option', () => {
       logger: false,
     });
     try {
-      const interceptor = app.get(RichMessagesInterceptor);
+      const interceptor = app.get(RichMessagesInterceptor, { strict: false });
       const { ctx, request } = sendMessageRequest();
       interceptor.intercept(ctx, noop);
       expect(request.method).toBe('sendMessage');
@@ -82,7 +82,7 @@ describe('richMessages option', () => {
   it('a configured default parseMode never leaks into the rewritten rich call', async () => {
     @Module({
       imports: [
-        BotModule.forRoot({
+        BotModule.forBot('default', {
           token: '1:T',
           parseMode: 'HTML',
           richMessages: { dialect: 'markdown' },
@@ -97,8 +97,8 @@ describe('richMessages option', () => {
     try {
       // Pipeline order: the rich rewrite runs before the parse-mode injector —
       // exactly what keeps the injected default out of the rich payload.
-      const rich = app.get(RichMessagesInterceptor);
-      const parseMode = app.get(DefaultParseModeInterceptor);
+      const rich = app.get(RichMessagesInterceptor, { strict: false });
+      const parseMode = app.get(DefaultParseModeInterceptor, { strict: false });
       const { ctx, request } = sendMessageRequest();
       rich.intercept(ctx, noop);
       parseMode.intercept(ctx, noop);

--- a/lib/builtins/throttle/throttle.module.ts
+++ b/lib/builtins/throttle/throttle.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, Provider } from '@nestjs/common';
 
 import { Providers } from '../../providers';
 import { ChatLimiterRegistry } from './chat-limiter-registry';
@@ -19,19 +19,17 @@ interface ThrottleConfigSource {
 }
 
 /**
- * Wires the throttle feature. This module is the composition root: it resolves
- * the settings from `BotOptions`, builds the shared global bucket and per-chat
- * registry (parameterised by those settings + the clock), and exposes the
- * interceptor. The {@link ThrottleInterceptor} therefore receives ready
- * collaborators and assembles nothing itself.
- *
- * A plain provider-grouping module (no `forRoot`): `BotModule` imports it and
- * places the exported interceptor in its ordered pipeline, so interceptor order
- * stays owned by `BotModule`, not scattered. `CLOCK` defaults to `SystemClock`
- * and can be overridden (e.g. a `FakeClock` in tests) by re-providing the token.
+ * The throttle feature's providers — settings resolved from `BotOptions`, the
+ * shared bucket + per-chat registry parameterised by them and the clock, and the
+ * interceptor. A hoisted function (callable from the `@Module` decorator below)
+ * so the SAME provider set can be spliced directly into a per-bot module: there
+ * each resolves THAT bot's `BOT_OPTIONS`, giving every bot its own throttle state
+ * — which an imported module couldn't do, as it would resolve a global token.
+ * `CLOCK` defaults to `SystemClock`; re-provide the token to override (e.g. a
+ * `FakeClock` in tests).
  */
-@Module({
-  providers: [
+export function throttleProviders(): Provider[] {
+  return [
     { provide: CLOCK, useClass: SystemClock },
     {
       provide: THROTTLE_SETTINGS,
@@ -64,7 +62,17 @@ interface ThrottleConfigSource {
       inject: [THROTTLE_SETTINGS, CLOCK],
     },
     ThrottleInterceptor,
-  ],
+  ];
+}
+
+/**
+ * The throttle composition root as a standalone module (kept for back-compat and
+ * direct import). `BotModule` no longer imports it — it splices
+ * {@link throttleProviders} into each per-bot module so the settings resolve that
+ * bot's options — but the module stays public.
+ */
+@Module({
+  providers: throttleProviders(),
   exports: [ThrottleInterceptor],
 })
 export class ThrottleModule {}

--- a/lib/decorators/for-bot.decorator.spec.ts
+++ b/lib/decorators/for-bot.decorator.spec.ts
@@ -1,0 +1,40 @@
+import 'reflect-metadata';
+
+import { ForBot } from './for-bot.decorator';
+import { Metadata } from './metadata.enum';
+import type { RoutePredicate } from '../engine/matching';
+import type { TelegramExecutionContext } from '../engine/context';
+
+function ctxForBot(name: string): TelegramExecutionContext {
+  return { bot: { name } } as unknown as TelegramExecutionContext;
+}
+
+function predicateOn(carrier: object): RoutePredicate {
+  const predicates: RoutePredicate[] =
+    Reflect.getMetadata(Metadata.MATCH, carrier) ?? [];
+  return predicates[0];
+}
+
+describe('ForBot', () => {
+  it('on a class stores a predicate matching the current bot by name', () => {
+    @ForBot('support')
+    class SupportRouter {}
+
+    const predicate = predicateOn(SupportRouter);
+    expect(predicate.matches(ctxForBot('support'))).toBe(true);
+    expect(predicate.matches(ctxForBot('sales'))).toBe(false);
+  });
+
+  it('on a method stores the same predicate on the method', () => {
+    class MixedRouter {
+      @ForBot('sales')
+      handle(): void {
+        // body irrelevant — only the decorator's metadata is under test
+      }
+    }
+
+    const predicate = predicateOn(MixedRouter.prototype.handle);
+    expect(predicate.matches(ctxForBot('sales'))).toBe(true);
+    expect(predicate.matches(ctxForBot('support'))).toBe(false);
+  });
+});

--- a/lib/decorators/for-bot.decorator.ts
+++ b/lib/decorators/for-bot.decorator.ts
@@ -1,0 +1,40 @@
+import type { RoutePredicate } from '../engine/matching';
+import { Metadata } from './metadata.enum';
+
+/**
+ * Scope a router or a handler to a single bot by name: it matches ONLY updates
+ * that arrived on that bot, and falls through otherwise (so another router can
+ * pick them up). Without it a router serves EVERY bot.
+ *
+ * ```ts
+ * @Router()
+ * @ForBot('support')           // whole router → support bot only
+ * export class SupportRouter {
+ *   @OnMessage()
+ *   @ForBot('support')         // or per-handler
+ *   handle(message: Message) {}
+ * }
+ * ```
+ *
+ * Built on the same `@Match` predicate mechanism as `@AnyState()`: it ANDs a
+ * "current bot is `name`" predicate into the routes — on a class it applies to
+ * every handler, on a method just that one. Reads `ctx.bot.name`, the per-update
+ * bot the dispatcher threaded in.
+ */
+export const ForBot = (name: string): ClassDecorator & MethodDecorator => {
+  const predicate: RoutePredicate = {
+    matches: (ctx) => ctx.bot?.name === name,
+  };
+  return (
+    target: object,
+    _propertyKey?: string | symbol,
+    descriptor?: PropertyDescriptor,
+  ): void => {
+    // Method usage carries the method via the descriptor; class usage gets the
+    // constructor as `target`. RouteExplorer reads MATCH from both.
+    const carrier: object = descriptor ? descriptor.value : target;
+    const existing: RoutePredicate[] =
+      Reflect.getMetadata(Metadata.MATCH, carrier) ?? [];
+    Reflect.defineMetadata(Metadata.MATCH, [...existing, predicate], carrier);
+  };
+};

--- a/lib/decorators/index.ts
+++ b/lib/decorators/index.ts
@@ -3,6 +3,7 @@ export * from './listeners';
 export * from './core';
 export * from './no-auto-answer.decorator';
 export * from './match.decorator';
+export * from './inject-bot.decorator';
 // NOTE: `./params` is intentionally NOT re-exported here. The param decorators
 // import from `../context`, and this barrel is imported by low-level code
 // (events, EventFactory via `getTelegramObjectByUpdateType`). Including

--- a/lib/decorators/index.ts
+++ b/lib/decorators/index.ts
@@ -4,6 +4,7 @@ export * from './core';
 export * from './no-auto-answer.decorator';
 export * from './match.decorator';
 export * from './inject-bot.decorator';
+export * from './for-bot.decorator';
 // NOTE: `./params` is intentionally NOT re-exported here. The param decorators
 // import from `../context`, and this barrel is imported by low-level code
 // (events, EventFactory via `getTelegramObjectByUpdateType`). Including

--- a/lib/decorators/inject-bot.decorator.ts
+++ b/lib/decorators/inject-bot.decorator.ts
@@ -1,0 +1,23 @@
+import { Inject } from '@nestjs/common';
+
+import { getBotToken } from '../providers';
+
+/**
+ * Inject a specific bot's {@link BotService} by name — sugar over
+ * `@Inject(getBotToken(name))`:
+ *
+ * ```ts
+ * constructor(@InjectBot('sales') private readonly sales: BotService) {}
+ * ```
+ *
+ * Omit the name for the default bot (the sole bot, or the one configured
+ * `default: true`) — equivalent to injecting a bare `BotService`.
+ *
+ * Resolves the bot DECLARED in `NestgramModule.forRoot({ bots: [...] })` under a
+ * static DI token, so the name must be known at compile time. To send through
+ * the bot that received the CURRENT update, use the `@Bot()` handler param
+ * instead — it carries the per-update bot, no name needed.
+ */
+export const InjectBot = (
+  name?: string,
+): ParameterDecorator & PropertyDecorator => Inject(getBotToken(name));

--- a/lib/decorators/metadata.enum.ts
+++ b/lib/decorators/metadata.enum.ts
@@ -4,6 +4,9 @@ export enum Metadata {
   ROUTER = 'ROUTER',
   NO_AUTO_ANSWER = 'NO_AUTO_ANSWER',
   UPDATE_STAGE = 'UPDATE_STAGE',
-  /** Method-level match predicates merged into every route of the method (`@Match`). */
+  /**
+   * Match predicates ANDed into routes — method-level (`@Match`, `@AnyState`) on
+   * the method, or class-level (`@ForBot` on a router) on the constructor.
+   */
   MATCH = 'MATCH',
 }

--- a/lib/decorators/params/bot.decorator.ts
+++ b/lib/decorators/params/bot.decorator.ts
@@ -1,0 +1,23 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+import { TelegramExecutionContext } from '../../engine/context';
+
+/**
+ * Injects the {@link BotService} that received the CURRENT update — the bot a
+ * reply goes back through. In a multi-bot app each update is handled by the bot
+ * whose source delivered it; `@Bot()` hands you that one without naming it:
+ *
+ * ```ts
+ * @OnMessage()
+ * handle(message: Message, @Bot() bot: BotService) {
+ *   // bot.name tells you which bot; bot.sendMessage(...) targets it
+ * }
+ * ```
+ *
+ * To reach a SPECIFIC bot by name (not the current one), inject it with
+ * `@InjectBot('name')` instead.
+ */
+export const Bot = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext) =>
+    TelegramExecutionContext.of(ctx).bot,
+);

--- a/lib/decorators/params/index.ts
+++ b/lib/decorators/params/index.ts
@@ -13,3 +13,4 @@ export * from './session.decorator';
 export * from './locale.decorator';
 export * from './state.decorator';
 export * from './fsm.decorator';
+export * from './bot.decorator';

--- a/lib/engine/context/context-factory.ts
+++ b/lib/engine/context/context-factory.ts
@@ -24,7 +24,16 @@ export class ContextFactory {
     private readonly eventFactory: EventFactory,
   ) {}
 
-  wrap(update: Readonly<RawUpdate>): TelegramExecutionContext | null {
+  /**
+   * `bot` is the bot that received THIS update — threaded by the dispatcher from
+   * the per-bot source, so the event's `answer()` and `ctx.bot` act through the
+   * right bot. Falls back to the injected default for the single-bot path (and
+   * any caller that dispatches without naming a bot).
+   */
+  wrap(
+    update: Readonly<RawUpdate>,
+    bot?: BotService,
+  ): TelegramExecutionContext | null {
     const kind = resolveKind(update);
     if (kind === null) {
       this.warnUnmodelled(update);
@@ -34,7 +43,7 @@ export class ContextFactory {
     return new TelegramExecutionContext(
       update,
       kind,
-      this.botService,
+      bot ?? this.botService,
       this.eventFactory,
     );
   }

--- a/lib/engine/discovery/route-explorer.spec.ts
+++ b/lib/engine/discovery/route-explorer.spec.ts
@@ -151,6 +151,33 @@ describe('RouteExplorer @Match (method-level predicates)', () => {
   });
 });
 
+describe('RouteExplorer class-level predicates (@ForBot on a router)', () => {
+  const onlyBotA: RoutePredicate = { matches: () => true };
+
+  class ScopedRouter {
+    a(): string {
+      return 'a';
+    }
+    b(): string {
+      return 'b';
+    }
+  }
+  Reflect.defineMetadata(Metadata.ROUTER, {}, ScopedRouter);
+  // Class-level MATCH, exactly as @ForBot('a') on the router stores it.
+  Reflect.defineMetadata(Metadata.MATCH, [onlyBotA], ScopedRouter);
+  listen(ScopedRouter.prototype, 'a', 'message');
+  listen(ScopedRouter.prototype, 'b', 'callback_query');
+
+  it('ANDs a class-level predicate into every route of the router', () => {
+    const routes = explorerOver([new ScopedRouter()]).explore();
+
+    expect(routes).toHaveLength(2);
+    for (const route of routes) {
+      expect(route.predicates).toContain(onlyBotA);
+    }
+  });
+});
+
 describe('RouteTable', () => {
   it('preserves declaration order and indexes by update type', () => {
     const table = new RouteTable(explorerOver([new GreetRouter()]).explore());

--- a/lib/engine/discovery/route-explorer.ts
+++ b/lib/engine/discovery/route-explorer.ts
@@ -42,6 +42,11 @@ export class RouteExplorer {
         continue;
       }
 
+      // Class-level predicates (e.g. `@ForBot('support')` on the router) AND into
+      // EVERY route the router declares — scoping the whole router to one bot.
+      const classPredicates: RoutePredicate[] =
+        Reflect.getMetadata(Metadata.MATCH, instance.constructor) ?? [];
+
       const prototype = Object.getPrototypeOf(instance);
       for (const methodName of this.scanner.getAllMethodNames(prototype)) {
         const listeners: ListenerOptions[] | undefined = Reflect.getMetadata(
@@ -61,7 +66,11 @@ export class RouteExplorer {
         for (const listener of listeners) {
           routes.push({
             updateType: listener.updateType,
-            predicates: [...(listener.predicates ?? []), ...methodPredicates],
+            predicates: [
+              ...(listener.predicates ?? []),
+              ...classPredicates,
+              ...methodPredicates,
+            ],
             instance,
             methodName,
           });

--- a/lib/engine/dispatcher/update-dispatcher.spec.ts
+++ b/lib/engine/dispatcher/update-dispatcher.spec.ts
@@ -99,6 +99,36 @@ describe('UpdateDispatcher', () => {
     expect(handled).toEqual(['reply from start']);
   });
 
+  it('threads the given bot into the context, falling back to the default', async () => {
+    let seenBot: BotService | undefined;
+    const contextFactory = new ContextFactory(fakeBot(), new EventFactory());
+    const executorFactory = {
+      create: () => (ctx: { bot: BotService }) => {
+        seenBot = ctx.bot;
+        return Promise.resolve(undefined);
+      },
+    } as unknown as HandlerExecutorFactory;
+    const resultHandler = {
+      handle: () => Promise.resolve(),
+    } as unknown as ResultHandler;
+    const dispatcher = new UpdateDispatcher(
+      contextFactory,
+      new RouteTable([route('message', 'h')]),
+      new RouteMatcher(),
+      executorFactory,
+      resultHandler,
+      new StageRegistry(),
+    );
+
+    const botB = { token: 'BOT_B' } as unknown as BotService;
+    await dispatcher.dispatch(messageUpdate(1, 'hi'), botB);
+    expect(seenBot).toBe(botB);
+
+    // Omitted → the ContextFactory's injected default (token 'TEST').
+    await dispatcher.dispatch(messageUpdate(2, 'hi'));
+    expect(seenBot?.token).toBe('TEST');
+  });
+
   it('runs only the first matching route (first-match)', async () => {
     const { dispatcher, calls } = makeDispatcher([
       route('message', 'first'),

--- a/lib/engine/dispatcher/update-dispatcher.spec.ts
+++ b/lib/engine/dispatcher/update-dispatcher.spec.ts
@@ -129,6 +129,27 @@ describe('UpdateDispatcher', () => {
     expect(seenBot?.token).toBe('TEST');
   });
 
+  it('skips a bot-scoped route when the current bot does not match (@ForBot)', async () => {
+    const forBotA: RoutePredicate = {
+      matches: (ctx) => ctx.bot?.name === 'a',
+    };
+    const { dispatcher, calls } = makeDispatcher([
+      route('message', 'scoped', [forBotA]),
+    ]);
+
+    // Wrong bot → predicate rejects → no route matches.
+    await dispatcher.dispatch(messageUpdate(1, 'hi'), {
+      name: 'b',
+    } as unknown as BotService);
+    expect(calls).toEqual([]);
+
+    // Right bot → fires.
+    await dispatcher.dispatch(messageUpdate(2, 'hi'), {
+      name: 'a',
+    } as unknown as BotService);
+    expect(calls).toEqual(['scoped']);
+  });
+
   it('runs only the first matching route (first-match)', async () => {
     const { dispatcher, calls } = makeDispatcher([
       route('message', 'first'),

--- a/lib/engine/dispatcher/update-dispatcher.ts
+++ b/lib/engine/dispatcher/update-dispatcher.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import type { BotService } from '../../api';
 import { runAmbient } from '../../ambient';
 import { ContextFactory } from '../context';
 import {
@@ -42,12 +43,17 @@ export class UpdateDispatcher {
     private readonly stages: StageRegistry,
   ) {}
 
-  async dispatch(update: RawUpdate): Promise<void> {
+  /**
+   * `bot` is the bot whose source delivered this update; threaded into the
+   * context so replies go back through it. Omitted (single-bot, tests) → the
+   * context uses the default bot.
+   */
+  async dispatch(update: RawUpdate, bot?: BotService): Promise<void> {
     // Each update runs inside its own ambient context, so sessions, locale/`t()`
     // and any user stage are reachable anywhere in the call chain without a ctx arg.
     await runAmbient(async () => {
       try {
-        const ctx = this.contextFactory.wrap(update);
+        const ctx = this.contextFactory.wrap(update, bot);
         if (!ctx) {
           return;
         }

--- a/lib/engine/execution/result-handler.spec.ts
+++ b/lib/engine/execution/result-handler.spec.ts
@@ -3,38 +3,41 @@ import { TelegramExecutionContext } from '../context';
 import { BotService } from '../../api';
 import { ApiMethod, GetMe } from '../../api/methods';
 
-function ctxWith(event: unknown): TelegramExecutionContext {
-  return { kind: 'message', event } as unknown as TelegramExecutionContext;
+// The handler reads the per-update bot off the context (ctx.bot), so the mock
+// bot is carried by the context, not injected into the handler.
+function ctxWith(event: unknown, bot: BotService): TelegramExecutionContext {
+  return { kind: 'message', event, bot } as unknown as TelegramExecutionContext;
 }
 
 describe('ResultHandler', () => {
   let called: ApiMethod<unknown, unknown>[];
   let handler: ResultHandler;
+  let bot: BotService;
 
   beforeEach(() => {
     called = [];
-    const bot = {
+    bot = {
       call: (method: ApiMethod<unknown, unknown>) => {
         called.push(method);
         return Promise.resolve();
       },
     } as unknown as BotService;
-    handler = new ResultHandler(bot);
+    handler = new ResultHandler();
   });
 
   it('sends a returned string via the event', async () => {
     const answered: string[] = [];
     const event = { answer: (text: string) => answered.push(text) };
 
-    await handler.handle('hello', ctxWith(event));
+    await handler.handle('hello', ctxWith(event, bot));
 
     expect(answered).toEqual(['hello']);
   });
 
-  it('executes a returned command object via bot.call', async () => {
+  it("executes a returned command object via the context's bot", async () => {
     const command = new GetMe();
 
-    await handler.handle(command, ctxWith({}));
+    await handler.handle(command, ctxWith({}, bot));
 
     expect(called).toEqual([command]);
   });
@@ -46,7 +49,7 @@ describe('ResultHandler', () => {
       },
     };
     await expect(
-      handler.handle(undefined, ctxWith(event)),
+      handler.handle(undefined, ctxWith(event, bot)),
     ).resolves.toBeUndefined();
     expect(called).toEqual([]);
   });
@@ -54,7 +57,7 @@ describe('ResultHandler', () => {
   it('ignores a non-string, non-command value (e.g. an already-sent result)', async () => {
     // `return message.answer(...)` resolves to a plain object — a silent noop.
     await expect(
-      handler.handle({ message_id: 7 }, ctxWith({})),
+      handler.handle({ message_id: 7 }, ctxWith({}, bot)),
     ).resolves.toBeUndefined();
     expect(called).toEqual([]);
   });

--- a/lib/engine/execution/result-handler.ts
+++ b/lib/engine/execution/result-handler.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { TelegramExecutionContext } from '../context/telegram-execution-context';
 import { TelegramEvent } from '../context/event-factory';
-import { BotService } from '../../api';
 import { ApiMethod } from '../../api/methods';
 
 /** An event that can reply to itself (e.g. `Message.answer`). */
@@ -25,8 +24,6 @@ interface Answerable {
 export class ResultHandler {
   private readonly logger = new Logger(ResultHandler.name);
 
-  constructor(private readonly bot: BotService) {}
-
   async handle(result: unknown, ctx: TelegramExecutionContext): Promise<void> {
     if (typeof result === 'string') {
       const event = ctx.event;
@@ -41,7 +38,9 @@ export class ResultHandler {
     }
 
     if (result instanceof ApiMethod) {
-      await this.bot.call(result);
+      // The bot that received this update — not a global default — so a returned
+      // command object (new SendMessage(...)) goes out through the right bot.
+      await ctx.bot.call(result);
     }
   }
 

--- a/lib/engine/source/bot-source.factory.spec.ts
+++ b/lib/engine/source/bot-source.factory.spec.ts
@@ -1,11 +1,18 @@
+import { ModuleRef } from '@nestjs/core';
+
 import { BotService } from '../../api';
+import { getWebhookSourceToken } from '../../providers';
 import { RouteTable } from '../discovery';
 import { AllowedUpdatesResolver } from './allowed-updates.resolver';
 import { BotSourceFactory } from './bot-source.factory';
 import { PollingUpdateSource } from './polling-update-source';
+import { WebhookUpdateSource } from './webhook-update-source';
 
-function factory(): BotSourceFactory {
-  return new BotSourceFactory(new AllowedUpdatesResolver(new RouteTable([])));
+function factory(moduleRef?: ModuleRef): BotSourceFactory {
+  return new BotSourceFactory(
+    new AllowedUpdatesResolver(new RouteTable([])),
+    moduleRef ?? ({ get: jest.fn() } as unknown as ModuleRef),
+  );
 }
 
 const bot = { token: 't' } as unknown as BotService;
@@ -20,10 +27,24 @@ describe('BotSourceFactory', () => {
     );
   });
 
-  it('returns null for a webhook bot (not auto-wired) or no transport', () => {
-    expect(
-      factory().create(bot, { webhook: { url: 'https://x/wh' } }),
-    ).toBeNull();
+  it('resolves the per-bot WebhookUpdateSource from DI for a webhook bot', () => {
+    const webhookSource = {} as WebhookUpdateSource;
+    const get = jest.fn().mockReturnValue(webhookSource);
+    const moduleRef = { get } as unknown as ModuleRef;
+
+    const source = factory(moduleRef).create(
+      bot,
+      { webhook: { url: 'https://x/wh' } },
+      'sales',
+    );
+
+    expect(source).toBe(webhookSource);
+    expect(get).toHaveBeenCalledWith(getWebhookSourceToken('sales'), {
+      strict: false,
+    });
+  });
+
+  it('returns null when no transport is configured', () => {
     expect(factory().create(bot, {})).toBeNull();
     expect(factory().create(bot, { polling: false })).toBeNull();
   });

--- a/lib/engine/source/bot-source.factory.spec.ts
+++ b/lib/engine/source/bot-source.factory.spec.ts
@@ -1,0 +1,30 @@
+import { BotService } from '../../api';
+import { RouteTable } from '../discovery';
+import { AllowedUpdatesResolver } from './allowed-updates.resolver';
+import { BotSourceFactory } from './bot-source.factory';
+import { PollingUpdateSource } from './polling-update-source';
+
+function factory(): BotSourceFactory {
+  return new BotSourceFactory(new AllowedUpdatesResolver(new RouteTable([])));
+}
+
+const bot = { token: 't' } as unknown as BotService;
+
+describe('BotSourceFactory', () => {
+  it('builds a PollingUpdateSource for a polling transport', () => {
+    expect(factory().create(bot, { polling: true })).toBeInstanceOf(
+      PollingUpdateSource,
+    );
+    expect(factory().create(bot, { polling: { idleMs: 5 } })).toBeInstanceOf(
+      PollingUpdateSource,
+    );
+  });
+
+  it('returns null for a webhook bot (not auto-wired) or no transport', () => {
+    expect(
+      factory().create(bot, { webhook: { url: 'https://x/wh' } }),
+    ).toBeNull();
+    expect(factory().create(bot, {})).toBeNull();
+    expect(factory().create(bot, { polling: false })).toBeNull();
+  });
+});

--- a/lib/engine/source/bot-source.factory.ts
+++ b/lib/engine/source/bot-source.factory.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+
+import { BotService } from '../../api';
+import type { WebhookOptions } from '../../module/nestgram-module.types';
+import { AllowedUpdatesResolver } from './allowed-updates.resolver';
+import { PollingOptions, PollingUpdateSource } from './polling-update-source';
+import { UpdateSource } from './update-source';
+
+/** One bot's transport config — in practice exactly one of polling / webhook. */
+export interface BotTransport {
+  polling?: boolean | PollingOptions;
+  webhook?: WebhookOptions;
+}
+
+/**
+ * Turns a bot's transport config into the update source the engine auto-manages
+ * for it — the single place that knows how to BUILD a source, so
+ * `NestgramBootstrap` (and the per-bot fleet) orchestrate lifecycle without
+ * constructing transports themselves.
+ *
+ * Polling → a per-bot {@link PollingUpdateSource}. Webhook returns `null`:
+ * delivery is HTTP-routed by a controller the author registers, and per-bot
+ * routing isn't auto-wired yet — in a multi-bot app, write a custom
+ * `UpdateSource` for a webhook bot (the single-bot webhook path is unchanged).
+ */
+@Injectable()
+export class BotSourceFactory {
+  constructor(
+    private readonly allowedUpdatesResolver: AllowedUpdatesResolver,
+  ) {}
+
+  create(botService: BotService, transport: BotTransport): UpdateSource | null {
+    if (transport.polling) {
+      const options =
+        typeof transport.polling === 'object' ? transport.polling : undefined;
+      return new PollingUpdateSource(
+        botService,
+        options,
+        this.allowedUpdatesResolver,
+      );
+    }
+    return null;
+  }
+}

--- a/lib/engine/source/bot-source.factory.ts
+++ b/lib/engine/source/bot-source.factory.ts
@@ -1,10 +1,13 @@
 import { Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 
 import { BotService } from '../../api';
 import type { WebhookOptions } from '../../module/nestgram-module.types';
+import { DEFAULT_BOT_NAME, getWebhookSourceToken } from '../../providers';
 import { AllowedUpdatesResolver } from './allowed-updates.resolver';
 import { PollingOptions, PollingUpdateSource } from './polling-update-source';
 import { UpdateSource } from './update-source';
+import { WebhookUpdateSource } from './webhook-update-source';
 
 /** One bot's transport config — in practice exactly one of polling / webhook. */
 export interface BotTransport {
@@ -18,18 +21,24 @@ export interface BotTransport {
  * `NestgramBootstrap` (and the per-bot fleet) orchestrate lifecycle without
  * constructing transports themselves.
  *
- * Polling → a per-bot {@link PollingUpdateSource}. Webhook returns `null`:
- * delivery is HTTP-routed by a controller the author registers, and per-bot
- * routing isn't auto-wired yet — in a multi-bot app, write a custom
- * `UpdateSource` for a webhook bot (the single-bot webhook path is unchanged).
+ * Polling → a freshly built per-bot {@link PollingUpdateSource}. Webhook → the
+ * per-bot {@link WebhookUpdateSource} provided under `getWebhookSourceToken(name)`
+ * (resolved, NOT rebuilt, so the fleet starts the SAME instance the webhook
+ * controller delivers to). Neither → `null` (no transport; e.g. a bot driven
+ * externally).
  */
 @Injectable()
 export class BotSourceFactory {
   constructor(
     private readonly allowedUpdatesResolver: AllowedUpdatesResolver,
+    private readonly moduleRef: ModuleRef,
   ) {}
 
-  create(botService: BotService, transport: BotTransport): UpdateSource | null {
+  create(
+    botService: BotService,
+    transport: BotTransport,
+    name: string = DEFAULT_BOT_NAME,
+  ): UpdateSource | null {
     if (transport.polling) {
       const options =
         typeof transport.polling === 'object' ? transport.polling : undefined;
@@ -37,6 +46,12 @@ export class BotSourceFactory {
         botService,
         options,
         this.allowedUpdatesResolver,
+      );
+    }
+    if (transport.webhook) {
+      return this.moduleRef.get<WebhookUpdateSource>(
+        getWebhookSourceToken(name),
+        { strict: false },
       );
     }
     return null;

--- a/lib/engine/source/index.ts
+++ b/lib/engine/source/index.ts
@@ -1,4 +1,5 @@
 export * from './allowed-updates.resolver';
+export * from './bot-source.factory';
 export * from './update-source';
 export * from './polling.constants';
 export * from './polling-update-source';

--- a/lib/engine/source/index.ts
+++ b/lib/engine/source/index.ts
@@ -6,3 +6,4 @@ export * from './polling-update-source';
 export * from './webhook.constants';
 export * from './webhook-update-source';
 export * from './webhook.controller';
+export * from './multibot-webhook.controller';

--- a/lib/engine/source/multibot-webhook.controller.spec.ts
+++ b/lib/engine/source/multibot-webhook.controller.spec.ts
@@ -1,0 +1,161 @@
+import { ForbiddenException, Logger, NotFoundException } from '@nestjs/common';
+import { PATH_METADATA } from '@nestjs/common/constants';
+
+import {
+  MultiBotWebhookController,
+  SharedWebhookController,
+  createMultiBotWebhookController,
+  createSharedWebhookController,
+} from './multibot-webhook.controller';
+import { WEBHOOK_PATH } from './webhook.constants';
+import {
+  WebhookSourceEntry,
+  WebhookUpdateSource,
+} from './webhook-update-source';
+import { RawUpdate } from '../../events/raw-update.types';
+
+const update = { update_id: 1 } as RawUpdate;
+
+/** The handler shapes the factory-built controllers expose (typed `Type<unknown>`). */
+interface PathController {
+  handle(botName: string, update: RawUpdate, secret?: string): void;
+}
+interface SharedController {
+  handle(update: RawUpdate, secret?: string): void;
+}
+
+/**
+ * A WebhookUpdateSource stub keyed by name and secret: `ownsSecret` matches the
+ * configured secret exactly (shared-endpoint routing), `verifySecret` is
+ * permissive when no secret is set (path-endpoint gate).
+ */
+function sourceStub(name: string, secretToken?: string) {
+  const deliver = jest.fn();
+  const source = {
+    name,
+    deliver,
+    verifySecret: (header?: string) =>
+      secretToken === undefined ? true : header === secretToken,
+    ownsSecret: (header?: string) =>
+      secretToken !== undefined && header === secretToken,
+  } as unknown as WebhookUpdateSource;
+  return { source, deliver };
+}
+
+describe('MultiBotWebhookController (path-based)', () => {
+  function make(entries: WebhookSourceEntry[]): PathController {
+    const Ctor = MultiBotWebhookController as unknown as new (
+      e: WebhookSourceEntry[],
+    ) => PathController;
+    return new Ctor(entries);
+  }
+
+  it('is served under the default webhook path with a :botName segment', () => {
+    expect(Reflect.getMetadata(PATH_METADATA, MultiBotWebhookController)).toBe(
+      WEBHOOK_PATH,
+    );
+  });
+
+  it('delivers to the named bot when its secret is valid', () => {
+    const support = sourceStub('support', 's-secret');
+    const sales = sourceStub('sales', 'x-secret');
+    const controller = make([
+      { source: support.source, isDefault: true },
+      { source: sales.source, isDefault: false },
+    ]);
+
+    controller.handle('sales', update, 'x-secret');
+
+    expect(sales.deliver).toHaveBeenCalledWith(update);
+    expect(support.deliver).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown bot name', () => {
+    const support = sourceStub('support', 's-secret');
+    const controller = make([{ source: support.source, isDefault: true }]);
+
+    expect(() => controller.handle('ghost', update, 's-secret')).toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('403s a bad secret for a known bot', () => {
+    const support = sourceStub('support', 's-secret');
+    const controller = make([{ source: support.source, isDefault: true }]);
+
+    expect(() => controller.handle('support', update, 'wrong')).toThrow(
+      ForbiddenException,
+    );
+    expect(support.deliver).not.toHaveBeenCalled();
+  });
+
+  it('binds to a custom base path via the factory', () => {
+    const Custom = createMultiBotWebhookController('hooks');
+    expect(Reflect.getMetadata(PATH_METADATA, Custom)).toBe('hooks');
+  });
+});
+
+describe('SharedWebhookController (single endpoint, secret-routed)', () => {
+  function make(entries: WebhookSourceEntry[]): SharedController {
+    const Ctor = SharedWebhookController as unknown as new (
+      e: WebhookSourceEntry[],
+    ) => SharedController;
+    return new Ctor(entries);
+  }
+
+  it('routes to the bot whose secret matches the header', () => {
+    const support = sourceStub('support', 's-secret');
+    const sales = sourceStub('sales', 'x-secret');
+    const controller = make([
+      { source: support.source, isDefault: true },
+      { source: sales.source, isDefault: false },
+    ]);
+
+    controller.handle(update, 'x-secret');
+
+    expect(sales.deliver).toHaveBeenCalledWith(update);
+    expect(support.deliver).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default bot when no secret matches', () => {
+    const support = sourceStub('support', 's-secret');
+    const sales = sourceStub('sales', 'x-secret');
+    const controller = make([
+      { source: support.source, isDefault: true },
+      { source: sales.source, isDefault: false },
+    ]);
+
+    controller.handle(update, 'unmatched');
+
+    expect(support.deliver).toHaveBeenCalledWith(update);
+    expect(sales.deliver).not.toHaveBeenCalled();
+  });
+
+  it('drops with a warning when nothing matches and there is no default', () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const a = sourceStub('a', 'a-secret');
+    const b = sourceStub('b', 'b-secret');
+    const controller = make([
+      { source: a.source, isDefault: false },
+      { source: b.source, isDefault: false },
+    ]);
+
+    controller.handle(update, 'unmatched');
+
+    expect(a.deliver).not.toHaveBeenCalled();
+    expect(b.deliver).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('no default bot'),
+    );
+    warn.mockRestore();
+  });
+
+  it('is served at the default webhook path; factory binds a custom one', () => {
+    expect(Reflect.getMetadata(PATH_METADATA, SharedWebhookController)).toBe(
+      WEBHOOK_PATH,
+    );
+    expect(
+      Reflect.getMetadata(PATH_METADATA, createSharedWebhookController('wh')),
+    ).toBe('wh');
+  });
+});

--- a/lib/engine/source/multibot-webhook.controller.ts
+++ b/lib/engine/source/multibot-webhook.controller.ts
@@ -1,0 +1,142 @@
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Logger,
+  NotFoundException,
+  Param,
+  Post,
+  Type,
+} from '@nestjs/common';
+
+import { RawUpdate } from '../../events/raw-update.types';
+import { Providers } from '../../providers';
+import { SECRET_HEADER, WEBHOOK_PATH } from './webhook.constants';
+import {
+  WebhookSourceEntry,
+  WebhookUpdateSource,
+} from './webhook-update-source';
+
+/**
+ * Build a controller that routes inbound webhook POSTs to the right bot by a
+ * `:botName` path segment — Telegram delivers to `POST /<basePath>/:botName`.
+ * Register each bot's webhook at the matching URL with {@link webhookUrl}
+ * (`webhookUrl(origin, name)`).
+ *
+ * The `:botName` path is publicly guessable, so each bot SHOULD set its own
+ * `secretToken` — the controller verifies the incoming secret against THAT bot
+ * before delivering (a bot left without one accepts any caller and is warned
+ * about at startup, as in the single-bot case). An unknown name is a 404; a bad
+ * secret a 403.
+ *
+ * Register the ready-made {@link MultiBotWebhookController} (served under
+ * `/<WEBHOOK_PATH>/:botName`) in a module's `controllers`, or call this with a
+ * custom base path. Only meaningful in a multi-bot app: it injects the
+ * `WEBHOOK_SOURCES` array `NestgramModule` provides for `bots: []` — and since
+ * `NestgramModule` is global, that token resolves wherever you register it.
+ */
+export function createMultiBotWebhookController(
+  basePath: string,
+): Type<unknown> {
+  @Controller(basePath)
+  class MultiBotWebhookController {
+    private readonly byName = new Map<string, WebhookUpdateSource>();
+
+    constructor(
+      @Inject(Providers.WEBHOOK_SOURCES) entries: WebhookSourceEntry[],
+    ) {
+      for (const { source } of entries) {
+        this.byName.set(source.name, source);
+      }
+    }
+
+    @Post(':botName')
+    @HttpCode(HttpStatus.OK)
+    handle(
+      @Param('botName') botName: string,
+      @Body() update: RawUpdate,
+      @Headers(SECRET_HEADER) secret?: string,
+    ): void {
+      const source = this.byName.get(botName);
+      if (!source) {
+        throw new NotFoundException(`No webhook bot named "${botName}"`);
+      }
+      if (!source.verifySecret(secret)) {
+        throw new ForbiddenException('Invalid webhook secret token');
+      }
+      // Respond 200 immediately; dispatch is fire-and-forget — the dispatcher
+      // isolates per-update failures, so it never throws back to Telegram.
+      void source.deliver(update);
+    }
+  }
+  return MultiBotWebhookController;
+}
+
+/**
+ * Ready-made multi-bot webhook controller served at `/<WEBHOOK_PATH>/:botName`.
+ * Add it to a module's `controllers` (`controllers: [MultiBotWebhookController]`)
+ * and register each bot's webhook at `webhookUrl(origin, name)`. For a custom
+ * base path use {@link createMultiBotWebhookController}.
+ */
+export const MultiBotWebhookController =
+  createMultiBotWebhookController(WEBHOOK_PATH);
+
+/**
+ * Build a controller that serves EVERY bot on ONE endpoint — Telegram delivers to
+ * the same `POST /<path>` for all of them (register every bot's webhook at the
+ * same `webhookUrl(origin)`). A Telegram update carries no bot identity, so it
+ * routes by the per-bot secret token: the bot whose `secretToken` matches the
+ * incoming header gets the update. With no match it falls back to the default
+ * bot; with no default either it logs and drops the update (still 200, so
+ * Telegram doesn't retry-storm).
+ *
+ * Give each bot a DISTINCT `secretToken` for this to disambiguate — without
+ * distinct secrets a shared endpoint cannot tell the bots apart and every update
+ * goes to the default. For per-bot routing without relying on secrets, use
+ * {@link createMultiBotWebhookController} (`:botName` in the path) instead.
+ */
+export function createSharedWebhookController(path: string): Type<unknown> {
+  @Controller(path)
+  class SharedWebhookController {
+    private readonly logger = new Logger(SharedWebhookController.name);
+
+    constructor(
+      @Inject(Providers.WEBHOOK_SOURCES)
+      private readonly entries: WebhookSourceEntry[],
+    ) {}
+
+    @Post()
+    @HttpCode(HttpStatus.OK)
+    handle(
+      @Body() update: RawUpdate,
+      @Headers(SECRET_HEADER) secret?: string,
+    ): void {
+      const owner = this.entries.find((entry) =>
+        entry.source.ownsSecret(secret),
+      );
+      const target = owner ?? this.entries.find((entry) => entry.isDefault);
+      if (!target) {
+        this.logger.warn(
+          'Webhook update matched no bot secret and there is no default bot — ' +
+            'dropping it. Give each bot a distinct secretToken, or mark a default.',
+        );
+        return;
+      }
+      void target.source.deliver(update);
+    }
+  }
+  return SharedWebhookController;
+}
+
+/**
+ * Ready-made shared webhook controller served at `/<WEBHOOK_PATH>` — one endpoint
+ * for all bots, routed by secret token (see {@link createSharedWebhookController}).
+ * Add it to a module's `controllers` and register every bot's webhook at the same
+ * `webhookUrl(origin)`.
+ */
+export const SharedWebhookController =
+  createSharedWebhookController(WEBHOOK_PATH);

--- a/lib/engine/source/polling-update-source.spec.ts
+++ b/lib/engine/source/polling-update-source.spec.ts
@@ -56,11 +56,7 @@ function harness(
     }),
   } as unknown as BotService;
 
-  const source = new PollingUpdateSource(
-    { token: 't', polling },
-    bot,
-    resolverFor(routes),
-  );
+  const source = new PollingUpdateSource(bot, polling, resolverFor(routes));
   return { source, bot, offsets };
 }
 
@@ -125,8 +121,8 @@ describe('PollingUpdateSource', () => {
       }),
     } as unknown as BotService;
     const source = new PollingUpdateSource(
-      { token: 't', polling: { backoffMs: 1, idleMs: 1 } },
       bot,
+      { backoffMs: 1, idleMs: 1 },
       resolverFor(),
     );
 

--- a/lib/engine/source/polling-update-source.ts
+++ b/lib/engine/source/polling-update-source.ts
@@ -1,9 +1,7 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { BotService } from '../../api';
 import { RawUpdate } from '../../events/raw-update.types';
-import { Providers } from '../../providers';
-import type { NestgramModuleOptions } from '../../module/nestgram-module.types';
 import type { AllowedUpdate } from '../context/update-kind';
 import { AllowedUpdatesResolver } from './allowed-updates.resolver';
 import {
@@ -41,8 +39,9 @@ export interface PollingOptions {
  * update. A failed fetch backs off instead of killing the loop. The bot identity
  * / health check (`getMe`) is warmed transport-agnostically in `NestgramBootstrap`.
  *
- * It reads its own polling options off the module config, so starting it is just
- * `start(onUpdate)` — see `NestgramBootstrap`.
+ * Bound to ONE bot: it takes that bot's `BotService` and polling options at
+ * construction, so a multi-bot app builds one poller per bot. The single-bot
+ * path constructs it from the top-level config via a factory provider.
  */
 @Injectable()
 export class PollingUpdateSource implements UpdateSource {
@@ -58,12 +57,11 @@ export class PollingUpdateSource implements UpdateSource {
   private running = false;
 
   constructor(
-    @Inject(Providers.NESTGRAM_OPTIONS) moduleOptions: NestgramModuleOptions,
     private readonly botService: BotService,
+    options: PollingOptions | undefined,
     private readonly allowedUpdatesResolver: AllowedUpdatesResolver,
   ) {
-    this.options =
-      typeof moduleOptions.polling === 'object' ? moduleOptions.polling : {};
+    this.options = options ?? {};
     this.offset = this.options.offset ?? 0;
     this.backoffMs = this.options.backoffMs ?? DEFAULT_POLLING_BACKOFF_MS;
     this.idleMs = this.options.idleMs ?? DEFAULT_POLLING_IDLE_MS;

--- a/lib/engine/source/webhook-update-source.spec.ts
+++ b/lib/engine/source/webhook-update-source.spec.ts
@@ -2,7 +2,7 @@ import { Logger } from '@nestjs/common';
 
 import { WebhookUpdateSource } from './webhook-update-source';
 import { BotService } from '../../api';
-import { NestgramModuleOptions } from '../../module/nestgram-module.types';
+import { WebhookOptions } from '../../module/nestgram-module.types';
 import { RawUpdate } from '../../events/raw-update.types';
 import { RouteTable } from '../discovery';
 import { Route } from '../discovery/route.types';
@@ -14,7 +14,7 @@ function listenerOn(updateType: string): Route {
 }
 
 function make(
-  webhook: NestgramModuleOptions['webhook'],
+  webhook: WebhookOptions | undefined,
   token = '123:ABC',
   routes: Route[] = [],
 ) {
@@ -22,8 +22,8 @@ function make(
   const deleteWebhook = jest.fn().mockResolvedValue(true);
   const bot = { token, setWebhook, deleteWebhook } as unknown as BotService;
   const source = new WebhookUpdateSource(
-    { token, webhook } as NestgramModuleOptions,
     bot,
+    webhook,
     new AllowedUpdatesResolver(new RouteTable(routes)),
   );
   return { source, setWebhook, deleteWebhook };
@@ -104,6 +104,30 @@ describe('WebhookUpdateSource', () => {
     const { source } = make({ url: 'https://x/h' });
     expect(source.verifySecret(undefined)).toBe(true);
     expect(source.verifySecret('whatever')).toBe(true);
+  });
+
+  it('ownsSecret is a positive match: true only when a secret is set and equal', () => {
+    const { source } = make({ url: 'https://x/h', secretToken: 's3cret' });
+    expect(source.ownsSecret('s3cret')).toBe(true);
+    expect(source.ownsSecret('nope')).toBe(false);
+    expect(source.ownsSecret(undefined)).toBe(false);
+  });
+
+  it('ownsSecret is always false without a configured secret (unroutable on a shared endpoint)', () => {
+    const { source } = make({ url: 'https://x/h' });
+    expect(source.ownsSecret(undefined)).toBe(false);
+    expect(source.ownsSecret('whatever')).toBe(false);
+  });
+
+  it('carries the bot name (defaults to the single-bot default)', () => {
+    expect(make({ url: 'https://x/h' }).source.name).toBe('default');
+    const named = new WebhookUpdateSource(
+      { token: 't' } as unknown as BotService,
+      { url: 'https://x/h' },
+      new AllowedUpdatesResolver(new RouteTable([])),
+      'sales',
+    );
+    expect(named.name).toBe('sales');
   });
 
   it('deliver forwards the update to the listener set in start', async () => {

--- a/lib/engine/source/webhook-update-source.ts
+++ b/lib/engine/source/webhook-update-source.ts
@@ -1,14 +1,22 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { BotService } from '../../api';
 import { RawUpdate } from '../../events/raw-update.types';
-import { Providers } from '../../providers';
-import type {
-  NestgramModuleOptions,
-  WebhookOptions,
-} from '../../module/nestgram-module.types';
+import { DEFAULT_BOT_NAME } from '../../providers';
+import type { WebhookOptions } from '../../module/nestgram-module.types';
 import { AllowedUpdatesResolver } from './allowed-updates.resolver';
 import { UpdateListener, UpdateSource } from './update-source';
+
+/**
+ * One webhook bot of a multi-bot app, paired with whether it is the app default.
+ * `NestgramModule` provides these as the `WEBHOOK_SOURCES` array; the ready-made
+ * multi-bot webhook controllers inject it to route an inbound POST to the right
+ * bot (by `source.name` or `source.ownsSecret`).
+ */
+export interface WebhookSourceEntry {
+  source: WebhookUpdateSource;
+  isDefault: boolean;
+}
 
 /**
  * Webhook update source.
@@ -19,20 +27,23 @@ import { UpdateListener, UpdateSource } from './update-source';
  * calls {@link verifySecret} then {@link deliver}. Implements the same
  * {@link UpdateSource} contract as polling, so the dispatcher and the rest of the
  * engine are unchanged.
+ *
+ * Bound to ONE bot: it takes that bot's `BotService` and webhook config at
+ * construction (mirroring {@link PollingUpdateSource}), so a multi-bot app builds
+ * one per webhook bot. The single-bot path constructs it from the top-level
+ * webhook config via a factory provider.
  */
 @Injectable()
 export class WebhookUpdateSource implements UpdateSource {
   private readonly logger = new Logger(WebhookUpdateSource.name);
-  private readonly config?: WebhookOptions;
   private onUpdate?: UpdateListener;
 
   constructor(
-    @Inject(Providers.NESTGRAM_OPTIONS) options: NestgramModuleOptions,
     private readonly botService: BotService,
+    private readonly config: WebhookOptions | undefined,
     private readonly allowedUpdatesResolver: AllowedUpdatesResolver,
-  ) {
-    this.config = options.webhook;
-  }
+    readonly name: string = DEFAULT_BOT_NAME,
+  ) {}
 
   async start(onUpdate: UpdateListener): Promise<void> {
     if (!this.config) {
@@ -52,8 +63,8 @@ export class WebhookUpdateSource implements UpdateSource {
     // a controller — the author does. Remind here (the one moment we know a
     // webhook is configured) so a missing controller isn't a silent 404.
     this.logger.log(
-      `Webhook registered: ${this.config.url} — a controller must serve this ` +
-        'URL (register WebhookController or your own).',
+      `Webhook registered for "${this.name}": ${this.config.url} — a controller ` +
+        'must serve this URL (register a webhook controller or your own).',
     );
   }
 
@@ -74,6 +85,21 @@ export class WebhookUpdateSource implements UpdateSource {
       return true;
     }
     return headerSecret === this.config.secretToken;
+  }
+
+  /**
+   * Whether this bot OWNS the incoming secret: a secret is configured AND the
+   * header matches it. Unlike {@link verifySecret} (which accepts anything when no
+   * secret is set), this is a positive identification — used to route a SHARED
+   * endpoint's update to the right bot by its secret token. A bot without a
+   * `secretToken` can never own a request, so it is unroutable on a shared
+   * endpoint (give each bot a distinct secret).
+   */
+  ownsSecret(headerSecret?: string): boolean {
+    return (
+      this.config?.secretToken !== undefined &&
+      headerSecret === this.config.secretToken
+    );
   }
 
   /** Hand a received update to the dispatcher (called by `WebhookController`). */

--- a/lib/engine/source/webhook.constants.ts
+++ b/lib/engine/source/webhook.constants.ts
@@ -4,3 +4,24 @@
  * here. For a different route, register `createWebhookController(path)` instead.
  */
 export const WEBHOOK_PATH = 'telegram/webhook';
+
+/** The header Telegram sends the configured secret token in. */
+export const SECRET_HEADER = 'x-telegram-bot-api-secret-token';
+
+/**
+ * Build the webhook URL to register with Telegram (`setWebhook`), kept in sync
+ * with the ready-made controllers' routes so the registered URL can't drift from
+ * the served route. Pass the public origin as `baseUrl` (e.g.
+ * `https://bots.example.com`). With a `name` it returns the per-bot path the
+ * {@link MultiBotWebhookController} serves (`<baseUrl>/<WEBHOOK_PATH>/<name>`);
+ * without, the single shared/default endpoint (`<baseUrl>/<WEBHOOK_PATH>`).
+ *
+ * The name is percent-encoded so a bot named with URL-unsafe characters still
+ * produces a URL that matches the decoded `:botName` route segment.
+ */
+export function webhookUrl(baseUrl: string, name?: string): string {
+  const base = baseUrl.replace(/\/+$/, '');
+  return name
+    ? `${base}/${WEBHOOK_PATH}/${encodeURIComponent(name)}`
+    : `${base}/${WEBHOOK_PATH}`;
+}

--- a/lib/engine/source/webhook.controller.ts
+++ b/lib/engine/source/webhook.controller.ts
@@ -10,11 +10,8 @@ import {
 } from '@nestjs/common';
 
 import { RawUpdate } from '../../events/raw-update.types';
-import { WEBHOOK_PATH } from './webhook.constants';
+import { SECRET_HEADER, WEBHOOK_PATH } from './webhook.constants';
 import { WebhookUpdateSource } from './webhook-update-source';
-
-/** The header Telegram sends the configured secret token in. */
-const SECRET_HEADER = 'x-telegram-bot-api-secret-token';
 
 /** What a webhook controller exposes — the POST handler Telegram calls. */
 export interface WebhookReceiver {

--- a/lib/events/raw-update.types.ts
+++ b/lib/events/raw-update.types.ts
@@ -15,6 +15,7 @@ import {
   InputMediaVideo,
 } from '../api/input-media';
 import type { ParseModeValue } from '../api/parse-mode';
+import type { ButtonStyleValue } from '../keyboards/button-style';
 
 export interface RawAcceptedGiftTypes {
   unlimited_gifts: boolean;
@@ -807,7 +808,7 @@ export interface RawInaccessibleMessage {
 export interface RawInlineKeyboardButton {
   text: string;
   icon_custom_emoji_id?: string;
-  style?: string;
+  style?: ButtonStyleValue;
   url?: string;
   callback_data?: string;
   web_app?: RawWebAppInfo;
@@ -1380,7 +1381,7 @@ export interface RawInvoice {
 export interface RawKeyboardButton {
   text: string;
   icon_custom_emoji_id?: string;
-  style?: string;
+  style?: ButtonStyleValue;
   request_users?: RawKeyboardButtonRequestUsers;
   request_chat?: RawKeyboardButtonRequestChat;
   request_managed_bot?: RawKeyboardButtonRequestManagedBot;

--- a/lib/keyboards/button-style.ts
+++ b/lib/keyboards/button-style.ts
@@ -1,0 +1,28 @@
+/**
+ * Every visual style Telegram accepts on a keyboard button's `style`. The single
+ * source of truth for button-style values across the framework — assign or
+ * compare against `ButtonStyle.X`, never a bare string. Omitting it lets the app
+ * pick its default style.
+ *
+ * @see https://core.telegram.org/bots/api#inlinekeyboardbutton
+ */
+export enum ButtonStyle {
+  /** Blue — the affirmative / main action. */
+  Primary = 'primary',
+  /** Green — a positive, confirming action. */
+  Success = 'success',
+  /** Red — a destructive or cancelling action. */
+  Danger = 'danger',
+}
+
+/**
+ * A button `style` accepted in markup — the string values of {@link ButtonStyle},
+ * so markup can be written as plain literals (`'primary'`) with autocomplete and
+ * no enum import, while framework code uses `ButtonStyle.X`.
+ */
+export type ButtonStyleValue = `${ButtonStyle}`;
+
+/** The slice of a button the keyboard builders stamp a pending style onto. */
+export interface StyleableButton {
+  style?: ButtonStyleValue;
+}

--- a/lib/keyboards/index.ts
+++ b/lib/keyboards/index.ts
@@ -1,3 +1,4 @@
+export * from './button-style';
 export * from './keyboard-builder';
 export * from './inline-keyboard';
 export * from './reply-keyboard';

--- a/lib/keyboards/inline-keyboard.ts
+++ b/lib/keyboards/inline-keyboard.ts
@@ -1,9 +1,11 @@
+import { ButtonStyleValue } from './button-style';
 import { KeyboardBuilder } from './keyboard-builder';
 
 interface InlineButton {
   text: string;
   callback_data?: string;
   url?: string;
+  style?: ButtonStyleValue;
 }
 
 /**
@@ -11,28 +13,28 @@ interface InlineButton {
  *
  * Buttons go into the current row; `.row()` starts a new one, or `.columns(n)`
  * auto-wraps into a grid. A trailing `hidden` flag drops the button (handy for
- * conditional buttons: `.text('Admin', 'admin', !isAdmin)`). Pass the instance
- * as `reply_markup` — `JSON.stringify` calls `toJSON()`, serializing to the
- * Telegram `{ inline_keyboard }` shape.
+ * conditional buttons: `.text('Admin', 'admin', !isAdmin)`). A colour modifier
+ * (`.primary()`/`.success()`/`.danger()`) styles the next button. Pass the
+ * instance as `reply_markup` — `JSON.stringify` calls `toJSON()`, serializing to
+ * the Telegram `{ inline_keyboard }` shape.
  *
  * ```ts
- * new InlineKeyboard().columns(2).text('Buy', 'buy').text('Info', 'info')
+ * new InlineKeyboard()
+ *   .columns(2)
+ *   .primary().text('Buy', 'buy')
+ *   .text('Info', 'info');
  * ```
  */
 export class InlineKeyboard extends KeyboardBuilder<InlineButton> {
   /** A callback button: pressing it sends `callbackData` back as an update. */
   text(label: string, callbackData: string, hidden = false): this {
-    if (!hidden) {
-      this.push({ text: label, callback_data: callbackData });
-    }
+    this.push({ text: label, callback_data: callbackData }, hidden);
     return this;
   }
 
   /** A URL button: pressing it opens the link. */
   url(label: string, url: string, hidden = false): this {
-    if (!hidden) {
-      this.push({ text: label, url });
-    }
+    this.push({ text: label, url }, hidden);
     return this;
   }
 

--- a/lib/keyboards/keyboard-builder.ts
+++ b/lib/keyboards/keyboard-builder.ts
@@ -1,4 +1,5 @@
 import { NestgramConfigError } from '../exceptions/config.exception';
+import { ButtonStyle, StyleableButton } from './button-style';
 
 /**
  * Shared row layout for the keyboard builders.
@@ -8,10 +9,15 @@ import { NestgramConfigError } from '../exceptions/config.exception';
  * fresh row — so you get an even grid without sprinkling `.row()` calls. Hidden
  * buttons are simply never added, so they don't take a grid slot and an
  * all-hidden row collapses away on serialize.
+ *
+ * A colour modifier (`.primary()`/`.success()`/`.danger()`) styles the NEXT
+ * button only — it sets a pending style the next button consumes, so
+ * `.danger().text('Delete', 'del')` reads as "this one button is red".
  */
-export abstract class KeyboardBuilder<TButton> {
+export abstract class KeyboardBuilder<TButton extends StyleableButton> {
   protected readonly rows: TButton[][] = [[]];
   private columnLimit?: number;
+  private pendingStyle?: ButtonStyle;
 
   /**
    * Auto-wrap into rows of `count` (a grid). The limit applies to every
@@ -32,8 +38,38 @@ export abstract class KeyboardBuilder<TButton> {
     return this;
   }
 
-  /** Append a button, honoring the current column limit. */
-  protected push(button: TButton): void {
+  /** Style the next button blue — the main / affirmative action. */
+  primary(): this {
+    this.pendingStyle = ButtonStyle.Primary;
+    return this;
+  }
+
+  /** Style the next button green — a positive, confirming action. */
+  success(): this {
+    this.pendingStyle = ButtonStyle.Success;
+    return this;
+  }
+
+  /** Style the next button red — a destructive or cancelling action. */
+  danger(): this {
+    this.pendingStyle = ButtonStyle.Danger;
+    return this;
+  }
+
+  /**
+   * Append a button, honoring the current column limit. A pending colour is
+   * consumed here whether or not the button is shown — so a hidden button takes
+   * its intended style down with it instead of leaking it onto the next one.
+   */
+  protected push(button: TButton, hidden = false): void {
+    const style = this.pendingStyle;
+    this.pendingStyle = undefined;
+    if (hidden) {
+      return;
+    }
+    if (style !== undefined) {
+      button.style = style;
+    }
     const current = this.rows[this.rows.length - 1];
     if (this.columnLimit !== undefined && current.length >= this.columnLimit) {
       this.rows.push([button]);

--- a/lib/keyboards/keyboards.spec.ts
+++ b/lib/keyboards/keyboards.spec.ts
@@ -129,6 +129,78 @@ describe('InlineKeyboard', () => {
       ],
     });
   });
+
+  it('a colour modifier styles the next button only (one-shot)', () => {
+    const kb = new InlineKeyboard()
+      .primary()
+      .text('Buy', 'buy')
+      .text('Info', 'info')
+      .danger()
+      .url('Cancel', 'https://x');
+
+    expect(serialize(kb)).toEqual({
+      inline_keyboard: [
+        [
+          { text: 'Buy', callback_data: 'buy', style: 'primary' },
+          { text: 'Info', callback_data: 'info' },
+          { text: 'Cancel', url: 'https://x', style: 'danger' },
+        ],
+      ],
+    });
+  });
+
+  it('exposes all three styles', () => {
+    const kb = new InlineKeyboard()
+      .primary()
+      .text('p', '1')
+      .success()
+      .text('s', '2')
+      .danger()
+      .text('d', '3');
+
+    expect(serialize(kb)).toEqual({
+      inline_keyboard: [
+        [
+          { text: 'p', callback_data: '1', style: 'primary' },
+          { text: 's', callback_data: '2', style: 'success' },
+          { text: 'd', callback_data: '3', style: 'danger' },
+        ],
+      ],
+    });
+  });
+
+  it('a hidden styled button does not leak its style onto the next', () => {
+    const kb = new InlineKeyboard()
+      .danger()
+      .text('drop', 'd', true)
+      .text('keep', 'k');
+
+    expect(serialize(kb)).toEqual({
+      inline_keyboard: [[{ text: 'keep', callback_data: 'k' }]],
+    });
+  });
+
+  it('a colour modifier attaches to the next button across a row break', () => {
+    const kb = new InlineKeyboard().primary().row().text('X', 'x');
+    expect(serialize(kb)).toEqual({
+      inline_keyboard: [[{ text: 'X', callback_data: 'x', style: 'primary' }]],
+    });
+  });
+
+  it('a styled button keeps its style when columns wraps it to a new row', () => {
+    const kb = new InlineKeyboard()
+      .columns(1)
+      .text('a', '1')
+      .danger()
+      .text('b', '2');
+
+    expect(serialize(kb)).toEqual({
+      inline_keyboard: [
+        [{ text: 'a', callback_data: '1' }],
+        [{ text: 'b', callback_data: '2', style: 'danger' }],
+      ],
+    });
+  });
 });
 
 describe('ReplyKeyboard', () => {
@@ -165,6 +237,13 @@ describe('ReplyKeyboard', () => {
   it('omits unset flags', () => {
     const kb = new ReplyKeyboard().text('Hi');
     expect(serialize(kb)).toEqual({ keyboard: [[{ text: 'Hi' }]] });
+  });
+
+  it('styles a button via a colour modifier', () => {
+    const kb = new ReplyKeyboard().success().text('Confirm').text('Plain');
+    expect(serialize(kb)).toEqual({
+      keyboard: [[{ text: 'Confirm', style: 'success' }, { text: 'Plain' }]],
+    });
   });
 });
 

--- a/lib/keyboards/reply-keyboard.ts
+++ b/lib/keyboards/reply-keyboard.ts
@@ -1,9 +1,11 @@
+import { ButtonStyleValue } from './button-style';
 import { KeyboardBuilder } from './keyboard-builder';
 
 interface ReplyButton {
   text: string;
   request_contact?: boolean;
   request_location?: boolean;
+  style?: ButtonStyleValue;
 }
 
 interface ReplyKeyboardMarkup {
@@ -18,8 +20,9 @@ interface ReplyKeyboardMarkup {
  * Fluent builder for a custom reply keyboard (buttons under the input field).
  *
  * Buttons go into the current row; `.row()` starts a new one, or `.columns(n)`
- * auto-wraps into a grid. A trailing `hidden` flag drops the button. Pass the
- * instance as `reply_markup` — `toJSON()` serializes to the Telegram
+ * auto-wraps into a grid. A trailing `hidden` flag drops the button; a colour
+ * modifier (`.primary()`/`.success()`/`.danger()`) styles the next button. Pass
+ * the instance as `reply_markup` — `toJSON()` serializes to the Telegram
  * `{ keyboard, ... }` shape.
  *
  * ```ts
@@ -34,9 +37,7 @@ export class ReplyKeyboard extends KeyboardBuilder<ReplyButton> {
 
   /** A plain text button (sends its label as a message when pressed). */
   text(label: string, hidden = false): this {
-    if (!hidden) {
-      this.push({ text: label });
-    }
+    this.push({ text: label }, hidden);
     return this;
   }
 

--- a/lib/module/bot-config.spec.ts
+++ b/lib/module/bot-config.spec.ts
@@ -1,0 +1,128 @@
+import { BotConfigResolver, DEFAULT_BOT_NAME, getBotToken } from './bot-config';
+import { ParseMode } from '../api/parse-mode';
+import { NestgramConfigError } from '../exceptions';
+
+describe('getBotToken', () => {
+  it('keys by name, defaulting to the default bot', () => {
+    expect(getBotToken('sales')).toBe('nestgram:bot:sales');
+    expect(getBotToken()).toBe(`nestgram:bot:${DEFAULT_BOT_NAME}`);
+  });
+});
+
+describe('BotConfigResolver', () => {
+  it('treats the single-bot shorthand as one default bot', () => {
+    const [bot, ...rest] = BotConfigResolver.resolve({
+      token: 'T',
+      polling: true,
+      parseMode: ParseMode.Html,
+    });
+
+    expect(rest).toHaveLength(0);
+    expect(bot.name).toBe(DEFAULT_BOT_NAME);
+    expect(bot.isDefault).toBe(true);
+    expect(bot.polling).toBe(true);
+    expect(bot.options).toMatchObject({
+      token: 'T',
+      parseMode: ParseMode.Html,
+    });
+  });
+
+  it('resolves a bots[] list, each carrying its own flags', () => {
+    const bots = BotConfigResolver.resolve({
+      bots: [
+        {
+          name: 'support',
+          token: 'A',
+          polling: true,
+          parseMode: ParseMode.Html,
+        },
+        { name: 'sales', token: 'B', webhook: { url: 'https://x/wh' } },
+      ],
+    });
+
+    expect(bots.map((b) => b.name)).toEqual(['support', 'sales']);
+    expect(bots[0].options.parseMode).toBe(ParseMode.Html);
+    expect(bots[1].webhook).toEqual({ url: 'https://x/wh' });
+    // No default flagged among several → none is the default.
+    expect(bots.every((b) => !b.isDefault)).toBe(true);
+  });
+
+  it('honours an explicit default among several bots', () => {
+    const bots = BotConfigResolver.resolve({
+      bots: [
+        { name: 'a', token: 'A' },
+        { name: 'b', token: 'B', default: true },
+      ],
+    });
+
+    expect(bots.find((b) => b.isDefault)?.name).toBe('b');
+  });
+
+  it('makes the sole bot the default even if it says default: false', () => {
+    const [bot] = BotConfigResolver.resolve({
+      bots: [{ name: 'only', token: 'A', default: false }],
+    });
+    expect(bot.isDefault).toBe(true);
+  });
+
+  it('rejects passing both token and bots', () => {
+    expect(() =>
+      BotConfigResolver.resolve({ token: 'T', bots: [{ token: 'A' }] }),
+    ).toThrow(NestgramConfigError);
+  });
+
+  it('rejects an empty config', () => {
+    expect(() => BotConfigResolver.resolve({})).toThrow(NestgramConfigError);
+  });
+
+  it('rejects an empty bots list', () => {
+    expect(() => BotConfigResolver.resolve({ bots: [] })).toThrow(
+      NestgramConfigError,
+    );
+  });
+
+  it('passes an empty token through (boot-time validation, not config shape)', () => {
+    // Token CONTENT is TokenValidationInterceptor's job at boot — the resolver
+    // only normalizes shape, so an empty token resolves rather than throwing here.
+    const [bot] = BotConfigResolver.resolve({ token: '' });
+    expect(bot.options.token).toBe('');
+  });
+
+  it('rejects duplicate names (including two unnamed bots)', () => {
+    expect(() =>
+      BotConfigResolver.resolve({
+        bots: [
+          { name: 'a', token: 'A' },
+          { name: 'a', token: 'B' },
+        ],
+      }),
+    ).toThrow(/Duplicate bot name/);
+    expect(() =>
+      BotConfigResolver.resolve({
+        bots: [{ token: 'A' }, { token: 'B' }],
+      }),
+    ).toThrow(/Duplicate bot name/);
+  });
+
+  it('rejects two bots sharing a token', () => {
+    expect(() =>
+      BotConfigResolver.resolve({
+        bots: [
+          { name: 'a', token: 'SAME' },
+          { name: 'b', token: 'SAME' },
+        ],
+      }),
+    ).toThrow(/share a token/);
+  });
+
+  it('rejects more than one default', () => {
+    expect(() =>
+      BotConfigResolver.resolve({
+        bots: [
+          { name: 'a', token: 'A', default: true },
+          { name: 'b', token: 'B', default: true },
+        ],
+      }),
+    ).toThrow(/more than one|at most one/i);
+  });
+});

--- a/lib/module/bot-config.spec.ts
+++ b/lib/module/bot-config.spec.ts
@@ -116,6 +116,36 @@ describe('BotConfigResolver', () => {
     ).toThrow(/share a token/);
   });
 
+  it('rejects two webhook bots sharing a secret token', () => {
+    expect(() =>
+      BotConfigResolver.resolve({
+        bots: [
+          {
+            name: 'a',
+            token: 'A',
+            webhook: { url: 'https://x/a', secretToken: 'SAME' },
+          },
+          {
+            name: 'b',
+            token: 'B',
+            webhook: { url: 'https://x/b', secretToken: 'SAME' },
+          },
+        ],
+      }),
+    ).toThrow(/share a webhook secretToken/);
+  });
+
+  it('allows webhook bots without secrets (uniqueness only checks set secrets)', () => {
+    expect(() =>
+      BotConfigResolver.resolve({
+        bots: [
+          { name: 'a', token: 'A', webhook: { url: 'https://x/a' } },
+          { name: 'b', token: 'B', webhook: { url: 'https://x/b' } },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
   it('rejects more than one default', () => {
     expect(() =>
       BotConfigResolver.resolve({

--- a/lib/module/bot-config.spec.ts
+++ b/lib/module/bot-config.spec.ts
@@ -1,4 +1,5 @@
-import { BotConfigResolver, DEFAULT_BOT_NAME, getBotToken } from './bot-config';
+import { BotConfigResolver } from './bot-config';
+import { DEFAULT_BOT_NAME, getBotToken } from '../providers';
 import { ParseMode } from '../api/parse-mode';
 import { NestgramConfigError } from '../exceptions';
 
@@ -27,7 +28,7 @@ describe('BotConfigResolver', () => {
     });
   });
 
-  it('resolves a bots[] list, each carrying its own flags', () => {
+  it('resolves a bots[] list (co-equal, no default), each carrying its own flags', () => {
     const bots = BotConfigResolver.resolve({
       bots: [
         {
@@ -43,7 +44,7 @@ describe('BotConfigResolver', () => {
     expect(bots.map((b) => b.name)).toEqual(['support', 'sales']);
     expect(bots[0].options.parseMode).toBe(ParseMode.Html);
     expect(bots[1].webhook).toEqual({ url: 'https://x/wh' });
-    // No default flagged among several → none is the default.
+    // No flag among several co-equal bots → none is the default.
     expect(bots.every((b) => !b.isDefault)).toBe(true);
   });
 

--- a/lib/module/bot-config.ts
+++ b/lib/module/bot-config.ts
@@ -58,6 +58,7 @@ export class BotConfigResolver {
     );
     this.assertUniqueNames(resolved);
     this.assertUniqueTokens(resolved);
+    this.assertUniqueWebhookSecrets(resolved);
     return this.applyDefault(resolved);
   }
 
@@ -132,6 +133,30 @@ export class BotConfigResolver {
         );
       }
       seen.add(bot.options.token);
+    }
+  }
+
+  /**
+   * Webhook secret tokens must be distinct across bots: the shared-endpoint
+   * webhook controller routes an inbound update to the bot whose secret matches,
+   * so a shared secret would silently misroute (first-match wins). Only bots that
+   * set a `secretToken` are checked — an absent one is a separate (insecure)
+   * config the source warns about at startup.
+   */
+  private static assertUniqueWebhookSecrets(bots: ResolvedBot[]): void {
+    const seen = new Set<string>();
+    for (const bot of bots) {
+      const secret = bot.webhook?.secretToken;
+      if (secret === undefined) {
+        continue;
+      }
+      if (seen.has(secret)) {
+        throw new NestgramConfigError(
+          `Two bots share a webhook secretToken (bot "${bot.name}") — each ` +
+            'needs its own so a shared endpoint can route to the right bot.',
+        );
+      }
+      seen.add(secret);
     }
   }
 

--- a/lib/module/bot-config.ts
+++ b/lib/module/bot-config.ts
@@ -1,0 +1,167 @@
+import { BotOptions } from '../api/bot-options';
+import type { PollingOptions } from '../engine/source';
+import { NestgramConfigError } from '../exceptions';
+import {
+  BotDefinition,
+  NestgramModuleOptions,
+  WebhookOptions,
+} from './nestgram-module.types';
+
+/** The name an unnamed single bot takes — what bare `BotService` resolves to. */
+export const DEFAULT_BOT_NAME = 'default';
+
+/**
+ * The DI token a bot's `BotService` is provided under, keyed by name. `@InjectBot`
+ * is sugar over `@Inject(getBotToken(name))`; a free function because it is the
+ * established Nest token-helper idiom (`getRepositoryToken` and friends).
+ */
+export function getBotToken(name: string = DEFAULT_BOT_NAME): string {
+  return `nestgram:bot:${name}`;
+}
+
+/**
+ * One bot after config normalization: its name, whether it is the default, its
+ * transport, and the per-bot {@link BotOptions} its interceptor pipeline is built
+ * from.
+ */
+export interface ResolvedBot {
+  name: string;
+  isDefault: boolean;
+  polling?: boolean | PollingOptions;
+  webhook?: WebhookOptions;
+  options: BotOptions;
+}
+
+/**
+ * Normalizes a {@link NestgramModuleOptions} into the canonical list of bots,
+ * collapsing the single-bot shorthand (`token` + transport at the top level) and
+ * the multi-bot `bots: []` into one shape — and rejecting an inconsistent config
+ * at boot rather than letting it half-work. Pure and static: it runs at module
+ * definition time, before DI exists.
+ */
+export class BotConfigResolver {
+  static resolve(options: NestgramModuleOptions): ResolvedBot[] {
+    const { bots, token } = options;
+    if (bots && token !== undefined) {
+      throw new NestgramConfigError(
+        'Pass either `token` (single bot) or `bots: []` (multi-bot), not both.',
+      );
+    }
+
+    let definitions: BotDefinition[];
+    if (bots) {
+      definitions = bots;
+    } else if (typeof token === 'string') {
+      definitions = [this.singleBotDefinition(token, options)];
+    } else {
+      throw new NestgramConfigError(
+        'No bot configured — pass `token` for a single bot or `bots: []` for several.',
+      );
+    }
+    if (definitions.length === 0) {
+      throw new NestgramConfigError(
+        '`bots: []` is empty — configure at least one bot.',
+      );
+    }
+
+    const resolved = definitions.map((definition) =>
+      this.resolveOne(definition),
+    );
+    this.assertUniqueNames(resolved);
+    this.assertUniqueTokens(resolved);
+    return this.applyDefault(resolved);
+  }
+
+  /** The single-bot shorthand as a {@link BotDefinition} (the top-level fields). */
+  private static singleBotDefinition(
+    token: string,
+    options: NestgramModuleOptions,
+  ): BotDefinition {
+    return {
+      token,
+      polling: options.polling,
+      webhook: options.webhook,
+      parseMode: options.parseMode,
+      richMessages: options.richMessages,
+      ignoreNotModified: options.ignoreNotModified,
+      apiInterceptors: options.apiInterceptors,
+      throttle: options.throttle,
+      throttler: options.throttler,
+    };
+  }
+
+  /**
+   * Token CONTENT (empty / malformed) is deliberately NOT validated here — that is
+   * `TokenValidationInterceptor`'s job at boot, so the message is consistent
+   * whether the token came from config or the wire. This guards only the SHAPE
+   * (a token must be present), defending the async path where one could be undefined.
+   */
+  private static resolveOne(definition: BotDefinition): ResolvedBot {
+    if (typeof definition.token !== 'string') {
+      const label = definition.name ? `"${definition.name}"` : '(unnamed)';
+      throw new NestgramConfigError(`Bot ${label} has no token.`);
+    }
+    return {
+      name: definition.name ?? DEFAULT_BOT_NAME,
+      isDefault: definition.default === true,
+      polling: definition.polling,
+      webhook: definition.webhook,
+      options: {
+        token: definition.token,
+        parseMode: definition.parseMode,
+        richMessages: definition.richMessages,
+        ignoreNotModified: definition.ignoreNotModified,
+        apiInterceptors: definition.apiInterceptors,
+        throttle: definition.throttle,
+        throttler: definition.throttler,
+      },
+    };
+  }
+
+  private static assertUniqueNames(bots: ResolvedBot[]): void {
+    const seen = new Set<string>();
+    for (const bot of bots) {
+      if (seen.has(bot.name)) {
+        const hint =
+          bot.name === DEFAULT_BOT_NAME
+            ? ' — give each bot a distinct `name` in a multi-bot setup'
+            : '';
+        throw new NestgramConfigError(
+          `Duplicate bot name "${bot.name}"${hint}.`,
+        );
+      }
+      seen.add(bot.name);
+    }
+  }
+
+  private static assertUniqueTokens(bots: ResolvedBot[]): void {
+    const seen = new Set<string>();
+    for (const bot of bots) {
+      if (seen.has(bot.options.token)) {
+        throw new NestgramConfigError(
+          `Two bots share a token (bot "${bot.name}") — each bot needs its own.`,
+        );
+      }
+      seen.add(bot.options.token);
+    }
+  }
+
+  /**
+   * Settle which bot is the default: the one bot in a single-bot app, or the one
+   * flagged `default: true`. At most one may be flagged; with several bots and
+   * none flagged, there is no default (a bare `BotService` injection then throws,
+   * by design — the caller must name the bot).
+   */
+  private static applyDefault(bots: ResolvedBot[]): ResolvedBot[] {
+    const flagged = bots.filter((bot) => bot.isDefault);
+    if (flagged.length > 1) {
+      throw new NestgramConfigError(
+        'More than one bot is marked `default: true` — at most one may be.',
+      );
+    }
+    if (bots.length === 1) {
+      bots[0].isDefault = true;
+    }
+    return bots;
+  }
+}

--- a/lib/module/bot-config.ts
+++ b/lib/module/bot-config.ts
@@ -1,23 +1,12 @@
 import { BotOptions } from '../api/bot-options';
 import type { PollingOptions } from '../engine/source';
 import { NestgramConfigError } from '../exceptions';
+import { DEFAULT_BOT_NAME } from '../providers';
 import {
   BotDefinition,
   NestgramModuleOptions,
   WebhookOptions,
 } from './nestgram-module.types';
-
-/** The name an unnamed single bot takes — what bare `BotService` resolves to. */
-export const DEFAULT_BOT_NAME = 'default';
-
-/**
- * The DI token a bot's `BotService` is provided under, keyed by name. `@InjectBot`
- * is sugar over `@Inject(getBotToken(name))`; a free function because it is the
- * established Nest token-helper idiom (`getRepositoryToken` and friends).
- */
-export function getBotToken(name: string = DEFAULT_BOT_NAME): string {
-  return `nestgram:bot:${name}`;
-}
 
 /**
  * One bot after config normalization: its name, whether it is the default, its
@@ -147,20 +136,25 @@ export class BotConfigResolver {
   }
 
   /**
-   * Settle which bot is the default: the one bot in a single-bot app, or the one
-   * flagged `default: true`. At most one may be flagged; with several bots and
-   * none flagged, there is no default (a bare `BotService` injection then throws,
-   * by design — the caller must name the bot).
+   * Settle which bot is the default — the one a bare `BotService` (and
+   * `@InjectBot()` with no name) resolves to. A single bot is implicitly the
+   * default. With several bots, AT MOST one may be flagged `default: true` (more
+   * than one is rejected). None is allowed too — co-equal bots (e.g. white-label
+   * tenants) with no primary: a bare `BotService` injection is then ambiguous and
+   * unavailable, and each bot is reached only via `@InjectBot(name)` / `@Bot()`.
+   * We never silently pick the first — that would make the default depend on
+   * array order.
    */
   private static applyDefault(bots: ResolvedBot[]): ResolvedBot[] {
+    if (bots.length === 1) {
+      bots[0].isDefault = true;
+      return bots;
+    }
     const flagged = bots.filter((bot) => bot.isDefault);
     if (flagged.length > 1) {
       throw new NestgramConfigError(
         'More than one bot is marked `default: true` — at most one may be.',
       );
-    }
-    if (bots.length === 1) {
-      bots[0].isDefault = true;
     }
     return bots;
   }

--- a/lib/module/nestgram-module.types.ts
+++ b/lib/module/nestgram-module.types.ts
@@ -32,9 +32,58 @@ export interface WebhookOptions {
   allowedUpdates?: AllowedUpdate[];
 }
 
-export interface NestgramModuleOptions {
+/**
+ * One bot in a multi-bot app's `bots: []`. Carries that bot's token, transport,
+ * and per-bot pipeline flags — each bot gets its OWN interceptor pipeline built
+ * from these, so `parseMode`/`throttle`/… are configured independently. Inject a
+ * specific bot with `@InjectBot('name')`; the current update's bot with `@Bot()`.
+ */
+export interface BotDefinition {
+  /**
+   * The bot's name — the key for `@InjectBot('name')` and `@ForBot('name')`.
+   * Optional only when there is a single bot (it becomes the default); with more
+   * than one bot, each needs a distinct name.
+   */
+  name?: string;
+  /**
+   * Make this the default bot: the one a bare `BotService` injection (and
+   * `@InjectBot()` with no name) resolves to. At most one bot may set it. A
+   * single bot is the default implicitly.
+   */
+  default?: boolean;
   /** Bot API token. */
   token: string;
+  /** Long-polling transport for this bot (see {@link NestgramModuleOptions.polling}). */
+  polling?: boolean | PollingOptions;
+  /** Webhook transport for this bot — needs a distinct `url`/path per bot. */
+  webhook?: WebhookOptions;
+  /** Default `parse_mode` for this bot's sends. */
+  parseMode?: ParseModeValue;
+  /** Rich-message rewriting for this bot. */
+  richMessages?: RichMessagesOptions;
+  /** Swallow the `message is not modified` edit no-op for this bot. */
+  ignoreNotModified?: boolean;
+  /** Extra outbound API interceptors for this bot. */
+  apiInterceptors?: Type<ApiInterceptor>[];
+  /** Send rate-limiting for this bot. */
+  throttle?: boolean | ThrottleOptions;
+  /** Replace this bot's throttler entirely. */
+  throttler?: Type<ApiInterceptor>;
+}
+
+export interface NestgramModuleOptions {
+  /**
+   * Bot API token for the single (default) bot. Pass EITHER this (single-bot) OR
+   * {@link NestgramModuleOptions.bots} (multi-bot), never both.
+   */
+  token?: string;
+  /**
+   * Run several bots from one app. Each entry is an independent bot with its own
+   * token, transport, and pipeline flags. Resolved from the options object, so a
+   * `forRootAsync` factory can build the list dynamically (e.g. from a database)
+   * without knowing the count ahead of time. Mutually exclusive with `token`.
+   */
+  bots?: BotDefinition[];
   /**
    * Long-polling transport. `true` uses defaults; pass an object to tune
    * offset/limit/timeout/etc. Omit to start the bot without a transport (e.g.

--- a/lib/module/nestgram.bootstrap.spec.ts
+++ b/lib/module/nestgram.bootstrap.spec.ts
@@ -10,7 +10,7 @@ import {
   StageRegistry,
   UpdateDispatcher,
 } from '../engine/dispatcher';
-import { AllowedUpdatesResolver, UpdateSource } from '../engine/source';
+import { BotSourceFactory, UpdateSource } from '../engine/source';
 
 function makeBootstrap(options: Partial<NestgramModuleOptions>) {
   const getMe = jest.fn().mockResolvedValue({ username: 'mybot' });
@@ -26,9 +26,7 @@ function makeBootstrap(options: Partial<NestgramModuleOptions>) {
     { start, stop: jest.fn() } as unknown as UpdateSource,
     { getMe } as unknown as BotService,
     { get: jest.fn() } as unknown as ModuleRef,
-    {
-      resolve: jest.fn().mockReturnValue([]),
-    } as unknown as AllowedUpdatesResolver,
+    { create: jest.fn().mockReturnValue(null) } as unknown as BotSourceFactory,
   );
 
   return { bootstrap, getMe, start };

--- a/lib/module/nestgram.bootstrap.spec.ts
+++ b/lib/module/nestgram.bootstrap.spec.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 
 import { NestgramBootstrap } from './nestgram.bootstrap';
 import { NestgramModuleOptions } from './nestgram-module.types';
@@ -9,7 +10,7 @@ import {
   StageRegistry,
   UpdateDispatcher,
 } from '../engine/dispatcher';
-import { UpdateSource } from '../engine/source';
+import { AllowedUpdatesResolver, UpdateSource } from '../engine/source';
 
 function makeBootstrap(options: Partial<NestgramModuleOptions>) {
   const getMe = jest.fn().mockResolvedValue({ username: 'mybot' });
@@ -24,6 +25,10 @@ function makeBootstrap(options: Partial<NestgramModuleOptions>) {
     { dispatch: jest.fn() } as unknown as UpdateDispatcher,
     { start, stop: jest.fn() } as unknown as UpdateSource,
     { getMe } as unknown as BotService,
+    { get: jest.fn() } as unknown as ModuleRef,
+    {
+      resolve: jest.fn().mockReturnValue([]),
+    } as unknown as AllowedUpdatesResolver,
   );
 
   return { bootstrap, getMe, start };

--- a/lib/module/nestgram.bootstrap.ts
+++ b/lib/module/nestgram.bootstrap.ts
@@ -15,11 +15,7 @@ import {
   StageRegistry,
   UpdateDispatcher,
 } from '../engine/dispatcher';
-import {
-  AllowedUpdatesResolver,
-  PollingUpdateSource,
-  UpdateSource,
-} from '../engine/source';
+import { BotSourceFactory, UpdateSource } from '../engine/source';
 import { BotConfigResolver } from './bot-config';
 import { NestgramModuleOptions } from './nestgram-module.types';
 
@@ -41,8 +37,8 @@ export class NestgramBootstrap
   implements OnApplicationBootstrap, OnApplicationShutdown
 {
   private readonly logger = new Logger(NestgramBootstrap.name);
-  /** Per-bot pollers started for a multi-bot config (one per polling bot). */
-  private readonly fleet: PollingUpdateSource[] = [];
+  /** Per-bot sources started for a multi-bot config (one per bot with a transport). */
+  private readonly fleet: UpdateSource[] = [];
 
   constructor(
     @Inject(Providers.NESTGRAM_OPTIONS)
@@ -56,7 +52,7 @@ export class NestgramBootstrap
     private readonly source: UpdateSource,
     private readonly botService: BotService,
     private readonly moduleRef: ModuleRef,
-    private readonly allowedUpdatesResolver: AllowedUpdatesResolver,
+    private readonly sourceFactory: BotSourceFactory,
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
@@ -85,33 +81,33 @@ export class NestgramBootstrap
   }
 
   /**
-   * Multi-bot transport: build and start one poller per bot that has `polling`,
-   * each dispatching with its OWN BotService so a reply goes back through the bot
-   * that received the update. Webhook bots are skipped with a warning — per-bot
-   * webhook (distinct delivery paths) is not wired yet.
+   * Multi-bot transport: build and start one source per bot via
+   * {@link BotSourceFactory}, each dispatching with its OWN BotService so a reply
+   * goes back through the bot that received the update. The factory returns no
+   * source for a webhook bot (per-bot webhook delivery isn't auto-wired) — warn,
+   * since such a bot needs a custom update source to receive.
    */
   private async startFleet(): Promise<void> {
     const bots = BotConfigResolver.resolve(this.options);
     for (const bot of bots) {
-      if (!bot.polling) {
+      const botService = this.moduleRef.get<BotService>(getBotToken(bot.name), {
+        strict: false,
+      });
+      const source = this.sourceFactory.create(botService, {
+        polling: bot.polling,
+        webhook: bot.webhook,
+      });
+      if (!source) {
         if (bot.webhook) {
           this.logger.warn(
-            `Bot "${bot.name}" is configured for webhook, which isn't supported ` +
-              `per-bot yet — it will not receive updates.`,
+            `Bot "${bot.name}" uses webhook, which isn't auto-wired per-bot yet — ` +
+              `give it a custom update source to receive updates.`,
           );
         }
         continue;
       }
-      const botService = this.moduleRef.get<BotService>(getBotToken(bot.name), {
-        strict: false,
-      });
       const me = await botService.getMe();
       this.logger.log(`Bot "${bot.name}" connected as @${me.username}`);
-      const source = new PollingUpdateSource(
-        botService,
-        typeof bot.polling === 'object' ? bot.polling : undefined,
-        this.allowedUpdatesResolver,
-      );
       await source.start((update) =>
         this.dispatcher.dispatch(update, botService),
       );

--- a/lib/module/nestgram.bootstrap.ts
+++ b/lib/module/nestgram.bootstrap.ts
@@ -5,16 +5,22 @@ import {
   OnApplicationBootstrap,
   OnApplicationShutdown,
 } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 
 import { BotService } from '../api';
 import { RouteExplorer, RouteTable } from '../engine/discovery';
-import { Providers } from '../providers';
+import { getBotToken, Providers } from '../providers';
 import {
   StageExplorer,
   StageRegistry,
   UpdateDispatcher,
 } from '../engine/dispatcher';
-import { UpdateSource } from '../engine/source';
+import {
+  AllowedUpdatesResolver,
+  PollingUpdateSource,
+  UpdateSource,
+} from '../engine/source';
+import { BotConfigResolver } from './bot-config';
 import { NestgramModuleOptions } from './nestgram-module.types';
 
 /**
@@ -35,6 +41,8 @@ export class NestgramBootstrap
   implements OnApplicationBootstrap, OnApplicationShutdown
 {
   private readonly logger = new Logger(NestgramBootstrap.name);
+  /** Per-bot pollers started for a multi-bot config (one per polling bot). */
+  private readonly fleet: PollingUpdateSource[] = [];
 
   constructor(
     @Inject(Providers.NESTGRAM_OPTIONS)
@@ -47,6 +55,8 @@ export class NestgramBootstrap
     @Inject(Providers.UPDATE_SOURCE)
     private readonly source: UpdateSource,
     private readonly botService: BotService,
+    private readonly moduleRef: ModuleRef,
+    private readonly allowedUpdatesResolver: AllowedUpdatesResolver,
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
@@ -64,10 +74,48 @@ export class NestgramBootstrap
     this.stageRegistry.set(stages);
     this.logger.log(`Pipeline stages: ${stages.length}`);
 
-    await this.warmBotIdentity();
-
     if (this.hasTransport()) {
+      // Single-bot via the top-level transport: the existing default-bot source.
+      await this.warmBotIdentity();
       await this.source.start((update) => this.dispatcher.dispatch(update));
+    } else {
+      // Per-bot transport (a `bots: []` config): one poller per polling bot.
+      await this.startFleet();
+    }
+  }
+
+  /**
+   * Multi-bot transport: build and start one poller per bot that has `polling`,
+   * each dispatching with its OWN BotService so a reply goes back through the bot
+   * that received the update. Webhook bots are skipped with a warning — per-bot
+   * webhook (distinct delivery paths) is not wired yet.
+   */
+  private async startFleet(): Promise<void> {
+    const bots = BotConfigResolver.resolve(this.options);
+    for (const bot of bots) {
+      if (!bot.polling) {
+        if (bot.webhook) {
+          this.logger.warn(
+            `Bot "${bot.name}" is configured for webhook, which isn't supported ` +
+              `per-bot yet — it will not receive updates.`,
+          );
+        }
+        continue;
+      }
+      const botService = this.moduleRef.get<BotService>(getBotToken(bot.name), {
+        strict: false,
+      });
+      const me = await botService.getMe();
+      this.logger.log(`Bot "${bot.name}" connected as @${me.username}`);
+      const source = new PollingUpdateSource(
+        botService,
+        typeof bot.polling === 'object' ? bot.polling : undefined,
+        this.allowedUpdatesResolver,
+      );
+      await source.start((update) =>
+        this.dispatcher.dispatch(update, botService),
+      );
+      this.fleet.push(source);
     }
   }
 
@@ -91,5 +139,6 @@ export class NestgramBootstrap
 
   async onApplicationShutdown(): Promise<void> {
     await this.source.stop();
+    await Promise.all(this.fleet.map((source) => source.stop()));
   }
 }

--- a/lib/module/nestgram.bootstrap.ts
+++ b/lib/module/nestgram.bootstrap.ts
@@ -83,9 +83,10 @@ export class NestgramBootstrap
   /**
    * Multi-bot transport: build and start one source per bot via
    * {@link BotSourceFactory}, each dispatching with its OWN BotService so a reply
-   * goes back through the bot that received the update. The factory returns no
-   * source for a webhook bot (per-bot webhook delivery isn't auto-wired) — warn,
-   * since such a bot needs a custom update source to receive.
+   * goes back through the bot that received the update. A polling bot gets a
+   * poller; a webhook bot gets its per-bot {@link WebhookUpdateSource} (started
+   * here to register the webhook — updates then arrive over HTTP via a webhook
+   * controller). A bot with no transport yields no source and is skipped.
    */
   private async startFleet(): Promise<void> {
     const bots = BotConfigResolver.resolve(this.options);
@@ -93,17 +94,12 @@ export class NestgramBootstrap
       const botService = this.moduleRef.get<BotService>(getBotToken(bot.name), {
         strict: false,
       });
-      const source = this.sourceFactory.create(botService, {
-        polling: bot.polling,
-        webhook: bot.webhook,
-      });
+      const source = this.sourceFactory.create(
+        botService,
+        { polling: bot.polling, webhook: bot.webhook },
+        bot.name,
+      );
       if (!source) {
-        if (bot.webhook) {
-          this.logger.warn(
-            `Bot "${bot.name}" uses webhook, which isn't auto-wired per-bot yet — ` +
-              `give it a custom update source to receive updates.`,
-          );
-        }
         continue;
       }
       const me = await botService.getMe();

--- a/lib/module/nestgram.module.spec.ts
+++ b/lib/module/nestgram.module.spec.ts
@@ -3,6 +3,7 @@ import { NestFactory } from '@nestjs/core';
 
 import { BotService } from '../api';
 import { InjectBot } from '../decorators/inject-bot.decorator';
+import { Bot } from '../decorators/params/bot.decorator';
 import { Command } from '../decorators/listeners/command.decorator';
 import { OnMessage } from '../decorators/listeners/on-message.decorator';
 import { OnCallbackQuery } from '../decorators/listeners/on-callback-query.decorator';
@@ -616,6 +617,39 @@ async function waitForCalls(
     await new Promise((r) => setTimeout(r, 5));
   }
 }
+
+// @Bot() injects the bot that received the current update.
+@Router()
+class BotAwareRouter {
+  seenName?: string;
+
+  @OnMessage()
+  handle(_message: RawUpdate['message'], @Bot() bot: BotService): void {
+    this.seenName = bot.name;
+  }
+}
+
+@Module({
+  imports: [NestgramModule.forRoot({ token: 'TEST' })],
+  providers: [BotAwareRouter],
+})
+class BotAwareAppModule {}
+
+describe('@Bot param', () => {
+  it('injects the current update’s bot (the default, here)', async () => {
+    const app = await NestFactory.createApplicationContext(BotAwareAppModule, {
+      logger: false,
+    });
+    const dispatcher = app.get(UpdateDispatcher);
+    const router = app.get(BotAwareRouter);
+
+    await dispatcher.dispatch(messageUpdate(1, 'hi'));
+
+    expect(router.seenName).toBe('default');
+
+    await app.close();
+  });
+});
 
 describe('multi-bot polling fleet', () => {
   afterEach(() => {

--- a/lib/module/nestgram.module.spec.ts
+++ b/lib/module/nestgram.module.spec.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Module } from '@nestjs/common';
+import { Inject, Injectable, Logger, Module } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 
 import { BotService } from '../api';
@@ -22,7 +22,7 @@ import {
 } from '../api/request';
 import type { Observable } from 'rxjs';
 import { Providers } from '../providers';
-import { WebhookUpdateSource } from '../engine/source';
+import { WebhookSourceEntry, WebhookUpdateSource } from '../engine/source';
 import { NestgramModule } from './nestgram.module';
 
 const originalFetch = global.fetch;
@@ -646,6 +646,77 @@ describe('@Bot param', () => {
     await dispatcher.dispatch(messageUpdate(1, 'hi'));
 
     expect(router.seenName).toBe('default');
+
+    await app.close();
+  });
+});
+
+// Multi-bot webhook: each webhook bot gets a per-bot WebhookUpdateSource under
+// getWebhookSourceToken(name), aggregated into WEBHOOK_SOURCES for the ready-made
+// controllers. Booting starts the fleet, registering each bot's webhook.
+@Injectable()
+class WebhookSourcesConsumer {
+  constructor(
+    @Inject(Providers.WEBHOOK_SOURCES) readonly entries: WebhookSourceEntry[],
+  ) {}
+}
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      bots: [
+        {
+          name: 'support',
+          token: '111:SUPPORT',
+          default: true,
+          webhook: {
+            url: 'https://x/telegram/webhook/support',
+            secretToken: 's',
+          },
+        },
+        {
+          name: 'sales',
+          token: '222:SALES',
+          webhook: {
+            url: 'https://x/telegram/webhook/sales',
+            secretToken: 'x',
+          },
+        },
+      ],
+    }),
+  ],
+  providers: [WebhookSourcesConsumer],
+})
+class MultiBotWebhookAppModule {}
+
+describe('multi-bot webhook (forRoot bots: [])', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('provides WEBHOOK_SOURCES — one per webhook bot, each its own source, default flagged', async () => {
+    // getMe + setWebhook (start) + deleteWebhook (close) hit fetch at boot; stub it.
+    global.fetch = (async () => ({
+      json: async () => ({ ok: true, result: { username: 'bot' } }),
+    })) as unknown as typeof fetch;
+
+    const app = await NestFactory.createApplicationContext(
+      MultiBotWebhookAppModule,
+      { logger: false },
+    );
+    const { entries } = app.get(WebhookSourcesConsumer);
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => e.source.name).sort()).toEqual([
+      'sales',
+      'support',
+    ]);
+    const support = entries.find((e) => e.source.name === 'support');
+    expect(support?.isDefault).toBe(true);
+    expect(support?.source).toBeInstanceOf(WebhookUpdateSource);
+    // Routing primitives the controllers rely on are wired per bot.
+    expect(support?.source.ownsSecret('s')).toBe(true);
+    expect(support?.source.ownsSecret('x')).toBe(false);
 
     await app.close();
   });

--- a/lib/module/nestgram.module.spec.ts
+++ b/lib/module/nestgram.module.spec.ts
@@ -586,3 +586,73 @@ describe('multi-bot with no default (co-equal)', () => {
     ).rejects.toThrow();
   });
 });
+
+// Phase 2: a multi-bot polling config starts one poller per bot, each
+// dispatching with its own BotService.
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      bots: [
+        { name: 'a', token: '111:AAA', polling: { idleMs: 5 }, default: true },
+        { name: 'b', token: '222:BBB', polling: { idleMs: 5 } },
+      ],
+    }),
+  ],
+  providers: [GreetRouter],
+})
+class PollingFleetAppModule {}
+
+function jsonResponse(body: unknown): Response {
+  return { json: async () => body } as Response;
+}
+
+async function waitForCalls(
+  pred: () => boolean,
+  timeoutMs = 1500,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!pred()) {
+    if (Date.now() > deadline) throw new Error('waitForCalls timed out');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe('multi-bot polling fleet', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('runs a poller per bot and dispatches with the originating bot', async () => {
+    // getUpdates: one update for bot A (matched by its token in the URL), then
+    // empty; everything else (getMe, deleteWebhook, bot B) returns empty/ok.
+    let servedA = false;
+    global.fetch = (async (url: string) => {
+      const target = String(url);
+      if (target.includes('/getUpdates')) {
+        if (target.includes('111:AAA') && !servedA) {
+          servedA = true;
+          return jsonResponse({ ok: true, result: [messageUpdate(1, 'hi')] });
+        }
+        return jsonResponse({ ok: true, result: [] });
+      }
+      return jsonResponse({ ok: true, result: { username: 'bot' } });
+    }) as unknown as typeof fetch;
+
+    // Spy before boot: the poller's onUpdate closure calls this.dispatcher.dispatch.
+    const dispatch = jest.spyOn(UpdateDispatcher.prototype, 'dispatch');
+
+    const app = await NestFactory.createApplicationContext(
+      PollingFleetAppModule,
+      { logger: false },
+    );
+    try {
+      await waitForCalls(() => dispatch.mock.calls.length >= 1);
+      const [, bot] = dispatch.mock.calls[0];
+      // The dispatched update was threaded with bot A's BotService.
+      expect((bot as BotService | undefined)?.token).toBe('111:AAA');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/lib/module/nestgram.module.spec.ts
+++ b/lib/module/nestgram.module.spec.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Module } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 
 import { BotService } from '../api';
+import { InjectBot } from '../decorators/inject-bot.decorator';
 import { Command } from '../decorators/listeners/command.decorator';
 import { OnMessage } from '../decorators/listeners/on-message.decorator';
 import { OnCallbackQuery } from '../decorators/listeners/on-callback-query.decorator';
@@ -476,5 +477,112 @@ describe('webhook transport (real-module DI)', () => {
     expect(app.get(WebhookConsumer).source).toBeInstanceOf(WebhookUpdateSource);
 
     await app.close();
+  });
+});
+
+// Multi-bot: forRoot({ bots: [...] }) provides one isolated BotService per bot.
+@Injectable()
+class CrossBotConsumer {
+  constructor(
+    // No decorator → the default bot (support, flagged default below).
+    readonly current: BotService,
+    @InjectBot('support') readonly support: BotService,
+    @InjectBot('sales') readonly sales: BotService,
+  ) {}
+}
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      bots: [
+        { name: 'support', token: '111:SUPPORT', default: true },
+        { name: 'sales', token: '222:SALES', parseMode: 'MarkdownV2' },
+      ],
+    }),
+  ],
+  providers: [CrossBotConsumer],
+})
+class MultiBotAppModule {}
+
+describe('multi-bot (forRoot bots: [])', () => {
+  it('provides one BotService per bot, injectable by name, default as the bare token', async () => {
+    const app = await NestFactory.createApplicationContext(MultiBotAppModule, {
+      logger: false,
+    });
+    const consumer = app.get(CrossBotConsumer);
+
+    // Each bot is its own instance carrying its own token.
+    expect(consumer.support.token).toBe('111:SUPPORT');
+    expect(consumer.sales.token).toBe('222:SALES');
+    expect(consumer.sales).not.toBe(consumer.support);
+    // A bare BotService injection resolves the default bot (support).
+    expect(consumer.current).toBe(consumer.support);
+
+    await app.close();
+  });
+});
+
+// Co-equal bots: no default flagged. Each is reached only by name; a bare
+// BotService is ambiguous and not provided.
+@Injectable()
+class NamedOnlyConsumer {
+  constructor(
+    @InjectBot('a') readonly a: BotService,
+    @InjectBot('b') readonly b: BotService,
+  ) {}
+}
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      bots: [
+        { name: 'a', token: '111:A' },
+        { name: 'b', token: '222:B' },
+      ],
+    }),
+  ],
+  providers: [NamedOnlyConsumer],
+})
+class CoEqualAppModule {}
+
+@Injectable()
+class BareConsumer {
+  constructor(readonly bot: BotService) {}
+}
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      bots: [
+        { name: 'a', token: '111:A' },
+        { name: 'b', token: '222:B' },
+      ],
+    }),
+  ],
+  providers: [BareConsumer],
+})
+class CoEqualBareAppModule {}
+
+describe('multi-bot with no default (co-equal)', () => {
+  it('boots and resolves each bot by name', async () => {
+    const app = await NestFactory.createApplicationContext(CoEqualAppModule, {
+      logger: false,
+    });
+    const consumer = app.get(NamedOnlyConsumer);
+
+    expect(consumer.a.token).toBe('111:A');
+    expect(consumer.b.token).toBe('222:B');
+    expect(consumer.a).not.toBe(consumer.b);
+
+    await app.close();
+  });
+
+  it('makes a bare BotService injection fail (ambiguous — must name the bot)', async () => {
+    await expect(
+      NestFactory.createApplicationContext(CoEqualBareAppModule, {
+        logger: false,
+        abortOnError: false,
+      }),
+    ).rejects.toThrow();
   });
 });

--- a/lib/module/nestgram.module.ts
+++ b/lib/module/nestgram.module.ts
@@ -2,6 +2,8 @@ import { DynamicModule, Global, Module, Provider } from '@nestjs/common';
 import { APP_INTERCEPTOR, DiscoveryModule } from '@nestjs/core';
 
 import { BotModule } from '../api';
+import { BotOptions } from '../api/bot-options';
+import { BotConfigResolver } from './bot-config';
 import { ContextFactory, EventFactory } from '../engine/context';
 import { RouteExplorer, RouteMatcher, RouteTable } from '../engine/discovery';
 import { NestgramConfigError } from '../exceptions';
@@ -97,19 +99,28 @@ export class NestgramModule {
     Providers.NESTGRAM_OPTIONS,
   ];
 
+  /**
+   * Normalize the config and take the single bot's options. Multi-bot wiring
+   * (one BotService + source per bot) is in progress on the `feature/multi-bot`
+   * branch — until it lands, a `bots: []` with more than one entry is rejected
+   * here, while the single-bot path runs entirely through the same resolver.
+   */
+  private static resolveSingleBot(options: NestgramModuleOptions): BotOptions {
+    const [bot, ...more] = BotConfigResolver.resolve(options);
+    if (more.length > 0) {
+      throw new NestgramConfigError(
+        'Multiple bots are configured, but multi-bot wiring is still in ' +
+          'progress on this build — use a single `token` for now.',
+      );
+    }
+    return bot.options;
+  }
+
   static forRoot(options: NestgramModuleOptions): DynamicModule {
     return {
       module: NestgramModule,
       imports: [
-        BotModule.forRoot({
-          token: options.token,
-          parseMode: options.parseMode,
-          richMessages: options.richMessages,
-          ignoreNotModified: options.ignoreNotModified,
-          apiInterceptors: options.apiInterceptors,
-          throttle: options.throttle,
-          throttler: options.throttler,
-        }),
+        BotModule.forRoot(NestgramModule.resolveSingleBot(options)),
         DiscoveryModule,
       ],
       // No controllers: the webhook receiver isn't auto-registered. The author
@@ -130,13 +141,8 @@ export class NestgramModule {
         ...(options.imports ?? []),
         BotModule.forRootAsync({
           inject: [Providers.NESTGRAM_OPTIONS],
-          useFactory: (resolved: NestgramModuleOptions) => ({
-            token: resolved.token,
-            parseMode: resolved.parseMode,
-            richMessages: resolved.richMessages,
-            ignoreNotModified: resolved.ignoreNotModified,
-            throttle: resolved.throttle,
-          }),
+          useFactory: (resolved: NestgramModuleOptions) =>
+            NestgramModule.resolveSingleBot(resolved),
           // Static (a class can't resolve through the value factory) — like apiInterceptors.
           apiInterceptors: options.apiInterceptors,
           throttler: options.throttler,

--- a/lib/module/nestgram.module.ts
+++ b/lib/module/nestgram.module.ts
@@ -16,6 +16,7 @@ import {
 } from '../engine/dispatcher';
 import {
   AllowedUpdatesResolver,
+  BotSourceFactory,
   PollingUpdateSource,
   UpdateSource,
   WebhookUpdateSource,
@@ -61,6 +62,9 @@ export class NestgramModule {
     StageRegistry,
     UpdateDispatcher,
     AllowedUpdatesResolver,
+    // Builds the per-bot update source for the multi-bot fleet (NestgramBootstrap
+    // uses it instead of constructing sources itself).
+    BotSourceFactory,
     // Built per-bot now (one poller per bot). The single-bot path constructs it
     // from the top-level polling config; multi-bot builds its own per bot.
     {

--- a/lib/module/nestgram.module.ts
+++ b/lib/module/nestgram.module.ts
@@ -3,11 +3,16 @@ import { APP_INTERCEPTOR, DiscoveryModule } from '@nestjs/core';
 
 import { BotModule, BotService } from '../api';
 import { BotOptions } from '../api/bot-options';
-import { BotConfigResolver } from './bot-config';
+import { BotConfigResolver, ResolvedBot } from './bot-config';
 import { ContextFactory, EventFactory } from '../engine/context';
 import { RouteExplorer, RouteMatcher, RouteTable } from '../engine/discovery';
 import { NestgramConfigError } from '../exceptions';
-import { DEFAULT_BOT_NAME, getBotToken, Providers } from '../providers';
+import {
+  DEFAULT_BOT_NAME,
+  getBotToken,
+  getWebhookSourceToken,
+  Providers,
+} from '../providers';
 import { HandlerExecutorFactory, ResultHandler } from '../engine/execution';
 import {
   StageExplorer,
@@ -19,6 +24,7 @@ import {
   BotSourceFactory,
   PollingUpdateSource,
   UpdateSource,
+  WebhookSourceEntry,
   WebhookUpdateSource,
 } from '../engine/source';
 import { AutoAnswerCallbackInterceptor } from '../builtins/auto-answer';
@@ -81,7 +87,18 @@ export class NestgramModule {
         ),
       inject: [Providers.NESTGRAM_OPTIONS, BotService, AllowedUpdatesResolver],
     },
-    WebhookUpdateSource,
+    // The single-bot webhook source, built from the top-level webhook config.
+    // Multi-bot builds its own per bot (see webhookSourceProviders).
+    {
+      provide: WebhookUpdateSource,
+      useFactory: (
+        options: NestgramModuleOptions,
+        bot: BotService,
+        resolver: AllowedUpdatesResolver,
+      ): WebhookUpdateSource =>
+        new WebhookUpdateSource(bot, options.webhook, resolver),
+      inject: [Providers.NESTGRAM_OPTIONS, BotService, AllowedUpdatesResolver],
+    },
     // The active transport, chosen by config: webhook if configured, else
     // polling. Bootstrap injects UPDATE_SOURCE and only starts it when a
     // transport is set.
@@ -144,6 +161,20 @@ export class NestgramModule {
     // placeholder that is NOT exported, so a user's bare `BotService` injection
     // still fails and forces `@InjectBot(name)`.
     const engineBot = defaultBot ?? bots[0];
+    // Multi-bot only: per-bot webhook sources + the WEBHOOK_SOURCES aggregate the
+    // ready-made multi-bot webhook controllers inject. The single-bot path uses
+    // the class-token WebhookUpdateSource above.
+    const isMultiBot = Array.isArray(options.bots);
+    // The class-token WebhookUpdateSource is the SINGLE-bot source (built from the
+    // top-level webhook config). In a multi-bot app it has no config and is a
+    // no-op that accepts every secret — don't export it (multi-bot webhook goes
+    // through WEBHOOK_SOURCES); it stays provided only for the UPDATE_SOURCE picker.
+    const engineExports = isMultiBot
+      ? this.engineExports.filter((token) => token !== WebhookUpdateSource)
+      : this.engineExports;
+    const baseExports = defaultBot
+      ? [...engineExports, BotService]
+      : [...engineExports];
     return {
       module: NestgramModule,
       imports: [
@@ -162,11 +193,43 @@ export class NestgramModule {
         // bot — exported only when one exists.
         { provide: BotService, useExisting: getBotToken(engineBot.name) },
         ...this.engineProviders,
+        ...(isMultiBot ? this.webhookSourceProviders(bots) : []),
       ],
-      exports: defaultBot
-        ? [...this.engineExports, BotService]
-        : [...this.engineExports],
+      exports: isMultiBot
+        ? [...baseExports, Providers.WEBHOOK_SOURCES]
+        : baseExports,
     };
+  }
+
+  /**
+   * Per-bot webhook plumbing for a multi-bot app: one {@link WebhookUpdateSource}
+   * under `getWebhookSourceToken(name)` for each webhook bot (it registers the
+   * webhook on start and verifies + delivers received updates), plus the
+   * `WEBHOOK_SOURCES` aggregate the ready-made multi-bot webhook controllers
+   * inject to route an inbound POST to the right bot. Empty (just the aggregate,
+   * resolving to `[]`) when no bot uses webhook, so the export is always valid.
+   */
+  private static webhookSourceProviders(bots: ResolvedBot[]): Provider[] {
+    const webhookBots = bots.filter((bot) => bot.webhook);
+    const sources: Provider[] = webhookBots.map((bot) => ({
+      provide: getWebhookSourceToken(bot.name),
+      useFactory: (
+        botService: BotService,
+        resolver: AllowedUpdatesResolver,
+      ): WebhookUpdateSource =>
+        new WebhookUpdateSource(botService, bot.webhook, resolver, bot.name),
+      inject: [getBotToken(bot.name), AllowedUpdatesResolver],
+    }));
+    const aggregate: Provider = {
+      provide: Providers.WEBHOOK_SOURCES,
+      useFactory: (...resolved: WebhookUpdateSource[]): WebhookSourceEntry[] =>
+        webhookBots.map((bot, index) => ({
+          source: resolved[index],
+          isDefault: bot.isDefault,
+        })),
+      inject: webhookBots.map((bot) => getWebhookSourceToken(bot.name)),
+    };
+    return [...sources, aggregate];
   }
 
   static forRootAsync(options: NestgramModuleAsyncOptions): DynamicModule {

--- a/lib/module/nestgram.module.ts
+++ b/lib/module/nestgram.module.ts
@@ -1,13 +1,13 @@
 import { DynamicModule, Global, Module, Provider } from '@nestjs/common';
 import { APP_INTERCEPTOR, DiscoveryModule } from '@nestjs/core';
 
-import { BotModule } from '../api';
+import { BotModule, BotService } from '../api';
 import { BotOptions } from '../api/bot-options';
 import { BotConfigResolver } from './bot-config';
 import { ContextFactory, EventFactory } from '../engine/context';
 import { RouteExplorer, RouteMatcher, RouteTable } from '../engine/discovery';
 import { NestgramConfigError } from '../exceptions';
-import { Providers } from '../providers';
+import { DEFAULT_BOT_NAME, getBotToken, Providers } from '../providers';
 import { HandlerExecutorFactory, ResultHandler } from '../engine/execution';
 import {
   StageExplorer,
@@ -100,27 +100,38 @@ export class NestgramModule {
   ];
 
   /**
-   * Normalize the config and take the single bot's options. Multi-bot wiring
-   * (one BotService + source per bot) is in progress on the `feature/multi-bot`
-   * branch — until it lands, a `bots: []` with more than one entry is rejected
-   * here, while the single-bot path runs entirely through the same resolver.
+   * Resolve the SINGLE bot for the async path. `forRootAsync` builds its bot from
+   * a runtime factory, so the count can't be known at module-definition time —
+   * multiple bots there would need dynamic provider tokens, which Nest can't do.
+   * Dynamic multi-bot is out of scope; declare several bots statically with
+   * `forRoot({ bots: [...] })` instead.
    */
   private static resolveSingleBot(options: NestgramModuleOptions): BotOptions {
     const [bot, ...more] = BotConfigResolver.resolve(options);
     if (more.length > 0) {
       throw new NestgramConfigError(
-        'Multiple bots are configured, but multi-bot wiring is still in ' +
-          'progress on this build — use a single `token` for now.',
+        'forRootAsync resolves a single bot — for several bots use ' +
+          'forRoot({ bots: [...] }) with a static array.',
       );
     }
     return bot.options;
   }
 
   static forRoot(options: NestgramModuleOptions): DynamicModule {
+    const bots = BotConfigResolver.resolve(options);
+    const defaultBot = bots.find((bot) => bot.isDefault);
+    // The engine constructs against a bare BotService. Alias it to the default;
+    // with no default (co-equal bots) alias to the first bot as an INTERNAL
+    // placeholder that is NOT exported, so a user's bare `BotService` injection
+    // still fails and forces `@InjectBot(name)`.
+    const engineBot = defaultBot ?? bots[0];
     return {
       module: NestgramModule,
       imports: [
-        BotModule.forRoot(NestgramModule.resolveSingleBot(options)),
+        // One isolated module per bot; each exports its BotService under
+        // getBotToken(name). The engine drives the default bot (Phase 2 adds a
+        // per-bot source); the rest are reachable via @InjectBot for sends.
+        ...bots.map((bot) => BotModule.forBot(bot.name, bot.options)),
         DiscoveryModule,
       ],
       // No controllers: the webhook receiver isn't auto-registered. The author
@@ -128,9 +139,14 @@ export class NestgramModule {
       // the WebhookOptions docs.
       providers: [
         { provide: Providers.NESTGRAM_OPTIONS, useValue: options },
+        // A bare BotService (and @InjectBot() with no name) resolves the default
+        // bot — exported only when one exists.
+        { provide: BotService, useExisting: getBotToken(engineBot.name) },
         ...this.engineProviders,
       ],
-      exports: this.engineExports,
+      exports: defaultBot
+        ? [...this.engineExports, BotService]
+        : [...this.engineExports],
     };
   }
 
@@ -139,7 +155,7 @@ export class NestgramModule {
       module: NestgramModule,
       imports: [
         ...(options.imports ?? []),
-        BotModule.forRootAsync({
+        BotModule.forBotAsync(DEFAULT_BOT_NAME, {
           inject: [Providers.NESTGRAM_OPTIONS],
           useFactory: (resolved: NestgramModuleOptions) =>
             NestgramModule.resolveSingleBot(resolved),
@@ -154,9 +170,10 @@ export class NestgramModule {
       // had to be known here to wire a route).
       providers: [
         ...this.createAsyncOptionsProviders(options),
+        { provide: BotService, useExisting: getBotToken(DEFAULT_BOT_NAME) },
         ...this.engineProviders,
       ],
-      exports: this.engineExports,
+      exports: [...this.engineExports, BotService],
     };
   }
 

--- a/lib/module/nestgram.module.ts
+++ b/lib/module/nestgram.module.ts
@@ -61,7 +61,22 @@ export class NestgramModule {
     StageRegistry,
     UpdateDispatcher,
     AllowedUpdatesResolver,
-    PollingUpdateSource,
+    // Built per-bot now (one poller per bot). The single-bot path constructs it
+    // from the top-level polling config; multi-bot builds its own per bot.
+    {
+      provide: PollingUpdateSource,
+      useFactory: (
+        options: NestgramModuleOptions,
+        bot: BotService,
+        resolver: AllowedUpdatesResolver,
+      ): PollingUpdateSource =>
+        new PollingUpdateSource(
+          bot,
+          typeof options.polling === 'object' ? options.polling : undefined,
+          resolver,
+        ),
+      inject: [Providers.NESTGRAM_OPTIONS, BotService, AllowedUpdatesResolver],
+    },
     WebhookUpdateSource,
     // The active transport, chosen by config: webhook if configured, else
     // polling. Bootstrap injects UPDATE_SOURCE and only starts it when a

--- a/lib/providers.ts
+++ b/lib/providers.ts
@@ -11,3 +11,16 @@ export enum Providers {
   /** FSM config, provided by `FsmModule.forRoot`/`forRootAsync`. */
   FSM_OPTIONS = 'FSM_OPTIONS',
 }
+
+/** The name an unnamed single bot takes — what a bare `BotService` resolves to. */
+export const DEFAULT_BOT_NAME = 'default';
+
+/**
+ * The DI token a bot's `BotService` is provided under, keyed by name. `@InjectBot`
+ * is sugar over `@Inject(getBotToken(name))`; a free function because it is the
+ * established Nest token-helper idiom (`getRepositoryToken` and friends). Lives in
+ * the tokens module so both the `api` and `module` layers reach it cycle-free.
+ */
+export function getBotToken(name: string = DEFAULT_BOT_NAME): string {
+  return `nestgram:bot:${name}`;
+}

--- a/lib/providers.ts
+++ b/lib/providers.ts
@@ -10,6 +10,12 @@ export enum Providers {
   SESSION_OPTIONS = 'SESSION_OPTIONS',
   /** FSM config, provided by `FsmModule.forRoot`/`forRootAsync`. */
   FSM_OPTIONS = 'FSM_OPTIONS',
+  /**
+   * The per-bot webhook sources of a multi-bot app (one per webhook bot), paired
+   * with whether each is the default. The ready-made multi-bot webhook
+   * controllers inject this to route an inbound POST to the right bot.
+   */
+  WEBHOOK_SOURCES = 'WEBHOOK_SOURCES',
 }
 
 /** The name an unnamed single bot takes — what a bare `BotService` resolves to. */
@@ -23,4 +29,14 @@ export const DEFAULT_BOT_NAME = 'default';
  */
 export function getBotToken(name: string = DEFAULT_BOT_NAME): string {
   return `nestgram:bot:${name}`;
+}
+
+/**
+ * The DI token a bot's per-bot `WebhookUpdateSource` is provided under in a
+ * multi-bot app — one instance shared between the fleet (which starts it, calling
+ * `setWebhook`) and the webhook controller (which delivers received updates to
+ * it). Keyed by name, mirroring {@link getBotToken}.
+ */
+export function getWebhookSourceToken(name: string = DEFAULT_BOT_NAME): string {
+  return `nestgram:webhook-source:${name}`;
 }

--- a/lib/sessions/session.integration.spec.ts
+++ b/lib/sessions/session.integration.spec.ts
@@ -63,10 +63,11 @@ describe('Sessions (integration)', () => {
     await dispatcher.dispatch(incFrom(3, 9)); // different user — own session
 
     // @Session injected the loaded session each time; per-user-per-chat keeps
-    // user 7 and user 9 apart even in the same chat.
+    // user 7 and user 9 apart even in the same chat. The key is scoped by the
+    // bot too (here the default bot → `ndefault` prefix).
     expect(router.seen).toEqual([1, 2, 1]);
-    expect(store.get('c1:u7')).toEqual({ count: 2 });
-    expect(store.get('c1:u9')).toEqual({ count: 1 });
+    expect(store.get('ndefault:c1:u7')).toEqual({ count: 2 });
+    expect(store.get('ndefault:c1:u9')).toEqual({ count: 1 });
 
     await app.close();
   });

--- a/lib/store/conversation-key.spec.ts
+++ b/lib/store/conversation-key.spec.ts
@@ -5,8 +5,10 @@ function ctx(
   chat: { id: number } | undefined,
   from: { id: number } | undefined,
   update: Record<string, unknown>,
+  botName?: string,
 ): TelegramExecutionContext {
-  return { chat, from, update } as unknown as TelegramExecutionContext;
+  const bot = botName ? { name: botName } : undefined;
+  return { chat, from, update, bot } as unknown as TelegramExecutionContext;
 }
 
 describe('defaultConversationKey', () => {
@@ -49,5 +51,19 @@ describe('defaultConversationKey', () => {
     expect(
       defaultConversationKey(ctx(undefined, { id: 7 }, {})),
     ).toBeUndefined();
+  });
+
+  it('scopes by the bot (outermost) so two bots never share state', () => {
+    const update = { message: { chat: { id: 5 }, from: { id: 5 } } };
+    const onSupport = defaultConversationKey(
+      ctx({ id: 5 }, { id: 5 }, update, 'support'),
+    );
+    const onSales = defaultConversationKey(
+      ctx({ id: 5 }, { id: 5 }, update, 'sales'),
+    );
+
+    expect(onSupport).toBe('nsupport:c5:u5');
+    expect(onSales).toBe('nsales:c5:u5');
+    expect(onSupport).not.toBe(onSales);
   });
 });

--- a/lib/store/conversation-key.ts
+++ b/lib/store/conversation-key.ts
@@ -11,6 +11,10 @@ import { RawMessage } from '../events/raw-update.types';
  * so an absent middle part can never collide with another. In a 1:1 chat
  * `chat.id === from.id`, so this collapses to a per-user key automatically.
  *
+ * In a multi-bot app it also scopes by the BOT that received the update
+ * (outermost), so the same user+chat on two different bots never shares session
+ * or FSM state.
+ *
  * Returns `undefined` when there is no chat to scope to (nothing to scope to
  * that update). Override via the `key` option for a group-shared,
  * global-per-user, or any custom scope.
@@ -36,6 +40,12 @@ export function defaultConversationKey(
   }
   if (source?.business_connection_id !== undefined) {
     parts.push(`b${source.business_connection_id}`);
+  }
+
+  // The bot is the OUTERMOST scope: a conversation belongs to the bot that
+  // received it, so two bots can't bleed state across one user+chat.
+  if (ctx.bot?.name) {
+    parts.unshift(`n${ctx.bot.name}`);
   }
 
   return parts.join(':');

--- a/tools/codegen/emit-types.ts
+++ b/tools/codegen/emit-types.ts
@@ -8,7 +8,12 @@
  * Output is unformatted; the orchestrator runs it through the project Prettier.
  */
 import { collectNamedTypes, collectReferences, Ir, IrObject } from './ir';
-import { isInputMediaName, resolveReference, SKIP_OBJECTS } from './manifest';
+import {
+  isInputMediaName,
+  namedTypeModule,
+  resolveReference,
+  SKIP_OBJECTS,
+} from './manifest';
 import { irTypeToTs } from './type-resolver';
 
 const HEADER = `/**
@@ -85,12 +90,15 @@ function buildImports(objects: IrObject[]): string {
         .join(', ')} } from '../api/input-media';`,
     );
   }
-  if (namedTypes.size > 0) {
-    lines.push(
-      `import type { ${[...namedTypes]
-        .sort()
-        .join(', ')} } from '../api/parse-mode';`,
-    );
+  const byModule = new Map<string, string[]>();
+  for (const named of namedTypes) {
+    const module = namedTypeModule(named);
+    const names = byModule.get(module) ?? [];
+    names.push(named);
+    byModule.set(module, names);
+  }
+  for (const [module, names] of [...byModule].sort()) {
+    lines.push(`import type { ${names.sort().join(', ')} } from '${module}';`);
   }
   return lines.join('\n');
 }

--- a/tools/codegen/manifest.ts
+++ b/tools/codegen/manifest.ts
@@ -132,18 +132,41 @@ export function enumLiterals(
 /**
  * Enum fields promoted to a NAMED, hand-owned exported type instead of an inline
  * literal union — for values referenced widely enough to deserve a name. The
- * type itself is hand-written (`ParseModeValue` in lib/api/parse-mode.ts); the
- * manifest only names it at the field position, and the emitters add the import
- * (all named types currently live in the parse-mode module). Keyed like
- * {@link ENUM_LITERALS}.
+ * type itself is hand-written (e.g. `ParseModeValue` in lib/api/parse-mode.ts);
+ * the manifest only names it at the field position, and the emitter adds the
+ * import from {@link NAMED_TYPE_MODULES}. Keyed like {@link ENUM_LITERALS}.
  */
 const NAMED_TYPES: Readonly<Record<string, string>> = {
   '*.parse_mode': 'ParseModeValue',
+  'InlineKeyboardButton.style': 'ButtonStyleValue',
+  'KeyboardButton.style': 'ButtonStyleValue',
 };
 
 /** The named type a field is promoted to, or `undefined` for a plain field. */
 export function namedTypeFor(owner: string, field: string): string | undefined {
   return NAMED_TYPES[`${owner}.${field}`] ?? NAMED_TYPES[`*.${field}`];
+}
+
+/**
+ * Where each named type is imported from, as a path RELATIVE TO the generated
+ * types file (`lib/events/raw-update.types.ts`) — the emitter groups its imports
+ * by this. (The bot-methods emitter imports its sole named type separately, from
+ * its own file depth.)
+ */
+const NAMED_TYPE_MODULES: Readonly<Record<string, string>> = {
+  ParseModeValue: '../api/parse-mode',
+  ButtonStyleValue: '../keyboards/button-style',
+};
+
+/** The import path for a named type, or throws if one was added without a home. */
+export function namedTypeModule(typeName: string): string {
+  const module = NAMED_TYPE_MODULES[typeName];
+  if (module === undefined) {
+    throw new Error(
+      `Named type '${typeName}' has no entry in NAMED_TYPE_MODULES — add its import path.`,
+    );
+  }
+  return module;
 }
 
 // --- BotService method generation --------------------------------------------


### PR DESCRIPTION
Run several Telegram bots from one Nestgram app — a support bot and a sales
bot, a bot per brand, a fleet of white-label bots. Each has its own token and
its own interceptor pipeline; they share your routers, services, and the one
engine. A single bot is unchanged at every level: `forRoot({ token })` and a
bare `BotService` injection work exactly as before — multiplicity is opt-in.

## What's in it

- **Config** — `forRoot({ bots: [{ name, token, ... }] })`. Per-bot transport
  and pipeline flags (`parseMode`, `throttle`, `richMessages`, …). Exactly one
  bot may be `default: true`; none is allowed (co-equal bots, e.g. tenants), and
  the default is never silently the array's first.
- **Injection** — `@InjectBot('name')` for a specific bot, `@Bot()` for the bot
  that received the current update, a bare `BotService` for the default. No
  ambient/magic — `@InjectBot` is sugar over `@Inject(getBotToken(name))`.
- **Scoping** — `@ForBot('name')` narrows a router (class) or handler (method)
  to one bot, ANDed in as a route predicate; non-match falls through.
- **Runtime** — one update source per bot. Polling: a poller per bot. Webhook:
  two opt-in controllers (`MultiBotWebhookController` for a `:botName` path,
  `SharedWebhookController` for one endpoint routed by secret token), plus
  `webhookUrl(origin, name?)` and a write-your-own path via `WEBHOOK_SOURCES`.
- **State isolation** — the conversation key gains a bot dimension, so the same
  user+chat has separate sessions/FSM per bot (no bleed).

## Design notes for review

- **Per-bot pipeline isolation** — each bot is built by a fresh generated module
  class with a private `BOT_OPTIONS`; the throttler's providers are spliced (not
  imported) so each bot resolves its own options and has its own throttle state.
- **Per-update bot threading** — `dispatch(update, bot?)` -> context -> events /
  `ResultHandler`, so a reply goes back through the bot that received the update
  (`message.answer(...)` needs nothing).
- **`BotSourceFactory`** is the single place that acquires a per-bot source
  (polling -> built, webhook -> resolved from DI), keeping `NestgramBootstrap`
  transport-agnostic.
- **No `WebhookSourceRegistry`** — webhook routing is the controllers + the
  `WEBHOOK_SOURCES` array; the per-bot webhook source is one DI instance shared
  by the fleet (registers `setWebhook`) and the controller (delivers).

## Verify

`npm run build`, `npm run lint`, `npx jest` (556 passing), `npm run generate -- --check`,
and `cd website && npm run build` all green.

## Limitations

- Webhook controllers are tested at the DI level, not over real HTTP (the round
  trip needs `@nestjs/platform-*`, not a dev dep) — same as the single-bot
  webhook test.
- A shared webhook endpoint can only tell bots apart by secret: give each a
  distinct `secretToken` (duplicates are rejected at boot); without one, updates
  fall back to the default bot.
- `forRootAsync` resolves a single bot — declare several statically with
  `forRoot({ bots: [...] })`.
