### PR TITLE
Docs site: search, llms.txt, code-block fix, and header redesign

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,6 +33,79 @@ Starting from scratch? Scaffold a Nest project first
 context with no HTTP server.
 :::
 
+## Recommended `tsconfig.json`
+
+Nestgram is decorator-driven, so the compiler needs `experimentalDecorators`
+and `emitDecoratorMetadata` (the standard Nest setup already enables both). A
+fresh Nest project on **TypeScript 6** also turns on `isolatedModules` — and
+that combination has one sharp edge worth knowing before you write your first
+handler (see the next section).
+
+:::code[tsconfig.json]{mark="7,8,9"}
+
+```json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2022",
+    "strict": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  }
+}
+```
+
+:::
+
+## Importing event types
+
+With `isolatedModules` and `emitDecoratorMetadata` both on (the TypeScript 6
+default for new projects), the compiler refuses to read a **type** out of a
+**value** import when that type appears in a decorated handler signature:
+
+```
+error TS1272: A type referenced in a decorated signature must be imported with
+'import type' or a namespace import when 'isolatedModules' and
+'emitDecoratorMetadata' are enabled.
+```
+
+It fires on any handler with a param decorator — `start(message: Message,
+@Sender() user: User)` trips it on `User`. The fix is to split the import:
+values (decorators, classes, free functions) stay a normal import; **event
+types come in through `import type`**:
+
+:::code[greet.router.ts]{mark="1,2"}
+
+```ts
+import { Router, OnStart, Sender } from 'nestgram'; // values
+import type { Message, User } from 'nestgram'; // types
+
+@Router()
+export class GreetRouter {
+  @OnStart()
+  start(message: Message, @Sender() user: User) {
+    return `Hello, ${user.first_name}!`;
+  }
+}
+```
+
+:::
+
+:::note
+This is safe — Nestgram never reads a handler's `design:paramtypes`. Param
+injection is decorator-based and the first argument is positional, so erasing
+the type at compile time breaks nothing. Constructor DI is unaffected:
+`constructor(private readonly svc: MyService)` stays a value import (the
+constructor carries no Nestgram param decorator, so TS1272 doesn't touch it).
+Splitting the imports also clears the matching `isolatedModules` warning
+`ts-jest` prints in a new project.
+:::
+
 ## Get a bot token
 
 Every bot needs a token from Telegram's [@BotFather](https://t.me/BotFather):

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -65,6 +65,12 @@ object (`return new SendMessage(...)`) or call an action on the event
 (`message.answer(text, options)`) — same result, more knobs.
 :::
 
+:::note
+On a fresh TypeScript 6 project the compiler may reject an event type in a
+handler signature with `TS1272`. Import event types with `import type` — see
+[importing event types](/docs/installation#importing-event-types) for the why.
+:::
+
 ## Register it in a module
 
 Routers are plain Nest providers. List them in `providers` and Nestgram

--- a/website/gen/remark-nestgram-blocks.mjs
+++ b/website/gen/remark-nestgram-blocks.mjs
@@ -357,25 +357,44 @@ function buildCodeIsland(node) {
   return setChildren(node, kids);
 }
 
-// ---- terminal island: wrap a bare shell fence in code-island chrome --------
-// Bare ```bash fences never reach buildCodeIsland (they aren't directives), so
-// they'd render as a plain Shiki <pre> with no chrome. Wrap such a top-level
-// code node in the same figure/.ci-bar structure, flagged as a terminal.
-function wrapTerminalIsland(codeNode, index, parent) {
-  const figure = el(
-    'figure',
-    { className: ['code-island', 'is-framed', 'is-terminal'] },
-    [
+// ---- bare fence islands: wrap a plain top-level fence in code-island chrome -
+// Bare fenced code (```ts … ```, no :::code directive) never reaches
+// buildCodeIsland, so it would render as a naked Shiki <pre> with no panel,
+// border, or copy button — visually broken next to directive blocks. Wrap every
+// such top-level fence in the same `.code-island.is-framed` chrome the directive
+// path produces, server-side, so the two are identical except for the (optional)
+// filename bar. Shell fences additionally get the terminal treatment: a
+// "Terminal" bar and the `.is-terminal` flavour.
+function wrapBareFence(codeNode, index, parent) {
+  const isTerminal = TERMINAL_LANGS.has((codeNode.lang || '').toLowerCase());
+  const className = isTerminal
+    ? ['code-island', 'is-framed', 'is-terminal']
+    : ['code-island', 'is-framed'];
+
+  // Only terminals carry a chrome bar (the traffic lights + "Terminal" label).
+  // A plain code fence has no filename, so it gets the panel/border but no bar.
+  const kids = [];
+  if (isTerminal) {
+    kids.push(
       el('div', { className: ['ci-bar'] }, [
         el('span', { className: ['ci-dot'] }),
         el('span', { className: ['ci-dot'] }),
         el('span', { className: ['ci-dot'] }),
         el('span', { className: ['ci-name'] }, [text(TERMINAL_LABEL)]),
       ]),
-      codeNode,
-    ],
-  );
-  parent.children[index] = figure;
+    );
+  }
+  kids.push(codeNode);
+
+  parent.children[index] = el('figure', { className }, kids);
+}
+
+// A node is already a code-island wrapper if it's an element whose hProperties
+// carry the `code-island` class (the figure built by buildCodeIsland or
+// wrapBareFence). Used to skip fences that already have chrome.
+function isCodeIsland(node) {
+  const cls = node && node.data && node.data.hProperties && node.data.hProperties.className;
+  return Array.isArray(cls) && cls.includes('code-island');
 }
 
 export default function remarkNestgramBlocks() {
@@ -415,13 +434,17 @@ export default function remarkNestgramBlocks() {
       }
     });
 
-    // Second pass: bare shell fences at the top level become terminal islands.
-    // (Code nodes already inside a :::code figure are children of a figure, not
-    // of the root, so they're left untouched.)
+    // Second pass: every fence that isn't already wrapped by the :::code
+    // directive gets the same code-island chrome — shell fences as terminals,
+    // everything else as a plain (barless) island. This covers bare fences at
+    // the document root AND fences nested inside other directives (e.g. a code
+    // block inside a :::tabs panel), so no code block ever renders naked.
+    // The :::code path (first pass) already wrapped its fence in a `figure`
+    // marked `code-island`; we detect that and leave those alone.
     visit(tree, 'code', (node, index, parent) => {
-      if (!parent || parent.type !== 'root' || index == null) return;
-      if (!TERMINAL_LANGS.has((node.lang || '').toLowerCase())) return;
-      wrapTerminalIsland(node, index, parent);
+      if (!parent || index == null) return;
+      if (isCodeIsland(parent)) return;
+      wrapBareFence(node, index, parent);
       return SKIP;
     });
   };

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,9 @@
         "astro": "^6.4.2",
         "remark-directive": "^3.0.1",
         "sharp": "^0.34.2"
+      },
+      "devDependencies": {
+        "pagefind": "^1.5.2"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1076,6 +1079,104 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
@@ -3740,6 +3841,25 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && npm run index",
+    "index": "npx -y pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -13,5 +14,8 @@
     "astro": "^6.4.2",
     "remark-directive": "^3.0.1",
     "sharp": "^0.34.2"
+  },
+  "devDependencies": {
+    "pagefind": "^1.5.2"
   }
 }

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -53,6 +53,7 @@ const toc = headings.filter((h) => h.depth === 2 || h.depth === 3);
 const crumbs = breadcrumb.split('/').map((part) => part.trim());
 
 const githubUrl = 'https://github.com/Degreet/nestgram';
+const examplesUrl = 'https://github.com/Degreet/nestgram/tree/main/examples';
 ---
 
 <!doctype html>
@@ -67,30 +68,39 @@ const githubUrl = 'https://github.com/Degreet/nestgram';
   <body>
     <header class="dx-nav">
       <a class="dx-brand" href="/"><img src={logo.src} alt="" />Nestgram</a>
+      <span class="dx-ver">v2.0</span>
+      <button class="dx-search-btn" type="button" aria-label="Search docs">
+        <svg
+          viewBox="0 0 24 24"
+          width="15"
+          height="15"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="7"></circle>
+          <path d="m21 21-4.3-4.3"></path>
+        </svg>
+        <span class="dx-search-btn__txt">Search docs</span>
+        <kbd class="dx-search-btn__kbd">/</kbd>
+      </button>
       <nav class="dx-nav-right">
         <button class="dx-menu-btn" type="button" aria-label="Open docs menu">
           ☰ Menu
         </button>
-        <button class="dx-search-btn" type="button" aria-label="Search docs">
-          <svg
-            viewBox="0 0 24 24"
-            width="15"
-            height="15"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <circle cx="11" cy="11" r="7"></circle>
-            <path d="m21 21-4.3-4.3"></path>
-          </svg>
-          <span class="dx-search-btn__txt">Search</span>
-          <kbd class="dx-search-btn__kbd">/</kbd>
-        </button>
         <a href="/docs/quickstart">Docs</a>
-        <a href={githubUrl}>GitHub</a>
+        <a href={examplesUrl} target="_blank" rel="noopener">Examples</a>
+        <a class="dx-star" href={githubUrl} target="_blank" rel="noopener">
+          <svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true">
+            <path
+              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
+            ></path>
+          </svg>
+          <span class="dx-star__txt">Star on GitHub</span>
+        </a>
       </nav>
     </header>
 

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -104,7 +104,66 @@ const githubUrl = 'https://github.com/Degreet/nestgram';
         aria-modal="true"
         aria-label="Search docs"
       >
-        <div id="dx-search-ui"></div>
+        <div class="dx-search-field">
+          <svg
+            class="dx-search-field__ico"
+            viewBox="0 0 24 24"
+            width="17"
+            height="17"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="7"></circle>
+            <path d="m21 21-4.3-4.3"></path>
+          </svg>
+          <input
+            id="dx-search-input"
+            class="dx-search-input"
+            type="search"
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            placeholder="Search the docs…"
+            aria-label="Search docs"
+            aria-controls="dx-search-results"
+            aria-expanded="false"
+            role="combobox"
+            aria-autocomplete="list"
+          />
+          <button
+            class="dx-search-clear"
+            type="button"
+            aria-label="Close search"
+            title="Close (Esc)"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="16"
+              height="16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M18 6 6 18M6 6l12 12"></path>
+            </svg>
+          </button>
+        </div>
+        <div
+          id="dx-search-results"
+          class="dx-search-results"
+          role="listbox"
+          aria-label="Search results"
+          tabindex="-1"
+        >
+        </div>
       </div>
     </div>
 
@@ -293,65 +352,215 @@ const githubUrl = 'https://github.com/Degreet/nestgram';
           heading.prepend(anchor);
         });
 
-      // Search: Pagefind indexes the built site at /pagefind after `astro build`
-      // (see the `index` npm script). Its UI bundle is loaded lazily the first
-      // time the modal opens, so a reader who never searches pays nothing.
+      // Search: a custom modal driven by Pagefind's JS API (not the default
+      // widget). Pagefind indexes the built site into /pagefind after
+      // `astro build` (see the `index` npm script). The index module is imported
+      // lazily the first time the modal opens, so a reader who never searches
+      // pays nothing, and `astro dev` (where /pagefind doesn't exist) degrades
+      // to a hint instead of throwing.
+      type PagefindSubResult = { title: string; url: string; excerpt: string };
+      type PagefindResultData = {
+        url: string;
+        meta: { title?: string };
+        excerpt: string;
+        sub_results?: PagefindSubResult[];
+      };
+      type PagefindApi = {
+        search: (q: string) => Promise<{ results: { data: () => Promise<PagefindResultData> }[] }>;
+      };
+
+      const SEARCH_DEBOUNCE_MS = 160;
+      const MAX_RESULTS = 8;
+
       const searchBtn = document.querySelector('.dx-search-btn');
       const searchModal = document.querySelector<HTMLElement>('.dx-search-modal');
       const searchOverlay = searchModal?.querySelector('.dx-search-overlay');
-      let pagefindLoaded = false;
+      const searchPanel = searchModal?.querySelector<HTMLElement>('.dx-search-panel');
+      const searchInput = document.querySelector<HTMLInputElement>('#dx-search-input');
+      const searchClear = searchModal?.querySelector<HTMLElement>('.dx-search-clear');
+      const searchResults = document.querySelector<HTMLElement>('#dx-search-results');
 
-      const loadPagefindUI = async () => {
-        if (pagefindLoaded) return;
-        pagefindLoaded = true;
-        // Pagefind only exists in a built site, not in `astro dev`. Guard the
-        // CSS/JS load so dev doesn't 404-spam, and surface a hint instead.
-        const css = document.createElement('link');
-        css.rel = 'stylesheet';
-        css.href = '/pagefind/pagefind-ui.css';
-        document.head.appendChild(css);
+      let pagefind: PagefindApi | null = null;
+      let pagefindStatus: 'idle' | 'ready' | 'unavailable' = 'idle';
+      let lastTrigger: HTMLElement | null = null;
+      let debounceTimer: number | undefined;
+      let activeIndex = -1;
+      let optionLinks: HTMLAnchorElement[] = [];
+
+      const stripExcerptMarks = (html: string): string =>
+        // Pagefind wraps matches in <mark>; we re-tag to our own class so the
+        // highlight is the brand accent, never the widget's yellow default.
+        html.replace(/<mark>/g, '<mark class="dx-hit">').replace(/<\/mark>/g, '</mark>');
+
+      const ensurePagefind = async (): Promise<void> => {
+        if (pagefindStatus !== 'idle') return;
         try {
-          // The bundle is emitted by Pagefind into dist/pagefind/ after the
-          // build, so it doesn't exist when Vite bundles this script. Build the
-          // path in a variable + @vite-ignore so Rollup leaves the import alone.
-          const uiPath = '/pagefind/pagefind-ui.js';
-          const mod = await import(/* @vite-ignore */ uiPath);
-          const PagefindUI = mod.PagefindUI ?? (window as any).PagefindUI;
-          new PagefindUI({
-            element: '#dx-search-ui',
-            showSubResults: true,
-            showImages: false,
-            resetStyles: false,
-          });
+          // The module is emitted into dist/pagefind/ after the build, so it
+          // doesn't exist when Vite bundles this script. Build the path in a
+          // variable + @vite-ignore so Rollup leaves the import alone.
+          const indexPath = '/pagefind/pagefind.js';
+          const mod = (await import(/* @vite-ignore */ indexPath)) as PagefindApi;
+          await (mod as unknown as { init?: () => Promise<void> }).init?.();
+          pagefind = mod;
+          pagefindStatus = 'ready';
         } catch {
-          const host = document.getElementById('dx-search-ui');
-          if (host) {
-            host.innerHTML =
-              '<p class="dx-search-fallback">Search is available in the built site (run <code>npm run build</code>), not in dev.</p>';
-          }
+          pagefindStatus = 'unavailable';
         }
       };
 
-      const openSearch = async () => {
-        if (!searchModal) return;
-        searchModal.hidden = false;
-        document.body.classList.add('dx-search-open');
-        await loadPagefindUI();
-        // Focus the Pagefind input once it has mounted.
-        window.setTimeout(() => {
-          searchModal
-            .querySelector<HTMLInputElement>('.pagefind-ui__search-input')
-            ?.focus();
-        }, 80);
+      const setEmptyState = (html: string): void => {
+        if (!searchResults) return;
+        searchResults.innerHTML = `<p class="dx-search-empty">${html}</p>`;
+        optionLinks = [];
+        activeIndex = -1;
+        searchInput?.setAttribute('aria-expanded', 'false');
       };
-      const closeSearch = () => {
+
+      const setActive = (next: number): void => {
+        if (optionLinks.length === 0) return;
+        const clamped = ((next % optionLinks.length) + optionLinks.length) % optionLinks.length;
+        optionLinks.forEach((a) => a.classList.remove('is-active'));
+        const link = optionLinks[clamped];
+        link.classList.add('is-active');
+        link.scrollIntoView({ block: 'nearest' });
+        searchInput?.setAttribute('aria-activedescendant', link.id);
+        activeIndex = clamped;
+      };
+
+      const renderResults = (items: PagefindResultData[]): void => {
+        if (!searchResults) return;
+        if (items.length === 0) {
+          setEmptyState('No matches. Try another term.');
+          return;
+        }
+        let optionId = 0;
+        const groups = items
+          .map((item) => {
+            const title = item.meta.title ?? item.url;
+            // Prefer sub-results (per-heading anchors) when Pagefind found them;
+            // fall back to the page-level excerpt otherwise.
+            const subs =
+              item.sub_results && item.sub_results.length > 0
+                ? item.sub_results.slice(0, 3)
+                : [{ title, url: item.url, excerpt: item.excerpt }];
+            const hits = subs
+              .map((sub) => {
+                const id = `dx-hit-${optionId++}`;
+                return `
+                  <a
+                    class="dx-search-hit"
+                    id="${id}"
+                    role="option"
+                    href="${sub.url}"
+                  >
+                    <span class="dx-search-hit__title">${sub.title}</span>
+                    <span class="dx-search-hit__excerpt">${stripExcerptMarks(sub.excerpt)}</span>
+                  </a>`;
+              })
+              .join('');
+            return `
+              <div class="dx-search-group">
+                <p class="dx-search-group__label">${title}</p>
+                ${hits}
+              </div>`;
+          })
+          .join('');
+        searchResults.innerHTML = groups;
+        optionLinks = [...searchResults.querySelectorAll<HTMLAnchorElement>('.dx-search-hit')];
+        optionLinks.forEach((a, i) => {
+          a.addEventListener('mousemove', () => setActive(i));
+        });
+        activeIndex = -1;
+        searchInput?.setAttribute('aria-expanded', 'true');
+        searchResults.scrollTop = 0;
+      };
+
+      const runSearch = async (query: string): Promise<void> => {
+        const trimmed = query.trim();
+        if (trimmed === '') {
+          setEmptyState('Type to search the documentation.');
+          return;
+        }
+        await ensurePagefind();
+        if (pagefindStatus === 'unavailable' || !pagefind) {
+          setEmptyState(
+            'Search is available in the production build (<code>npm run build</code>), not in dev.',
+          );
+          return;
+        }
+        const search = await pagefind.search(trimmed);
+        const data = await Promise.all(search.results.slice(0, MAX_RESULTS).map((r) => r.data()));
+        renderResults(data);
+      };
+
+      const onInput = (): void => {
+        window.clearTimeout(debounceTimer);
+        debounceTimer = window.setTimeout(() => {
+          void runSearch(searchInput?.value ?? '');
+        }, SEARCH_DEBOUNCE_MS);
+      };
+
+      const openSearch = (): void => {
+        if (!searchModal || !searchInput || !searchModal.hidden) return;
+        lastTrigger = document.activeElement as HTMLElement | null;
+        searchModal.hidden = false;
+        document.documentElement.classList.add('dx-search-open');
+        document.body.classList.add('dx-search-open');
+        setEmptyState('Type to search the documentation.');
+        // Warm the index in the background so the first keystroke is instant.
+        void ensurePagefind();
+        window.requestAnimationFrame(() => searchInput.focus());
+      };
+
+      const closeSearch = (): void => {
         if (!searchModal) return;
         searchModal.hidden = true;
+        document.documentElement.classList.remove('dx-search-open');
         document.body.classList.remove('dx-search-open');
+        if (searchInput) searchInput.value = '';
+        window.clearTimeout(debounceTimer);
+        lastTrigger?.focus();
       };
 
       searchBtn?.addEventListener('click', openSearch);
       searchOverlay?.addEventListener('click', closeSearch);
+      searchClear?.addEventListener('click', closeSearch);
+      searchInput?.addEventListener('input', onInput);
+
+      // Keyboard nav within the modal: arrows move the active option, Enter
+      // follows it, Tab is trapped inside the panel.
+      searchInput?.addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          setActive(activeIndex + 1);
+        } else if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          setActive(activeIndex - 1);
+        } else if (event.key === 'Enter') {
+          if (activeIndex >= 0 && optionLinks[activeIndex]) {
+            event.preventDefault();
+            window.location.href = optionLinks[activeIndex].href;
+          }
+        }
+      });
+
+      const trapFocus = (event: KeyboardEvent): void => {
+        if (event.key !== 'Tab' || !searchPanel) return;
+        const focusable = searchPanel.querySelectorAll<HTMLElement>(
+          'input, button, a[href], [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      };
+
       document.addEventListener('keydown', (event) => {
         if (
           event.key === '/' &&
@@ -361,8 +570,13 @@ const githubUrl = 'https://github.com/Degreet/nestgram';
         ) {
           event.preventDefault();
           openSearch();
-        } else if (event.key === 'Escape' && !searchModal?.hidden) {
-          closeSearch();
+        } else if (!searchModal?.hidden) {
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            closeSearch();
+          } else {
+            trapFocus(event);
+          }
         }
       });
     </script>

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -71,12 +71,42 @@ const githubUrl = 'https://github.com/Degreet/nestgram';
         <button class="dx-menu-btn" type="button" aria-label="Open docs menu">
           ☰ Menu
         </button>
+        <button class="dx-search-btn" type="button" aria-label="Search docs">
+          <svg
+            viewBox="0 0 24 24"
+            width="15"
+            height="15"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="7"></circle>
+            <path d="m21 21-4.3-4.3"></path>
+          </svg>
+          <span class="dx-search-btn__txt">Search</span>
+          <kbd class="dx-search-btn__kbd">/</kbd>
+        </button>
         <a href="/docs/quickstart">Docs</a>
         <a href={githubUrl}>GitHub</a>
       </nav>
     </header>
 
     <div class="dx-backdrop" aria-hidden="true"></div>
+
+    <div class="dx-search-modal" data-pagefind-ignore hidden>
+      <div class="dx-search-overlay" aria-hidden="true"></div>
+      <div
+        class="dx-search-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search docs"
+      >
+        <div id="dx-search-ui"></div>
+      </div>
+    </div>
 
     <div class="dx-shell">
       <aside class="dx-sidebar">
@@ -109,13 +139,13 @@ const githubUrl = 'https://github.com/Degreet/nestgram';
             ))
           }
         </div>
-        <article class="dx-content">
-          <h1>{title}</h1>
+        <article class="dx-content" data-pagefind-body>
+          <h1 data-pagefind-meta="title">{title}</h1>
           <slot />
 
           {
             (prev || next) && (
-              <nav class="dx-pager">
+              <nav class="dx-pager" data-pagefind-ignore>
                 {prev ? (
                   <a class="dx-pager-btn dx-pager-prev" href={prev.href}>
                     <span class="dx-pager-dir">← Previous</span>
@@ -262,6 +292,79 @@ const githubUrl = 'https://github.com/Degreet/nestgram';
           });
           heading.prepend(anchor);
         });
+
+      // Search: Pagefind indexes the built site at /pagefind after `astro build`
+      // (see the `index` npm script). Its UI bundle is loaded lazily the first
+      // time the modal opens, so a reader who never searches pays nothing.
+      const searchBtn = document.querySelector('.dx-search-btn');
+      const searchModal = document.querySelector<HTMLElement>('.dx-search-modal');
+      const searchOverlay = searchModal?.querySelector('.dx-search-overlay');
+      let pagefindLoaded = false;
+
+      const loadPagefindUI = async () => {
+        if (pagefindLoaded) return;
+        pagefindLoaded = true;
+        // Pagefind only exists in a built site, not in `astro dev`. Guard the
+        // CSS/JS load so dev doesn't 404-spam, and surface a hint instead.
+        const css = document.createElement('link');
+        css.rel = 'stylesheet';
+        css.href = '/pagefind/pagefind-ui.css';
+        document.head.appendChild(css);
+        try {
+          // The bundle is emitted by Pagefind into dist/pagefind/ after the
+          // build, so it doesn't exist when Vite bundles this script. Build the
+          // path in a variable + @vite-ignore so Rollup leaves the import alone.
+          const uiPath = '/pagefind/pagefind-ui.js';
+          const mod = await import(/* @vite-ignore */ uiPath);
+          const PagefindUI = mod.PagefindUI ?? (window as any).PagefindUI;
+          new PagefindUI({
+            element: '#dx-search-ui',
+            showSubResults: true,
+            showImages: false,
+            resetStyles: false,
+          });
+        } catch {
+          const host = document.getElementById('dx-search-ui');
+          if (host) {
+            host.innerHTML =
+              '<p class="dx-search-fallback">Search is available in the built site (run <code>npm run build</code>), not in dev.</p>';
+          }
+        }
+      };
+
+      const openSearch = async () => {
+        if (!searchModal) return;
+        searchModal.hidden = false;
+        document.body.classList.add('dx-search-open');
+        await loadPagefindUI();
+        // Focus the Pagefind input once it has mounted.
+        window.setTimeout(() => {
+          searchModal
+            .querySelector<HTMLInputElement>('.pagefind-ui__search-input')
+            ?.focus();
+        }, 80);
+      };
+      const closeSearch = () => {
+        if (!searchModal) return;
+        searchModal.hidden = true;
+        document.body.classList.remove('dx-search-open');
+      };
+
+      searchBtn?.addEventListener('click', openSearch);
+      searchOverlay?.addEventListener('click', closeSearch);
+      document.addEventListener('keydown', (event) => {
+        if (
+          event.key === '/' &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !/^(INPUT|TEXTAREA)$/.test((event.target as HTMLElement)?.tagName)
+        ) {
+          event.preventDefault();
+          openSearch();
+        } else if (event.key === 'Escape' && !searchModal?.hidden) {
+          closeSearch();
+        }
+      });
     </script>
   </body>
 </html>

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -94,9 +94,9 @@ const examplesUrl = 'https://github.com/Degreet/nestgram/tree/main/examples';
         <a href="/docs/quickstart">Docs</a>
         <a href={examplesUrl} target="_blank" rel="noopener">Examples</a>
         <a class="dx-star" href={githubUrl} target="_blank" rel="noopener">
-          <svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true">
             <path
-              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
+              d="M12 2.5l2.94 5.96 6.58.96-4.76 4.64 1.12 6.55L12 17.98l-5.88 3.09 1.12-6.55L2.48 9.42l6.58-.96L12 2.5z"
             ></path>
           </svg>
           <span class="dx-star__txt">Star on GitHub</span>

--- a/website/src/pages/llms-full.txt.ts
+++ b/website/src/pages/llms-full.txt.ts
@@ -1,0 +1,53 @@
+// Generates /llms-full.txt at build time: the full text of every doc page
+// concatenated in reading order, for LLMs that want the whole corpus in one
+// fetch. Built from the docs collection's raw markdown bodies, with the block
+// directives stripped to their inner content so the prose reads cleanly.
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+const SITE = 'https://nestgram.vercel.app';
+
+const HEADER = `# Nestgram — full documentation
+
+> Nestgram is a framework (not a wrapper) for building Telegram bots on NestJS,
+> using Nest's own execution pipeline. This file is the full text of every docs
+> page, concatenated in reading order.
+`;
+
+const cleanSlug = (id: string): string => id.replace(/^\d+[-_]/, '');
+
+// The docs use :::name[label]{attrs} … ::: block directives for callouts and
+// code islands. Strip the directive fences (keep the inner content) so the
+// plain-text corpus reads as prose, not as our authoring vocabulary.
+const stripDirectives = (md: string): string =>
+  md
+    .split('\n')
+    .filter((line) => {
+      const t = line.trim();
+      if (/^:::+[a-z]/i.test(t)) return false; // opening directive
+      if (/^:::+\s*$/.test(t)) return false; // closing directive
+      if (/^::[a-z]/i.test(t)) return false; // leaf directive (::tab[...])
+      return true;
+    })
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+export const GET: APIRoute = async () => {
+  const entries = await getCollection('docs');
+  const sorted = [...entries].sort(
+    (a, b) => (a.data.sidebar?.order ?? 999) - (b.data.sidebar?.order ?? 999),
+  );
+
+  const pages = sorted.map((entry) => {
+    const href = `${SITE}/docs/${cleanSlug(entry.id)}`;
+    const desc = entry.data.description ? `\n${entry.data.description}\n` : '\n';
+    const body = stripDirectives(entry.body ?? '');
+    return `# ${entry.data.title}\n\nSource: ${href}\n${desc}\n${body}`;
+  });
+
+  const body = `${HEADER}\n${pages.join('\n\n---\n\n')}\n`;
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -1,0 +1,59 @@
+// Generates /llms.txt at build time from the docs collection, following the
+// llmstxt.org convention: a short project description, then sections (one per
+// sidebar group, in order) linking to each doc page with a one-line summary.
+// Generated from the same frontmatter the site renders, so it never drifts.
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+const SITE = 'https://nestgram.vercel.app';
+
+const INTRO = `# Nestgram
+
+> Nestgram is a framework (not a wrapper) for building Telegram bots on NestJS,
+> using Nest's own execution pipeline. A \`@Router()\` is a controller, a Telegram
+> update is a request, and a handler's return value is the reply. Guards,
+> interceptors, pipes, and exception filters all work because handlers run
+> through Nest's \`ExternalContextCreator\`. Events are rich typed objects
+> (\`Message\`, \`CallbackQuery\`, …) passed positionally; param decorators
+> (\`@Sender()\`, \`@Args()\`) cover cross-cutting values. The Bot API surface,
+> sessions, i18n, typed callback-data, typed command args, a send throttler, and
+> an FSM core are built in.
+
+Status: v2 pre-release (alpha). Docs are authored as Markdown and rendered by a
+custom Astro site.`;
+
+const cleanSlug = (id: string): string => id.replace(/^\d+[-_]/, '');
+
+export const GET: APIRoute = async () => {
+  const entries = await getCollection('docs');
+  const sorted = [...entries].sort(
+    (a, b) => (a.data.sidebar?.order ?? 999) - (b.data.sidebar?.order ?? 999),
+  );
+
+  // Group by sidebar group, preserving first-seen order.
+  const groups: { label: string; items: typeof sorted }[] = [];
+  for (const entry of sorted) {
+    const label = entry.data.sidebar?.group ?? 'Docs';
+    let group = groups.find((g) => g.label === label);
+    if (!group) {
+      group = { label, items: [] };
+      groups.push(group);
+    }
+    group.items.push(entry);
+  }
+
+  const sections = groups.map((group) => {
+    const lines = group.items.map((entry) => {
+      const title = entry.data.sidebar?.label ?? entry.data.title;
+      const href = `${SITE}/docs/${cleanSlug(entry.id)}`;
+      const desc = entry.data.description ? `: ${entry.data.description}` : '';
+      return `- [${title}](${href})${desc}`;
+    });
+    return `## ${group.label}\n\n${lines.join('\n')}`;
+  });
+
+  const body = `${INTRO}\n\n${sections.join('\n\n')}\n`;
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/website/src/styles/docs.css
+++ b/website/src/styles/docs.css
@@ -1000,7 +1000,8 @@ body {
   color: var(--muted);
 }
 
-/* The modal: fixed overlay + centred panel that holds the Pagefind UI. */
+/* Custom search modal driven by Pagefind's JS API (not the default widget).
+   Fixed overlay + centred panel; the results list is the only scroll region. */
 .dx-search-modal {
   position: fixed;
   inset: 0;
@@ -1015,40 +1016,154 @@ body {
   background: rgba(3, 5, 9, 0.66);
   backdrop-filter: blur(4px);
 }
+/* Lock the page behind the modal so a wheel/touch scroll moves the results
+   list, never the document underneath. */
+html.dx-search-open,
+body.dx-search-open {
+  overflow: hidden;
+}
 .dx-search-panel {
   position: relative;
+  display: flex;
+  flex-direction: column;
   max-width: 40rem;
+  max-height: 76vh;
   margin: 8vh auto 0;
-  padding: 1rem;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-lg);
   background: var(--panel);
   box-shadow: 0 30px 80px rgba(0, 0, 0, 0.5);
-}
-.dx-search-fallback {
-  margin: 0;
-  padding: 0.6rem 0.3rem;
-  color: var(--text-2);
-  font-size: 0.9rem;
+  overflow: hidden;
 }
 
-/* Theme the prebuilt Pagefind UI to the nestgram palette via its CSS vars. */
-#dx-search-ui {
-  --pagefind-ui-primary: var(--accent);
-  --pagefind-ui-text: var(--text);
-  --pagefind-ui-background: var(--panel);
-  --pagefind-ui-border: var(--border-strong);
-  --pagefind-ui-tag: var(--panel-2);
-  --pagefind-ui-border-width: 1px;
-  --pagefind-ui-border-radius: 10px;
-  --pagefind-ui-font: var(--font-body);
+/* ---- the input field ---- */
+.dx-search-field {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border);
 }
-#dx-search-ui .pagefind-ui__result-title {
+.dx-search-field__ico {
+  flex: none;
+  color: var(--muted);
+}
+.dx-search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 1.02rem;
+  line-height: 1.4;
+}
+.dx-search-input::placeholder {
+  color: var(--muted);
+  opacity: 1;
+}
+/* Drop the browser-native search cancel/clear chrome — we ship our own. */
+.dx-search-input::-webkit-search-cancel-button,
+.dx-search-input::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+/* On-brand, centred close control (no default button chrome). */
+.dx-search-clear {
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-soft);
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.dx-search-clear:hover {
+  color: var(--text);
+  border-color: color-mix(in oklab, var(--accent) 50%, var(--border-strong));
+  background: var(--panel-2);
+}
+.dx-search-clear:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ---- the results list (the only scroll region) ---- */
+.dx-search-results {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  padding: 0.5rem;
+}
+.dx-search-empty {
+  margin: 0;
+  padding: 1.4rem 0.8rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+  text-align: center;
+}
+.dx-search-empty code {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.05em 0.4em;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--a1);
+}
+.dx-search-group + .dx-search-group {
+  margin-top: 0.4rem;
+}
+.dx-search-group__label {
+  margin: 0.7rem 0.7rem 0.3rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.dx-search-hit {
+  display: block;
+  padding: 0.6rem 0.7rem;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: background 0.12s, border-color 0.12s;
+}
+.dx-search-hit:hover,
+.dx-search-hit.is-active {
+  background: var(--accent-soft);
+  border-color: color-mix(in oklab, var(--accent) 38%, var(--border));
+}
+.dx-search-hit__title {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 0.96rem;
+  font-weight: 500;
   color: var(--text);
 }
-#dx-search-ui .pagefind-ui__result-excerpt {
+.dx-search-hit__excerpt {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.86rem;
+  line-height: 1.55;
   color: var(--text-2);
 }
+/* Our own highlight — brand accent, never the widget's yellow <mark>. */
+.dx-search-hit__excerpt mark.dx-hit {
+  background: transparent;
+  color: var(--a1);
+  font-weight: 600;
+}
+
 @media (max-width: 640px) {
   .dx-search-btn__txt,
   .dx-search-btn__kbd {
@@ -1056,5 +1171,6 @@ body {
   }
   .dx-search-panel {
     margin: 4vh 0.8rem 0;
+    max-height: 84vh;
   }
 }

--- a/website/src/styles/docs.css
+++ b/website/src/styles/docs.css
@@ -56,7 +56,7 @@ body {
   height: var(--nav-h);
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 1.4rem;
   padding: 0 1.6rem;
   border-bottom: 1px solid var(--border);
   background: color-mix(in oklab, var(--bg) 82%, transparent);
@@ -64,6 +64,7 @@ body {
 }
 .dx-brand {
   display: flex;
+  flex: none;
   align-items: center;
   gap: 0.55rem;
   font-family: var(--font-display);
@@ -75,10 +76,21 @@ body {
 .dx-brand img {
   height: 1.7rem;
 }
+.dx-ver {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  line-height: 1;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+}
 .dx-nav-right {
   display: flex;
   align-items: center;
-  gap: 0.9rem;
+  gap: 0.5rem;
+  margin-left: auto;
   font-size: 0.9rem;
 }
 .dx-nav-right a {
@@ -411,6 +423,9 @@ body {
   }
   .dx-menu-btn {
     display: inline-flex;
+  }
+  .dx-nav-right a:not(.dx-star) {
+    display: none;
   }
   /* the sidebar becomes a left drawer under the top nav */
   .dx-sidebar {
@@ -968,9 +983,13 @@ body {
 /* ============================================================ */
 .dx-search-btn {
   display: inline-flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 360px;
   align-items: center;
+  justify-content: flex-start;
   gap: 0.5rem;
-  padding: 0.4rem 0.7rem;
+  padding: 0.45rem 0.8rem;
   border: 1px solid var(--border-strong);
   border-radius: 10px;
   background: var(--panel);
@@ -990,6 +1009,7 @@ body {
   flex: none;
 }
 .dx-search-btn__kbd {
+  margin-left: auto;
   font-family: var(--font-mono);
   font-size: 0.72rem;
   line-height: 1;
@@ -998,6 +1018,26 @@ body {
   border-radius: 6px;
   background: var(--bg-soft);
   color: var(--muted);
+}
+.dx-nav-right a.dx-star {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.38rem 0.75rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  background: var(--panel);
+  color: var(--text);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.dx-nav-right a.dx-star:hover {
+  border-color: color-mix(in oklab, var(--accent) 50%, var(--border-strong));
+  background: var(--accent-soft);
+}
+.dx-star svg {
+  flex: none;
+  color: var(--a1);
 }
 
 /* Custom search modal driven by Pagefind's JS API (not the default widget).
@@ -1167,6 +1207,14 @@ body.dx-search-open {
 @media (max-width: 640px) {
   .dx-search-btn__txt,
   .dx-search-btn__kbd {
+    display: none;
+  }
+  .dx-search-btn {
+    flex: 0 0 auto;
+    max-width: none;
+  }
+  .dx-ver,
+  .dx-star__txt {
     display: none;
   }
   .dx-search-panel {

--- a/website/src/styles/docs.css
+++ b/website/src/styles/docs.css
@@ -796,17 +796,20 @@ body {
   margin-top: 0.6rem;
 }
 
-/* code island */
+/* code island — the panel chrome (background, border, rounding, shadow) is on
+   the base class so EVERY code block looks the same: directive blocks with a
+   filename bar (.is-framed), plain fences wrapped server-side (.is-framed, no
+   bar), labelless :::code directives (.code-island only), and the JS fallback
+   wrapper (.is-plain). The optional filename bar (.ci-bar) is the only visual
+   difference between them. */
 .code-island {
   position: relative;
   margin: 1.6rem 0;
   border-radius: 13px;
   overflow: hidden;
   background: #080a0f;
-}
-/* wrapper the copy-button script adds around a bare Shiki <pre> */
-.code-island.is-plain {
-  background: transparent;
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 24px 60px -30px rgba(0, 0, 0, 0.8);
 }
 
 /* ---- copy button (hover-reveal, top-right of any code block) ---- */
@@ -856,19 +859,13 @@ body {
 .code-copy.is-copied .code-copy__ico--done {
   display: inline-flex;
 }
-/* keep the button clear of the filename when chrome is present */
-.code-island .ci-bar {
-  padding-right: 92px;
-}
-.code-island.is-framed {
-  border: 1px solid var(--border-strong);
-  box-shadow: 0 24px 60px -30px rgba(0, 0, 0, 0.8);
-}
+/* the filename bar; padding-right keeps the copy button clear of the name */
 .code-island .ci-bar {
   display: flex;
   align-items: center;
   gap: 7px;
   padding: 10px 14px;
+  padding-right: 92px;
   background: rgba(255, 255, 255, 0.015);
   border-bottom: 1px solid var(--border);
 }

--- a/website/src/styles/docs.css
+++ b/website/src/styles/docs.css
@@ -21,6 +21,7 @@
   --a2: #1f8fe6;
   --accent: var(--a2);
   --accent-soft: rgba(54, 180, 244, 0.14);
+  --gold: #ffcb7a;
   --font-display: 'Space Grotesk', system-ui, sans-serif;
   --font-body: 'Hanken Grotesk', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
@@ -89,7 +90,7 @@ body {
 .dx-nav-right {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 1rem;
   margin-left: auto;
   font-size: 0.9rem;
 }
@@ -1026,18 +1027,18 @@ body {
   padding: 0.38rem 0.75rem;
   border: 1px solid var(--border-strong);
   border-radius: 9px;
-  background: var(--panel);
+  background: rgba(255, 255, 255, 0.03);
   color: var(--text);
   font-weight: 500;
   white-space: nowrap;
 }
 .dx-nav-right a.dx-star:hover {
-  border-color: color-mix(in oklab, var(--accent) 50%, var(--border-strong));
-  background: var(--accent-soft);
+  border-color: rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.07);
 }
 .dx-star svg {
   flex: none;
-  color: var(--a1);
+  color: var(--gold);
 }
 
 /* Custom search modal driven by Pagefind's JS API (not the default widget).

--- a/website/src/styles/docs.css
+++ b/website/src/styles/docs.css
@@ -965,3 +965,99 @@ body {
   border-top: 1px solid var(--border);
   color: var(--text-2);
 }
+
+/* ============================================================ */
+/* Search — header trigger + Pagefind modal                     */
+/* ============================================================ */
+.dx-search-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: var(--panel);
+  color: var(--text-2);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+}
+.dx-search-btn:hover {
+  color: var(--text);
+  border-color: color-mix(in oklab, var(--accent) 50%, var(--border-strong));
+}
+.dx-search-btn svg {
+  flex: none;
+}
+.dx-search-btn__kbd {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 0.18rem 0.36rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  background: var(--bg-soft);
+  color: var(--muted);
+}
+
+/* The modal: fixed overlay + centred panel that holds the Pagefind UI. */
+.dx-search-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+}
+.dx-search-modal[hidden] {
+  display: none;
+}
+.dx-search-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(3, 5, 9, 0.66);
+  backdrop-filter: blur(4px);
+}
+.dx-search-panel {
+  position: relative;
+  max-width: 40rem;
+  margin: 8vh auto 0;
+  padding: 1rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--panel);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.5);
+}
+.dx-search-fallback {
+  margin: 0;
+  padding: 0.6rem 0.3rem;
+  color: var(--text-2);
+  font-size: 0.9rem;
+}
+
+/* Theme the prebuilt Pagefind UI to the nestgram palette via its CSS vars. */
+#dx-search-ui {
+  --pagefind-ui-primary: var(--accent);
+  --pagefind-ui-text: var(--text);
+  --pagefind-ui-background: var(--panel);
+  --pagefind-ui-border: var(--border-strong);
+  --pagefind-ui-tag: var(--panel-2);
+  --pagefind-ui-border-width: 1px;
+  --pagefind-ui-border-radius: 10px;
+  --pagefind-ui-font: var(--font-body);
+}
+#dx-search-ui .pagefind-ui__result-title {
+  color: var(--text);
+}
+#dx-search-ui .pagefind-ui__result-excerpt {
+  color: var(--text-2);
+}
+@media (max-width: 640px) {
+  .dx-search-btn__txt,
+  .dx-search-btn__kbd {
+    display: none;
+  }
+  .dx-search-panel {
+    margin: 4vh 0.8rem 0;
+  }
+}


### PR DESCRIPTION
## What this does

Brings the docs site (`website/`) up to launch quality and adds a recommended-tsconfig note to the docs content.

**Docs content**
- Recommended `tsconfig.json` + an "import event types via `import type`" note: explains the TS1272 a new project hits under `isolatedModules` + `emitDecoratorMetadata`, and why it's safe (Nestgram never reads handler `design:paramtypes`; constructor DI is unaffected).

**Site**
- **Code-block fix:** every code block now renders with the same panel chrome (background, border, copy button). Previously only `:::code[file]` directive blocks were framed; plain fenced blocks rendered bare on the page background. Fixed at the renderer + CSS level, not per page.
- **Search:** build-time Pagefind index plus a custom search UI built on Pagefind's JS API — themed to the site palette, brand-accent highlights (no default widget), page-grouped results, a scroll-locked modal (results scroll, page doesn't), `/` shortcut, and keyboard navigation.
- **`llms.txt` + `llms-full.txt`:** generated at build from the docs collection — a compact link index and the full corpus — for LLM consumption.
- **Header:** redesigned to match the design — a `v2.0` badge, a wide search field, `Docs` / `Examples` links, and a "Star on GitHub" button (gold star, ghost style).

## How to verify

```
cd website && npm run build      # exit 0; produces dist/pagefind/, /llms.txt, /llms-full.txt
npm run preview                  # open the built site
```

- Open search (click the field or press `/`), query e.g. `session` — results group by page, the results list scrolls while the page behind stays fixed, Escape / click-outside close.
- Code blocks across docs pages (handling-errors, sessions, match-predicates, …) all show the panel + copy button.
- `/llms.txt` and `/llms-full.txt` return `text/plain`.

## Notes

- The `Examples` header link currently points to the GitHub `examples/` directory (no example-gallery page yet).
- The search index is produced by the production build; dev mode shows a graceful fallback note instead of erroring.
