### PR TITLE
Testing utilities: NestgramTestbed + fake-update factory

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,291 @@
+---
+title: Testing
+description: Dispatch fake updates against your real routers with NestgramTestbed — the genuine engine, no Telegram connection, only the HTTP wire stubbed.
+sidebar:
+  label: Testing
+  group: Tooling
+  order: 110
+---
+
+A bot is just routers running through the Nest pipeline, so test it the way
+you'd test a controller: feed it a request, assert on the reply. `NestgramTestbed`
+boots your **real** routers and runs each fake update through the **real**
+engine — discovery builds the route table, matching picks the handler, and
+guards / interceptors / pipes / exception filters fire through ECC exactly as in
+production. The only thing swapped is the HTTP boundary: every outgoing Bot API
+call is captured instead of sent, so nothing ever reaches Telegram.
+
+:::mental
+updates.command('start') -> real dispatch -> handler -> captured `sent`
+:::
+
+That fidelity is the point. A guard that denies, a pipe that transforms an arg,
+a `parse_mode` default, an interceptor that mutates the request — all of it runs,
+because it's the same pipeline, not a re-implementation. You assert on what the
+bot _would have sent_, and the wire is the only fake.
+
+## Quickstart
+
+A testbed is framework-agnostic — nothing here imports Jest, the harness just
+returns plain data. Register a router, dispatch an update, assert on the reply:
+
+:::code[start.router.ts]
+
+```ts
+import { Router, Command, Message } from 'nestgram';
+
+@Router()
+export class StartRouter {
+  @Command('start')
+  start(message: Message): string {
+    return `Hi ${message.from?.first_name}`;
+  }
+}
+```
+
+:::
+
+:::code[start.router.spec.ts]
+
+```ts
+import { NestgramTestbed, updates } from 'nestgram/testing';
+import { StartRouter } from './start.router';
+
+describe('StartRouter', () => {
+  let bot: NestgramTestbed;
+
+  beforeEach(async () => {
+    bot = await NestgramTestbed.create({ routers: [StartRouter] });
+  });
+
+  afterEach(() => bot.close());
+
+  it('greets the sender', async () => {
+    await bot.dispatch(updates.command('start'));
+
+    expect(bot.lastMessage?.text).toBe('Hi Test');
+  });
+});
+```
+
+:::
+
+`create` boots a Nest application context with **no transport** — polling and
+webhook are off, so the network is never touched. `close()` tears it down; call
+it in `afterEach`.
+
+:::tip
+`import { NestgramTestbed, updates } from 'nestgram/testing'`. The subpath keeps
+the harness out of your runtime bundle. The symbols are also re-exported from the
+main `nestgram` barrel if you prefer a single import.
+:::
+
+### What `create` accepts
+
+Pass `routers` (plus any `providers` they depend on) for a focused router test,
+or `imports` (e.g. your real `AppModule`) for a wider one — or both.
+
+| Option                      | Type                        | What it does                                                                                              |
+| --------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `routers`                   | `Type[]`                    | Router classes (and other providers) to register.                                                         |
+| `providers`                 | `Provider[]`                | Extra providers the routers depend on — services, mocks, …                                                |
+| `imports`                   | `ModuleMetadata['imports']` | Whole modules to bring in (e.g. `AppModule`, `SessionsModule`).                                           |
+| `token`                     | `string`                    | The bot token. Any non-empty string — it's never sent anywhere.                                           |
+| `parseMode`                 | `ParseModeValue`            | Default `parse_mode` for sends, mirroring `NestgramModule.forRoot`.                                       |
+| `autoAnswerCallbackQueries` | `boolean`                   | Auto-answer unanswered callback queries (on by default).                                                  |
+| `apiInterceptors`           | `Type<ApiInterceptor>[]`    | Outbound interceptors to test; they run **before** capture, so their request mutations show up in `sent`. |
+
+## Building updates
+
+`updates` is a ready-to-use factory of well-formed fake updates. Every builder
+fills sensible defaults — a private chat, a non-bot sender, an auto-incrementing
+`update_id` / `message_id`, a fixed `date` — so a test states only what matters:
+
+```ts
+await bot.dispatch(updates.message('hi'));
+await bot.dispatch(updates.command('start', 'ref_42')); // → text '/start ref_42'
+await bot.dispatch(updates.callbackQuery('menu:open'));
+```
+
+The builder set covers every routable update kind:
+
+| Builder                                 | Update kind           | Signature                                                 |
+| --------------------------------------- | --------------------- | --------------------------------------------------------- |
+| `updates.message(text, o?)`             | `message`             | a plain text message                                      |
+| `updates.command(name, args?, o?)`      | `message`             | `command('start')` → `/start`; the slash is added for you |
+| `updates.editedMessage(text, o?)`       | `edited_message`      | an edited message                                         |
+| `updates.channelPost(text, o?)`         | `channel_post`        | a post in a `channel` chat, no `from`                     |
+| `updates.editedChannelPost(text, o?)`   | `edited_channel_post` | an edited channel post                                    |
+| `updates.photo(caption?, o?)`           | `message`             | a message carrying a `photo` (+ caption)                  |
+| `updates.callbackQuery(data, o?)`       | `callback_query`      | an inline-button tap, carrying `data`                     |
+| `updates.inlineQuery(query, o?)`        | `inline_query`        | `@bot query` typed in any chat                            |
+| `updates.myChatMember(o?)`              | `my_chat_member`      | the bot's own membership changing                         |
+| `updates.chatMember(o?)`                | `chat_member`         | another member's status changing                          |
+| `updates.chatJoinRequest(o?)`           | `chat_join_request`   | a request to join a chat needing approval                 |
+| `updates.preCheckoutQuery(payload, o?)` | `pre_checkout_query`  | a pre-checkout query to answer                            |
+| `updates.shippingQuery(payload, o?)`    | `shipping_query`      | a shipping query for a flexible invoice                   |
+| `updates.poll(question, o?)`            | `poll`                | a poll state update                                       |
+| `updates.pollAnswer(optionIds, o?)`     | `poll_answer`         | a user's answer in a non-anonymous poll                   |
+| `updates.messageReaction(emoji, o?)`    | `message_reaction`    | a reaction added to a message                             |
+
+Each builder takes a final `UpdateOverrides` (`o`) to change just the parts that
+matter. Top-level keys replace the defaults, so pass a whole nested object to
+override a nested default wholesale:
+
+```ts
+await bot.dispatch(
+  updates.command('start', undefined, {
+    from: { first_name: 'Bob', id: 42 }, // merged over the default test user
+    chat: { id: -1001, type: 'supergroup' }, // replaces the default private chat
+  }),
+);
+```
+
+| Override    | Overrides                                                 |
+| ----------- | --------------------------------------------------------- |
+| `updateId`  | the synthetic `update_id` (defaults to auto-incrementing) |
+| `from`      | the sender — merged over the default test user            |
+| `chat`      | the chat — merged over the default private chat           |
+| `messageId` | the `message_id` of the synthetic message                 |
+| `date`      | the Unix `date` of the synthetic message                  |
+
+### The `raw` escape hatch
+
+For any update without a dedicated builder, hand-build the partial and let `raw`
+fill in `update_id` (auto-incrementing) when absent:
+
+```ts
+await bot.dispatch(
+  updates.raw({
+    poll_answer: {
+      poll_id: 'hand_built',
+      option_ids: [0],
+      option_persistent_ids: ['opt_0'],
+    },
+  }),
+);
+```
+
+:::note
+Need an isolated `update_id` counter for one test? Instantiate your own
+`new UpdateFactory()` — the shared `updates` singleton is just one instance.
+:::
+
+## Asserting what the bot sent
+
+Every captured call lands on `sent` in send order. Each is a `SentCall` —
+`{ method, payload }` — where `payload` is the **final** request, after every
+built-in interceptor (default `parse_mode`, rich messages, …) has run, so it's
+exactly what would have gone on the wire.
+
+```ts
+await bot.dispatch(updates.command('start'));
+
+expect(bot.sent).toHaveLength(1);
+expect(bot.sent[0]).toMatchObject({
+  method: 'sendMessage',
+  payload: { text: 'Hi Test' },
+});
+```
+
+Three accessors cover the common assertions:
+
+- **`lastMessage`** — the payload of the most recent `sendMessage`, typed as the
+  generated `sendMessage` options so `.text` / `.parse_mode` / `.reply_markup`
+  autocomplete. The "what did the bot reply?" one-liner.
+- **`lastCall`** — the most recent captured call of any method (`{ method, payload }`).
+- **`calls(key)`** — every captured call for one method, in order. Key it by the
+  **command class** (`bot.calls(SendMessage)`, preferred — no magic string and the
+  payload is typed) or the bare method name (`bot.calls('sendMessage')`, the
+  escape hatch).
+
+```ts
+import { SendMessage } from 'nestgram';
+
+await bot.dispatch(updates.command('start'));
+await bot.dispatch(updates.message('again'));
+
+expect(bot.calls(SendMessage)).toHaveLength(2);
+expect(bot.calls(SendMessage)[0].payload.text).toBe('Hi Test');
+```
+
+`reset()` forgets all captured calls and the last error (registered stubs stay)
+— handy between cases that share one testbed.
+
+## Stubbing API results
+
+When a handler **reads back** a send result — `const sent = await message.answer('hi');`
+then uses `sent.message_id` — stub the raw Telegram response with `onApi`. Return
+the raw Telegram shape; the harness runs the method's own `wrap()` over it, so the
+handler still receives a rich `Message` / `User` / …:
+
+```ts
+import { SendMessage } from 'nestgram';
+
+bot.onApi(SendMessage, () => ({
+  message_id: 999,
+  date: 1,
+  chat: { id: 1, type: 'private' },
+  text: 'stubbed',
+}));
+
+await bot.dispatch(updates.message('hi'));
+```
+
+The responder receives the captured `ApiRequest` and may be sync or async — branch
+on the payload to return different results per call. Key it by the command class
+(preferred) or the bare method name. `getMe` already returns a default identity
+without a stub.
+
+## Testing guards & errors
+
+The real dispatcher swallows handler errors — it logs and moves on, so one bad
+update can't kill polling — and `dispatch()` keeps that fidelity. The error is
+still observable on `lastError`:
+
+```ts
+await bot.dispatch(updates.command('boom')); // resolves, doesn't throw
+
+expect(bot.lastError).toBeInstanceOf(Error);
+expect((bot.lastError as Error).message).toBe('handler exploded');
+```
+
+For an assertion-style test, pass `{ rethrow: true }` to re-throw the captured
+error so `rejects` works:
+
+```ts
+await expect(
+  bot.dispatch(updates.command('boom'), { rethrow: true }),
+).rejects.toThrow('handler exploded');
+```
+
+A **guard denial** surfaces the same way. Nest guards reject by throwing
+`ForbiddenException`, so a blocked handler is distinguishable from a clean
+no-match — `lastError` holds the exception in the first case, `undefined` in the
+second:
+
+```ts
+await bot.dispatch(updates.command('secret')); // @UseGuards(DenyGuard)
+
+expect(bot.sent).toHaveLength(0);
+expect(bot.lastError).toBeInstanceOf(ForbiddenException);
+```
+
+:::guardrail[only in Nestgram]
+This is the same pipeline production runs, not a stand-in. The guard, the filter,
+the interceptors — your real classes, resolved through DI and run via ECC. A test
+that passes here passes because the engine genuinely routed and executed the
+update, the way polling would.
+:::
+
+## Notes & limits
+
+- **Captures are one flat list.** All sends collapse into a single `sent`
+  list regardless of which bot produced them — multi-bot setups aren't partitioned
+  per token. For a multi-bot scenario, test one bot's routers per testbed.
+- **Errors clear per dispatch.** Each `dispatch()` resets `lastError` first, so it
+  always reflects the most recent update — a clean dispatch leaves it `undefined`.
+- **The wire is the only fake.** Sessions, i18n, FSM, the throttler, your own
+  interceptors — everything above the HTTP boundary is real. If a behaviour depends
+  on a module, import it (or your `AppModule`) so it's wired up the same as in
+  production.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,3 +25,7 @@ export * from './engine/execution';
 export * from './engine/dispatcher';
 export * from './engine/source';
 export * from './module';
+
+// Testing utilities (dispatch fake updates against your routers). Jest-agnostic
+// and dependency-light — safe to ship in the barrel.
+export * from './testing';

--- a/lib/testing/api-capture.store.ts
+++ b/lib/testing/api-capture.store.ts
@@ -1,6 +1,13 @@
 import type { ApiRequest } from '../api/request';
 import { GetMe } from '../api/methods';
-import type { ApiResponder, SentCall, TestUser } from './testing.types';
+import type {
+  ApiResponder,
+  CommandClass,
+  MethodKey,
+  OptionsOf,
+  SentCall,
+  TestUser,
+} from './testing.types';
 
 /** The synthetic bot identity `getMe` returns by default (no network). */
 const DEFAULT_BOT_IDENTITY: TestUser = {
@@ -25,15 +32,52 @@ export class ApiCaptureStore {
   readonly sent: SentCall[] = [];
   /** Per-method response stubs registered via {@link onApi}. */
   private readonly responders = new Map<string, ApiResponder>();
+  /** The most recent handler error a {@link CaptureErrorFilter} recorded. */
+  private capturedError: unknown;
 
-  /** Register (or replace) the stubbed RAW result for one Bot API method. */
-  onApi(method: string, responder: ApiResponder): void {
-    this.responders.set(method, responder);
+  /**
+   * Reads the Bot API method name off a {@link MethodKey}: the bare string as-is,
+   * or a throwaway instance of a command class (`new SendMessage().method`) so the
+   * caller can name the method by its typed command, not a string literal.
+   *
+   * The instance is built with no payload on purpose — only `.method` (a
+   * class-level readonly string, set independently of the payload) is read, never
+   * the payload itself.
+   */
+  static methodNameOf(key: MethodKey): string {
+    if (typeof key === 'string') {
+      return key;
+    }
+    return new key().method;
   }
 
-  /** Forget all captured calls (the registered responders stay). */
+  /** Register (or replace) the stubbed RAW result for one Bot API method. */
+  onApi(key: MethodKey, responder: ApiResponder): void {
+    this.responders.set(ApiCaptureStore.methodNameOf(key), responder);
+  }
+
+  /** Every captured call for one method, in send order. */
+  calls<C extends CommandClass>(key: C): SentCall<OptionsOf<C>>[];
+  calls(key: string): SentCall[];
+  calls(key: MethodKey): SentCall<unknown>[] {
+    const method = ApiCaptureStore.methodNameOf(key);
+    return this.sent.filter((call) => call.method === method);
+  }
+
+  /** Record a handler error (called by {@link CaptureErrorFilter}). */
+  recordError(error: unknown): void {
+    this.capturedError = error;
+  }
+
+  /** The most recent handler error, or `undefined` if none was thrown. */
+  get lastError(): unknown {
+    return this.capturedError;
+  }
+
+  /** Forget all captured calls and the last error (registered responders stay). */
   reset(): void {
     this.sent.length = 0;
+    this.capturedError = undefined;
   }
 
   /**

--- a/lib/testing/api-capture.store.ts
+++ b/lib/testing/api-capture.store.ts
@@ -1,0 +1,60 @@
+import type { ApiRequest } from '../api/request';
+import { GetMe } from '../api/methods';
+import type { ApiResponder, SentCall, TestUser } from './testing.types';
+
+/** The synthetic bot identity `getMe` returns by default (no network). */
+const DEFAULT_BOT_IDENTITY: TestUser = {
+  id: 42,
+  is_bot: true,
+  first_name: 'Test Bot',
+  username: 'test_bot',
+};
+
+/**
+ * Records every outgoing Bot API call and resolves a stubbed response for it —
+ * the in-memory state behind {@link CaptureBotService}. Shared by reference
+ * between the capturing `BotService` (which writes to it on each call) and the
+ * {@link NestgramTestbed} the author asserts on (which reads it).
+ *
+ * Jest-agnostic on purpose: it holds plain data and returns plain values, so
+ * `lib/testing` never imports a test framework and nothing test-only leaks into
+ * the runtime bundle.
+ */
+export class ApiCaptureStore {
+  /** Every captured call, in send order. */
+  readonly sent: SentCall[] = [];
+  /** Per-method response stubs registered via {@link onApi}. */
+  private readonly responders = new Map<string, ApiResponder>();
+
+  /** Register (or replace) the stubbed RAW result for one Bot API method. */
+  onApi(method: string, responder: ApiResponder): void {
+    this.responders.set(method, responder);
+  }
+
+  /** Forget all captured calls (the registered responders stay). */
+  reset(): void {
+    this.sent.length = 0;
+  }
+
+  /**
+   * Record one call and resolve its RAW result. Called by {@link CaptureBotService}
+   * with the FINAL request (post-interceptors). A registered responder wins; else
+   * `getMe` returns the default identity and every other method returns an empty
+   * object — enough for the common `wrap()` to build a (sparse) rich result.
+   */
+  async capture(request: ApiRequest): Promise<unknown> {
+    // A shallow copy is enough: capture is the terminal step (it short-circuits
+    // the wire), so nothing mutates the payload after this point — nested objects
+    // shared by reference can't be retro-mutated.
+    this.sent.push({ method: request.method, payload: { ...request.payload } });
+
+    const responder = this.responders.get(request.method);
+    if (responder) {
+      return responder(request);
+    }
+    if (request.method === new GetMe().method) {
+      return DEFAULT_BOT_IDENTITY;
+    }
+    return {};
+  }
+}

--- a/lib/testing/capture-error.filter.ts
+++ b/lib/testing/capture-error.filter.ts
@@ -1,0 +1,32 @@
+import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
+
+import { ApiCaptureStore } from './api-capture.store';
+
+/**
+ * Records handler errors so a test can assert a handler threw.
+ *
+ * Without this, a throwing handler is invisible: the real {@link UpdateDispatcher}
+ * try/catches every error and only logs it (correct for production — one bad
+ * update mustn't kill polling), so the test sees an empty `sent` —
+ * indistinguishable from a guard block or a no-match.
+ *
+ * Registered as a global `APP_FILTER`, this filter sits in the same Nest pipeline
+ * the handler runs through (via `ExternalContextCreator`), so a thrown error
+ * reaches it BEFORE the dispatcher's catch. It records the error to the capture
+ * store and then RE-THROWS it, so the error keeps flowing exactly as in
+ * production: the dispatcher's own try/catch logs it and skips the post-handler
+ * stage `commit` (sessions stay unpersisted on a thrown handler). Recording
+ * before re-throwing is the only added behaviour — control flow is unchanged.
+ *
+ * The testbed reads {@link ApiCaptureStore.lastError} afterwards for assertions
+ * and, only when `{ rethrow: true }`, re-surfaces it to the caller.
+ */
+@Catch()
+export class CaptureErrorFilter implements ExceptionFilter {
+  constructor(private readonly store: ApiCaptureStore) {}
+
+  catch(exception: unknown, _host: ArgumentsHost): never {
+    this.store.recordError(exception);
+    throw exception;
+  }
+}

--- a/lib/testing/capture.interceptor.ts
+++ b/lib/testing/capture.interceptor.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { from, type Observable } from 'rxjs';
+
+import { BotService } from '../api/bot.service';
+import {
+  ApiCallHandler,
+  ApiExecutionContext,
+  ApiInterceptor,
+} from '../api/request';
+import { ApiCaptureStore } from './api-capture.store';
+
+/**
+ * Captures every outgoing Bot API call instead of sending it — the seam that
+ * makes {@link NestgramTestbed} network-free.
+ *
+ * Registered as the LAST entry of a bot's `apiInterceptors`, so it sits just
+ * above the throttler and the wire call: the built-in mutators (default
+ * parse-mode, rich-messages, …) have already run, so the request it records is
+ * exactly what would have gone out. It then short-circuits — it never calls
+ * `next.handle()`, so neither the throttler nor `fetch` runs — and emits the
+ * stubbed result through the method's own `wrap()`, so a handler that awaits the
+ * send still gets a real rich object (`Message`, `User`, …).
+ *
+ * `ModuleRef` resolves the `BotService` lazily at call time (not in the
+ * constructor) to break the obvious cycle: the bot is built FROM the pipeline this
+ * interceptor lives in.
+ */
+@Injectable()
+export class CaptureInterceptor implements ApiInterceptor {
+  constructor(
+    private readonly store: ApiCaptureStore,
+    private readonly moduleRef: ModuleRef,
+  ) {}
+
+  intercept<T>(
+    context: ApiExecutionContext,
+    _next: ApiCallHandler<T>,
+  ): Observable<T> {
+    return from(this.captureAndStub<T>(context));
+  }
+
+  private async captureAndStub<T>(context: ApiExecutionContext): Promise<T> {
+    const raw = await this.store.capture(context.getRequest());
+    const method = context.getMethod();
+    if (!method.wrap) {
+      return raw as T;
+    }
+    const bot = this.moduleRef.get(BotService, { strict: false });
+    return method.wrap(raw, bot) as T;
+  }
+}

--- a/lib/testing/index.ts
+++ b/lib/testing/index.ts
@@ -3,11 +3,12 @@
  * on what the bot would send, with no Telegram connection.
  *
  * Jest-agnostic: nothing here imports a test framework; the harness returns plain
- * data you assert on with your own runner. Import from `nestgram` (the main
- * barrel) or, where the package's subpath exports allow it, `nestgram/testing`.
+ * data you assert on with your own runner. Import from `nestgram/testing` (kept
+ * out of the runtime bundle) or from the main `nestgram` barrel.
  */
 export * from './nestgram-testbed';
 export * from './update-factory';
 export * from './api-capture.store';
 export * from './capture.interceptor';
+export * from './capture-error.filter';
 export * from './testing.types';

--- a/lib/testing/index.ts
+++ b/lib/testing/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Testing utilities — dispatch fake updates against your real routers and assert
+ * on what the bot would send, with no Telegram connection.
+ *
+ * Jest-agnostic: nothing here imports a test framework; the harness returns plain
+ * data you assert on with your own runner. Import from `nestgram` (the main
+ * barrel) or, where the package's subpath exports allow it, `nestgram/testing`.
+ */
+export * from './nestgram-testbed';
+export * from './update-factory';
+export * from './api-capture.store';
+export * from './capture.interceptor';
+export * from './testing.types';

--- a/lib/testing/nestgram-testbed.spec.ts
+++ b/lib/testing/nestgram-testbed.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * Dogfoods the testing harness: a sample bot tested entirely through
+ * {@link NestgramTestbed}, exercising the REAL engine (discovery, matching, the
+ * Nest pipeline via ECC) with no Telegram connection. Also asserts the harness
+ * never touches the network.
+ */
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UseGuards,
+} from '@nestjs/common';
+import type { Observable } from 'rxjs';
+
+import { Action } from '../decorators/listeners/action.decorator';
+import { Command } from '../decorators/listeners/command.decorator';
+import { OnMessage } from '../decorators/listeners/on-message.decorator';
+import { Router } from '../decorators/injectable/router.decorator';
+import { CallbackData } from '../decorators/params/callback-data.decorator';
+import { CallbackQuery } from '../events/callback-query';
+import { Message } from '../events/message';
+import {
+  ApiCallHandler,
+  ApiExecutionContext,
+  ApiInterceptor,
+} from '../api/request';
+import { ParseMode } from '../api/parse-mode';
+import { NestgramTestbed } from './nestgram-testbed';
+import { updates, UpdateFactory } from './update-factory';
+
+@Injectable()
+class DenyGuard implements CanActivate {
+  canActivate(_context: ExecutionContext): boolean {
+    return false;
+  }
+}
+
+@Router()
+class SampleRouter {
+  @Command('start')
+  start(message: Message): string {
+    return `Hi ${message.from?.first_name}`;
+  }
+
+  @Action('menu:open')
+  async openMenu(
+    query: CallbackQuery,
+    @CallbackData() data?: string,
+  ): Promise<void> {
+    // A real handler edits/answers the attached message; the fake callback
+    // update carries one, so `message` is present.
+    const message = query.message;
+    if (message) {
+      await message.answer(`menu opened via ${data}`);
+    }
+  }
+
+  @UseGuards(DenyGuard)
+  @Command('secret')
+  secret(): string {
+    return 'you should never see this';
+  }
+
+  @OnMessage()
+  echo(message: Message): Promise<unknown> {
+    return message.answer(`echo: ${message.text}`);
+  }
+}
+
+@Injectable()
+class TagInterceptor implements ApiInterceptor {
+  intercept<T>(
+    context: ApiExecutionContext,
+    next: ApiCallHandler<T>,
+  ): Observable<T> {
+    const request = context.getRequest();
+    if (typeof request.payload.text === 'string') {
+      request.payload.text = `[tagged] ${request.payload.text}`;
+    }
+    return next.handle();
+  }
+}
+
+describe('NestgramTestbed', () => {
+  let bot: NestgramTestbed;
+
+  beforeEach(async () => {
+    bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+  });
+
+  afterEach(async () => {
+    await bot.close();
+  });
+
+  it('matches a command and captures the reply (return string)', async () => {
+    await bot.dispatch(updates.command('start'));
+
+    expect(bot.sent).toHaveLength(1);
+    expect(bot.sent[0]).toMatchObject({
+      method: 'sendMessage',
+      payload: { text: 'Hi Test' },
+    });
+    expect(bot.lastMessage?.text).toBe('Hi Test');
+  });
+
+  it('matches a callback query and captures message.answer()', async () => {
+    await bot.dispatch(updates.callbackQuery('menu:open'));
+
+    expect(bot.lastMessage?.text).toBe('menu opened via menu:open');
+  });
+
+  it('a denying guard blocks the handler — nothing is sent', async () => {
+    // Control: a matching command DOES run (proved above), so an empty capture
+    // here is the guard, not a routing failure.
+    await bot.dispatch(updates.command('secret'));
+
+    expect(bot.sent).toHaveLength(0);
+  });
+
+  it('routes plain text to @OnMessage, not a command', async () => {
+    await bot.dispatch(updates.message('just text'));
+
+    expect(bot.lastMessage?.text).toBe('echo: just text');
+  });
+
+  it('runs multiple updates in order, accumulating captures', async () => {
+    await bot.dispatch(updates.command('start'));
+    await bot.dispatch(updates.message('again'));
+
+    expect(bot.sent.map((call) => call.payload.text)).toEqual([
+      'Hi Test',
+      'echo: again',
+    ]);
+  });
+
+  it('reset() clears captured calls', async () => {
+    await bot.dispatch(updates.command('start'));
+    bot.reset();
+
+    expect(bot.sent).toHaveLength(0);
+  });
+
+  it('overrides the sender via update overrides', async () => {
+    await bot.dispatch(
+      updates.command('start', undefined, { from: { first_name: 'Bob' } }),
+    );
+
+    expect(bot.lastMessage?.text).toBe('Hi Bob');
+  });
+});
+
+describe('NestgramTestbed — pipeline + stubs', () => {
+  it('captures the request AFTER built-in interceptors (default parse_mode)', async () => {
+    const bot = await NestgramTestbed.create({
+      routers: [SampleRouter],
+      parseMode: ParseMode.Html,
+    });
+
+    await bot.dispatch(updates.command('start'));
+
+    expect(bot.lastMessage?.parse_mode).toBe('HTML');
+    await bot.close();
+  });
+
+  it('runs a user apiInterceptor before capture (its mutation shows in sent)', async () => {
+    const bot = await NestgramTestbed.create({
+      routers: [SampleRouter],
+      apiInterceptors: [TagInterceptor],
+    });
+
+    await bot.dispatch(updates.command('start'));
+
+    expect(bot.lastMessage?.text).toBe('[tagged] Hi Test');
+    await bot.close();
+  });
+
+  it('onApi() stubs the raw result a handler reads back', async () => {
+    const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+    bot.onApi('sendMessage', () => ({
+      message_id: 999,
+      date: 1,
+      chat: { id: 1, type: 'private' },
+      text: 'stubbed',
+    }));
+
+    // The @OnMessage handler returns message.answer(...) — its resolved value is
+    // the wrapped Message built from the stub.
+    await bot.dispatch(updates.message('hi'));
+
+    expect(bot.lastCall?.method).toBe('sendMessage');
+    await bot.close();
+  });
+});
+
+describe('NestgramTestbed — no network', () => {
+  it('never calls fetch while dispatching and sending', async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchSpy = jest.fn(() => {
+      throw new Error('network was touched');
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    try {
+      const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+      await bot.dispatch(updates.command('start'));
+      await bot.dispatch(updates.message('text'));
+      await bot.close();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('UpdateFactory', () => {
+  it('auto-increments update_id across builders', () => {
+    const factory = new UpdateFactory();
+    const a = factory.message('a');
+    const b = factory.callbackQuery('x');
+
+    expect(b.update_id).toBe(a.update_id + 1);
+  });
+
+  it('builds /command text from the bare command name and args', () => {
+    const factory = new UpdateFactory();
+    expect(factory.command('start').message?.text).toBe('/start');
+    expect(factory.command('start', 'ref_42').message?.text).toBe(
+      '/start ref_42',
+    );
+  });
+
+  it('fills sensible defaults a handler can read', () => {
+    const factory = new UpdateFactory();
+    const update = factory.message('hi');
+
+    expect(update.message?.chat).toMatchObject({ id: 1000, type: 'private' });
+    expect(update.message?.from).toMatchObject({ is_bot: false });
+  });
+});

--- a/lib/testing/nestgram-testbed.spec.ts
+++ b/lib/testing/nestgram-testbed.spec.ts
@@ -7,6 +7,7 @@
 import {
   CanActivate,
   ExecutionContext,
+  ForbiddenException,
   Injectable,
   UseGuards,
 } from '@nestjs/common';
@@ -19,6 +20,7 @@ import { Router } from '../decorators/injectable/router.decorator';
 import { CallbackData } from '../decorators/params/callback-data.decorator';
 import { CallbackQuery } from '../events/callback-query';
 import { Message } from '../events/message';
+import { SendMessage } from '../api/methods';
 import {
   ApiCallHandler,
   ApiExecutionContext,
@@ -59,6 +61,11 @@ class SampleRouter {
   @Command('secret')
   secret(): string {
     return 'you should never see this';
+  }
+
+  @Command('boom')
+  boom(): string {
+    throw new Error('handler exploded');
   }
 
   @OnMessage()
@@ -174,9 +181,9 @@ describe('NestgramTestbed — pipeline + stubs', () => {
     await bot.close();
   });
 
-  it('onApi() stubs the raw result a handler reads back', async () => {
+  it('onApi() stubs the raw result a handler reads back (command class key)', async () => {
     const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
-    bot.onApi('sendMessage', () => ({
+    bot.onApi(SendMessage, () => ({
       message_id: 999,
       date: 1,
       chat: { id: 1, type: 'private' },
@@ -188,6 +195,101 @@ describe('NestgramTestbed — pipeline + stubs', () => {
     await bot.dispatch(updates.message('hi'));
 
     expect(bot.lastCall?.method).toBe('sendMessage');
+    await bot.close();
+  });
+
+  it('onApi() also accepts the bare method name (escape hatch)', async () => {
+    const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+    bot.onApi('sendMessage', () => ({
+      message_id: 7,
+      date: 1,
+      chat: { id: 1, type: 'private' },
+      text: 'stubbed',
+    }));
+
+    await bot.dispatch(updates.message('hi'));
+
+    expect(bot.lastCall?.method).toBe('sendMessage');
+    await bot.close();
+  });
+
+  it('calls() finds every send for a method (class and string keys agree)', async () => {
+    const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+
+    await bot.dispatch(updates.command('start'));
+    await bot.dispatch(updates.message('again'));
+
+    expect(bot.calls(SendMessage)).toHaveLength(2);
+    expect(bot.calls('sendMessage')).toHaveLength(2);
+    expect(bot.calls(SendMessage)[0].payload.text).toBe('Hi Test');
+    await bot.close();
+  });
+});
+
+describe('NestgramTestbed — error paths', () => {
+  it('records a thrown handler error on lastError, still swallowing by default', async () => {
+    const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+
+    // Default dispatch resolves (production fidelity — the dispatcher logs and
+    // moves on), but the error is observable.
+    await expect(
+      bot.dispatch(updates.command('boom')),
+    ).resolves.toBeUndefined();
+
+    expect(bot.lastError).toBeInstanceOf(Error);
+    expect((bot.lastError as Error).message).toBe('handler exploded');
+    expect(bot.sent).toHaveLength(0);
+    await bot.close();
+  });
+
+  it('rethrows the captured error when { rethrow: true }', async () => {
+    const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+
+    await expect(
+      bot.dispatch(updates.command('boom'), { rethrow: true }),
+    ).rejects.toThrow('handler exploded');
+    await bot.close();
+  });
+
+  it('leaves lastError undefined on a clean dispatch', async () => {
+    const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+
+    await bot.dispatch(updates.command('start'));
+
+    expect(bot.lastError).toBeUndefined();
+    await bot.close();
+  });
+
+  it('surfaces a guard denial as the thrown ForbiddenException', async () => {
+    // A Nest guard denies by throwing ForbiddenException; that real exception
+    // flows through the same filter, so it is observable on lastError — letting a
+    // test assert the guard fired, distinct from a clean no-match (undefined).
+    const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+
+    await bot.dispatch(updates.command('secret'));
+
+    expect(bot.sent).toHaveLength(0);
+    expect(bot.lastError).toBeInstanceOf(ForbiddenException);
+    await bot.close();
+  });
+
+  it('leaves lastError undefined when nothing matches', async () => {
+    const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+
+    await bot.dispatch(updates.callbackQuery('no:such:action'));
+
+    expect(bot.lastError).toBeUndefined();
+    await bot.close();
+  });
+
+  it('clears a prior error on the next clean dispatch', async () => {
+    const bot = await NestgramTestbed.create({ routers: [SampleRouter] });
+
+    await bot.dispatch(updates.command('boom'));
+    expect(bot.lastError).toBeInstanceOf(Error);
+
+    await bot.dispatch(updates.command('start'));
+    expect(bot.lastError).toBeUndefined();
     await bot.close();
   });
 });

--- a/lib/testing/nestgram-testbed.ts
+++ b/lib/testing/nestgram-testbed.ts
@@ -1,0 +1,189 @@
+import {
+  DynamicModule,
+  Global,
+  Module,
+  ModuleMetadata,
+  Provider,
+  Type,
+} from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import type { INestApplicationContext } from '@nestjs/common';
+
+import type { RawUpdate } from '../events/raw-update.types';
+import { SendMessage } from '../api/methods';
+import type { ApiInterceptor } from '../api/request';
+import type { ParseModeValue } from '../api/parse-mode';
+import { UpdateDispatcher } from '../engine/dispatcher';
+import { NestgramModule } from '../module';
+import { ApiCaptureStore } from './api-capture.store';
+import { CaptureInterceptor } from './capture.interceptor';
+import type { ApiResponder, SentCall } from './testing.types';
+
+/**
+ * What {@link NestgramTestbed.create} accepts. Provide EITHER `routers` (+ any
+ * `providers`) for a focused router test, OR `imports` (e.g. your real
+ * `AppModule`) for a wider one — or both. The bot starts with NO transport
+ * (polling/webhook off), so nothing ever reaches the network; the harness drives
+ * the real {@link UpdateDispatcher} directly.
+ */
+export interface TestbedOptions extends Pick<ModuleMetadata, 'imports'> {
+  /** Router classes (and other providers) to register for this test. */
+  routers?: Type[];
+  /** Extra providers the routers depend on (services, mocks, …). */
+  providers?: Provider[];
+  /** The bot token (any non-empty string — it is never sent anywhere). */
+  token?: string;
+  /** Default `parse_mode` for sends, mirroring `NestgramModule.forRoot`. */
+  parseMode?: ParseModeValue;
+  /** Auto-answer unanswered callback queries (on by default, as in production). */
+  autoAnswerCallbackQueries?: boolean;
+  /**
+   * Extra outbound API interceptors to test alongside the capture seam. They run
+   * before the capture, so their request mutations show up in `sent`.
+   */
+  apiInterceptors?: Type<ApiInterceptor>[];
+}
+
+/** The token the testbed uses when none is given — never sent anywhere. */
+const TEST_TOKEN = 'TEST:token';
+
+/** The Bot API method behind {@link NestgramTestbed.lastMessage} — read off the
+ * command class, not a bare string literal. */
+const SEND_MESSAGE_METHOD = new SendMessage({ chat_id: 0, text: '' }).method;
+
+/**
+ * Makes the per-testbed {@link ApiCaptureStore} resolvable app-wide, so the
+ * `CaptureInterceptor` Nest instantiates inside each (global) per-bot module
+ * injects THIS testbed's store. Built per `create()` with the right instance.
+ */
+@Global()
+@Module({})
+class CaptureStoreModule {
+  static withStore(store: ApiCaptureStore): DynamicModule {
+    return {
+      module: CaptureStoreModule,
+      providers: [{ provide: ApiCaptureStore, useValue: store }],
+      exports: [ApiCaptureStore],
+    };
+  }
+}
+
+/**
+ * Tests a bot's REAL routers and pipeline without a Telegram connection.
+ *
+ * It boots a Nest application context with the genuine engine — discovery builds
+ * the route table, {@link UpdateDispatcher} runs each update through the full Nest
+ * pipeline (stages, matching, guards/interceptors/pipes/filters via ECC) — and
+ * swaps only the HTTP boundary for capture, via a {@link CaptureInterceptor} on
+ * the bot's API pipeline. Every outgoing call is recorded on {@link sent} instead
+ * of sent; stub the responses a handler reads back with {@link onApi}.
+ *
+ * ```ts
+ * const bot = await NestgramTestbed.create({ routers: [StartRouter] });
+ * await bot.dispatch(updates.command('start'));
+ * expect(bot.lastMessage?.text).toBe('Hi');
+ * await bot.close();
+ * ```
+ */
+export class NestgramTestbed {
+  private constructor(
+    private readonly app: INestApplicationContext,
+    private readonly dispatcher: UpdateDispatcher,
+    private readonly store: ApiCaptureStore,
+  ) {}
+
+  static async create(options: TestbedOptions = {}): Promise<NestgramTestbed> {
+    const store = new ApiCaptureStore();
+    const rootModule = this.buildRootModule(options, store);
+    // createApplicationContext runs the full lifecycle, incl.
+    // OnApplicationBootstrap — where NestgramBootstrap builds the route table and
+    // pipeline stages. No transport is configured, so nothing touches the network.
+    const app = await NestFactory.createApplicationContext(rootModule, {
+      logger: false,
+    });
+    const dispatcher = app.get(UpdateDispatcher);
+    return new NestgramTestbed(app, dispatcher, store);
+  }
+
+  /**
+   * The root module: the user's routers/imports plus `NestgramModule.forRoot`
+   * with NO transport and the capture interceptor appended LAST (so it sees the
+   * fully-mutated request and short-circuits the wire), plus the global module
+   * carrying this testbed's capture store.
+   */
+  private static buildRootModule(
+    options: TestbedOptions,
+    store: ApiCaptureStore,
+  ): DynamicModule {
+    const userInterceptors = options.apiInterceptors ?? [];
+    @Module({
+      imports: [
+        CaptureStoreModule.withStore(store),
+        NestgramModule.forRoot({
+          token: options.token ?? TEST_TOKEN,
+          autoAnswerCallbackQueries: options.autoAnswerCallbackQueries,
+          parseMode: options.parseMode,
+          // Capture is the last interceptor: after the built-in mutators, just
+          // above the throttler/wire — so it records the final request and never
+          // lets the call go out.
+          apiInterceptors: [...userInterceptors, CaptureInterceptor],
+        }),
+        ...(options.imports ?? []),
+      ],
+      providers: [...(options.routers ?? []), ...(options.providers ?? [])],
+    })
+    class NestgramTestbedRootModule {}
+    return { module: NestgramTestbedRootModule };
+  }
+
+  /** Run one fake update through the real dispatcher (the full pipeline). */
+  async dispatch(update: RawUpdate): Promise<void> {
+    await this.dispatcher.dispatch(update);
+  }
+
+  /** Every captured outgoing API call, in send order. */
+  get sent(): readonly SentCall[] {
+    return this.store.sent;
+  }
+
+  /** The most recent captured call, or `undefined` if nothing was sent. */
+  get lastCall(): SentCall | undefined {
+    return this.store.sent[this.store.sent.length - 1];
+  }
+
+  /**
+   * The payload of the most recent `sendMessage` as a convenience accessor — the
+   * common "what did the bot reply?" assertion (`bot.lastMessage?.text`).
+   * `undefined` if no `sendMessage` was captured.
+   */
+  get lastMessage(): Record<string, unknown> | undefined {
+    for (let i = this.store.sent.length - 1; i >= 0; i -= 1) {
+      const call = this.store.sent[i];
+      if (call.method === SEND_MESSAGE_METHOD) {
+        return call.payload;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Stub the RAW result of a Bot API method, for a handler that reads a send
+   * result (e.g. `const sent = await message.answer('hi'); sent.message_id`). The
+   * harness runs the method's `wrap()` over what you return, so return the raw
+   * Telegram shape. `getMe` already returns a default identity without a stub.
+   */
+  onApi(method: string, responder: ApiResponder): this {
+    this.store.onApi(method, responder);
+    return this;
+  }
+
+  /** Forget all captured calls (registered `onApi` stubs stay) — between cases. */
+  reset(): void {
+    this.store.reset();
+  }
+
+  /** Tear down the Nest app (closes the application context). */
+  async close(): Promise<void> {
+    await this.app.close();
+  }
+}

--- a/lib/testing/nestgram-testbed.ts
+++ b/lib/testing/nestgram-testbed.ts
@@ -6,7 +6,7 @@ import {
   Provider,
   Type,
 } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import { APP_FILTER, NestFactory } from '@nestjs/core';
 import type { INestApplicationContext } from '@nestjs/common';
 
 import type { RawUpdate } from '../events/raw-update.types';
@@ -17,7 +17,26 @@ import { UpdateDispatcher } from '../engine/dispatcher';
 import { NestgramModule } from '../module';
 import { ApiCaptureStore } from './api-capture.store';
 import { CaptureInterceptor } from './capture.interceptor';
-import type { ApiResponder, SentCall } from './testing.types';
+import { CaptureErrorFilter } from './capture-error.filter';
+import type {
+  ApiResponder,
+  CommandClass,
+  MethodKey,
+  OptionsOf,
+  SentCall,
+  SentMessagePayload,
+} from './testing.types';
+
+/** Options for a single {@link NestgramTestbed.dispatch}. */
+export interface DispatchOptions {
+  /**
+   * Re-throw a handler error after capturing it, so a test can
+   * `await expect(bot.dispatch(u, { rethrow: true })).rejects.toThrow(...)`.
+   * Off by default — normal `dispatch()` swallows errors for production fidelity
+   * (the real dispatcher logs and moves on), exactly as polling would.
+   */
+  rethrow?: boolean;
+}
 
 /**
  * What {@link NestgramTestbed.create} accepts. Provide EITHER `routers` (+ any
@@ -46,10 +65,6 @@ export interface TestbedOptions extends Pick<ModuleMetadata, 'imports'> {
 
 /** The token the testbed uses when none is given — never sent anywhere. */
 const TEST_TOKEN = 'TEST:token';
-
-/** The Bot API method behind {@link NestgramTestbed.lastMessage} — read off the
- * command class, not a bare string literal. */
-const SEND_MESSAGE_METHOD = new SendMessage({ chat_id: 0, text: '' }).method;
 
 /**
  * Makes the per-testbed {@link ApiCaptureStore} resolvable app-wide, so the
@@ -130,15 +145,37 @@ export class NestgramTestbed {
         }),
         ...(options.imports ?? []),
       ],
-      providers: [...(options.routers ?? []), ...(options.providers ?? [])],
+      providers: [
+        // A global filter recording handler errors into the capture store, so a
+        // throwing handler is observably testable (see CaptureErrorFilter). It
+        // runs in the same ECC pipeline the handler does, ahead of the
+        // dispatcher's catch.
+        { provide: APP_FILTER, useClass: CaptureErrorFilter },
+        ...(options.routers ?? []),
+        ...(options.providers ?? []),
+      ],
     })
     class NestgramTestbedRootModule {}
     return { module: NestgramTestbedRootModule };
   }
 
-  /** Run one fake update through the real dispatcher (the full pipeline). */
-  async dispatch(update: RawUpdate): Promise<void> {
+  /**
+   * Run one fake update through the real dispatcher (the full pipeline).
+   *
+   * Errors a handler throws are recorded (assert via {@link lastError}) but
+   * swallowed by default, mirroring production — the real dispatcher logs and
+   * moves on so one bad update can't kill polling. Pass `{ rethrow: true }` to
+   * re-throw the captured error so `await expect(...).rejects` works.
+   */
+  async dispatch(
+    update: RawUpdate,
+    options: DispatchOptions = {},
+  ): Promise<void> {
+    this.store.recordError(undefined);
     await this.dispatcher.dispatch(update);
+    if (options.rethrow && this.store.lastError !== undefined) {
+      throw this.store.lastError;
+    }
   }
 
   /** Every captured outgoing API call, in send order. */
@@ -152,18 +189,42 @@ export class NestgramTestbed {
   }
 
   /**
-   * The payload of the most recent `sendMessage` as a convenience accessor — the
-   * common "what did the bot reply?" assertion (`bot.lastMessage?.text`).
-   * `undefined` if no `sendMessage` was captured.
+   * The error the last {@link dispatch} raised in the Nest pipeline, or
+   * `undefined` if it completed cleanly (or matched nothing). Lets a test assert
+   * a handler threw even though the dispatcher swallows it:
+   * `expect(bot.lastError).toBeInstanceOf(...)`. A guard denial surfaces here too
+   * (Nest guards reject by throwing `ForbiddenException`), so a guard block is
+   * distinguishable from a clean no-match (`undefined`).
    */
-  get lastMessage(): Record<string, unknown> | undefined {
-    for (let i = this.store.sent.length - 1; i >= 0; i -= 1) {
-      const call = this.store.sent[i];
-      if (call.method === SEND_MESSAGE_METHOD) {
-        return call.payload;
-      }
-    }
-    return undefined;
+  get lastError(): unknown {
+    return this.store.lastError;
+  }
+
+  /**
+   * Every captured call for one method, in send order — the generic finder for
+   * any Bot API method (edited messages, callback answers, …). Accepts the
+   * command class (`bot.calls(SendMessage)`, preferred) or the bare method name
+   * (`bot.calls('sendMessage')`, the escape hatch).
+   */
+  calls<C extends CommandClass>(key: C): SentCall<OptionsOf<C>>[];
+  calls(key: string): SentCall[];
+  calls(key: MethodKey): SentCall<unknown>[] {
+    // The branches look identical but aren't: each narrows `key` to one side of
+    // the union so it resolves against the store's matching `calls` overload — an
+    // overloaded method's impl signature isn't callable with the raw union.
+    return typeof key === 'string'
+      ? this.store.calls(key)
+      : this.store.calls(key);
+  }
+
+  /**
+   * The payload of the most recent `sendMessage` as a convenience accessor — the
+   * common "what did the bot reply?" assertion (`bot.lastMessage?.text`), typed
+   * as the generated `sendMessage` options so `.text`/`.parse_mode`/`.reply_markup`
+   * autocomplete. `undefined` if no `sendMessage` was captured.
+   */
+  get lastMessage(): SentMessagePayload | undefined {
+    return this.calls(SendMessage).at(-1)?.payload;
   }
 
   /**
@@ -171,13 +232,19 @@ export class NestgramTestbed {
    * result (e.g. `const sent = await message.answer('hi'); sent.message_id`). The
    * harness runs the method's `wrap()` over what you return, so return the raw
    * Telegram shape. `getMe` already returns a default identity without a stub.
+   *
+   * Key it by the command class (`onApi(SendMessage, …)`, preferred) or the bare
+   * method name (`onApi('sendMessage', …)`, the escape hatch).
    */
-  onApi(method: string, responder: ApiResponder): this {
-    this.store.onApi(method, responder);
+  onApi(key: MethodKey, responder: ApiResponder): this {
+    this.store.onApi(key, responder);
     return this;
   }
 
-  /** Forget all captured calls (registered `onApi` stubs stay) — between cases. */
+  /**
+   * Forget all captured calls and the last error (registered `onApi` stubs stay)
+   * — between cases.
+   */
   reset(): void {
     this.store.reset();
   }

--- a/lib/testing/testing.types.ts
+++ b/lib/testing/testing.types.ts
@@ -1,4 +1,28 @@
 import type { ApiRequest } from '../api/request';
+import type { ApiMethod } from '../api/methods';
+import type { SendMessageOptions } from '../api/methods';
+
+/**
+ * A command CLASS used as a method key — `onApi(SendMessage, …)`,
+ * `bot.calls(SendMessage)`. The harness reads the Bot API method name off a
+ * throwaway instance (`new SendMessage().method`), so a test names the method by
+ * its typed command rather than a bare string literal.
+ */
+export type CommandClass<TOptions = unknown> = new (
+  ...args: never[]
+) => ApiMethod<TOptions, unknown>;
+
+/**
+ * A method key for the assertion/stub finders: either the bare Bot API method
+ * name (`'sendMessage'`, the escape hatch) or the command class that carries it
+ * (`SendMessage` — preferred, no magic string).
+ */
+export type MethodKey = string | CommandClass;
+
+/** The payload (options) type a command class carries. */
+export type OptionsOf<C> = C extends CommandClass<infer TOptions>
+  ? TOptions
+  : never;
 
 /**
  * One outgoing Bot API call the harness captured instead of sending. `method` is
@@ -6,11 +30,18 @@ import type { ApiRequest } from '../api/request';
  * is the FINAL request payload — after every built-in interceptor (default
  * parse-mode, rich-messages, …) has run, so it is exactly what would have gone on
  * the wire. Assert on it with `expect(bot.sent[0]).toMatchObject({ method, payload })`.
+ *
+ * `TPayload` defaults to the generic request payload; the finders narrow it when
+ * the method is known (e.g. {@link NestgramTestbed.lastMessage} →
+ * {@link SendMessageOptions}).
  */
-export interface SentCall {
+export interface SentCall<TPayload = Record<string, unknown>> {
   method: string;
-  payload: Record<string, unknown>;
+  payload: TPayload;
 }
+
+/** The payload shape behind {@link NestgramTestbed.lastMessage} — a `sendMessage`. */
+export type SentMessagePayload = SendMessageOptions;
 
 /**
  * A stubbed Bot API response for one method. Receives the captured

--- a/lib/testing/testing.types.ts
+++ b/lib/testing/testing.types.ts
@@ -1,0 +1,59 @@
+import type { ApiRequest } from '../api/request';
+
+/**
+ * One outgoing Bot API call the harness captured instead of sending. `method` is
+ * the Bot API method name (`sendMessage`, `answerCallbackQuery`, …) and `payload`
+ * is the FINAL request payload — after every built-in interceptor (default
+ * parse-mode, rich-messages, …) has run, so it is exactly what would have gone on
+ * the wire. Assert on it with `expect(bot.sent[0]).toMatchObject({ method, payload })`.
+ */
+export interface SentCall {
+  method: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * A stubbed Bot API response for one method. Receives the captured
+ * {@link ApiRequest} and returns the RAW result Telegram would have put in
+ * `response.result` (the harness then runs the method's own `wrap()` over it, so
+ * the handler still gets a rich `Message`/`User`/…). Sync or async.
+ */
+export type ApiResponder = (request: ApiRequest) => unknown | Promise<unknown>;
+
+/**
+ * Per-field overrides for a fake update. A deep-ish merge target: top-level keys
+ * replace the defaults, so pass a whole nested object (e.g. `{ chat: {...} }`) to
+ * override a nested default wholesale.
+ */
+export interface UpdateOverrides {
+  /** Override the synthetic `update_id` (defaults to an auto-incrementing value). */
+  updateId?: number;
+  /** Override the sender (`from`) — merged over the default test user. */
+  from?: Partial<TestUser>;
+  /** Override the chat — merged over the default private chat. */
+  chat?: Partial<TestChat>;
+  /** Override the `message_id` of the synthetic message. */
+  messageId?: number;
+  /** Override the Unix `date` of the synthetic message (defaults to a fixed value). */
+  date?: number;
+}
+
+/** The minimal sender shape the update factory fills in (a Bot API `User`). */
+export interface TestUser {
+  id: number;
+  is_bot: boolean;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+  language_code?: string;
+}
+
+/** The minimal chat shape the update factory fills in (a Bot API `Chat`). */
+export interface TestChat {
+  id: number;
+  type: 'private' | 'group' | 'supergroup' | 'channel';
+  title?: string;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+}

--- a/lib/testing/update-factory-kinds.spec.ts
+++ b/lib/testing/update-factory-kinds.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * Dogfoods the {@link UpdateFactory} builders for the routable update kinds
+ * beyond the original four: each kind gets a router with the REAL `@On*`
+ * listener that targets it, the built update is dispatched through the genuine
+ * engine, and we assert it routed to the matching handler with the expected
+ * rich event type.
+ */
+import { Injectable } from '@nestjs/common';
+
+import { OnChannelPost } from '../decorators/listeners/on-channel-post.decorator';
+import { OnChatJoinRequest } from '../decorators/listeners/on-chat-join-request.decorator';
+import { OnChatMember } from '../decorators/listeners/on-chat-member.decorator';
+import { OnEditedChannelPost } from '../decorators/listeners/on-edited-channel-post.decorator';
+import { OnEditedMessage } from '../decorators/listeners/on-edited-message.decorator';
+import { OnMyChatMember } from '../decorators/listeners/on-my-chat-member.decorator';
+import { OnPhoto } from '../decorators/listeners/content.decorators';
+import { OnPoll } from '../decorators/listeners/on-poll.decorator';
+import { OnPollAnswer } from '../decorators/listeners/on-poll-answer.decorator';
+import { OnPreCheckoutQuery } from '../decorators/listeners/on-pre-checkout-query.decorator';
+import { OnMessageReaction } from '../decorators/listeners/on-message-reaction.decorator';
+import { OnShippingQuery } from '../decorators/listeners/on-shipping-query.decorator';
+import { Router } from '../decorators/injectable/router.decorator';
+import { ChatJoinRequest } from '../events/chat-join-request';
+import { ChatMemberUpdated } from '../events/chat-member-updated';
+import { Message } from '../events/message';
+import { MessageReactionUpdated } from '../events/message-reaction-updated';
+import { Poll } from '../events/poll';
+import { PollAnswer } from '../events/poll-answer';
+import { PreCheckoutQuery } from '../events/pre-checkout-query';
+import { ShippingQuery } from '../events/shipping-query';
+import { NestgramTestbed } from './nestgram-testbed';
+import { updates, UpdateFactory } from './update-factory';
+
+/** Collects the rich events each handler receives, so a test can assert routing. */
+@Injectable()
+class EventSink {
+  readonly events: unknown[] = [];
+
+  record(event: unknown): void {
+    this.events.push(event);
+  }
+}
+
+@Router()
+class KindsRouter {
+  constructor(private readonly sink: EventSink) {}
+
+  @OnEditedMessage()
+  editedMessage(message: Message): void {
+    this.sink.record(message);
+  }
+
+  @OnChannelPost()
+  channelPost(message: Message): void {
+    this.sink.record(message);
+  }
+
+  @OnEditedChannelPost()
+  editedChannelPost(message: Message): void {
+    this.sink.record(message);
+  }
+
+  @OnPhoto()
+  photo(message: Message): void {
+    this.sink.record(message);
+  }
+
+  @OnMyChatMember()
+  myChatMember(update: ChatMemberUpdated): void {
+    this.sink.record(update);
+  }
+
+  @OnChatMember()
+  chatMember(update: ChatMemberUpdated): void {
+    this.sink.record(update);
+  }
+
+  @OnChatJoinRequest()
+  chatJoinRequest(request: ChatJoinRequest): void {
+    this.sink.record(request);
+  }
+
+  @OnPreCheckoutQuery()
+  preCheckout(query: PreCheckoutQuery): void {
+    this.sink.record(query);
+  }
+
+  @OnShippingQuery()
+  shipping(query: ShippingQuery): void {
+    this.sink.record(query);
+  }
+
+  @OnPoll()
+  poll(poll: Poll): void {
+    this.sink.record(poll);
+  }
+
+  @OnPollAnswer()
+  pollAnswer(answer: PollAnswer): void {
+    this.sink.record(answer);
+  }
+
+  @OnMessageReaction()
+  reaction(reaction: MessageReactionUpdated): void {
+    this.sink.record(reaction);
+  }
+}
+
+describe('UpdateFactory — routable-kind builders', () => {
+  let bot: NestgramTestbed;
+  let sink: EventSink;
+
+  beforeEach(async () => {
+    sink = new EventSink();
+    bot = await NestgramTestbed.create({
+      routers: [KindsRouter],
+      providers: [{ provide: EventSink, useValue: sink }],
+    });
+  });
+
+  afterEach(async () => {
+    await bot.close();
+  });
+
+  it('editedMessage() routes to @OnEditedMessage as a Message', async () => {
+    await bot.dispatch(updates.editedMessage('fixed typo'));
+
+    expect(sink.events).toHaveLength(1);
+    expect(sink.events[0]).toBeInstanceOf(Message);
+    expect((sink.events[0] as Message).text).toBe('fixed typo');
+  });
+
+  it('channelPost() routes to @OnChannelPost in a channel chat', async () => {
+    await bot.dispatch(updates.channelPost('news'));
+
+    expect(sink.events[0]).toBeInstanceOf(Message);
+    expect((sink.events[0] as Message).chat.type).toBe('channel');
+    expect((sink.events[0] as Message).from).toBeUndefined();
+  });
+
+  it('editedChannelPost() routes to @OnEditedChannelPost', async () => {
+    await bot.dispatch(updates.editedChannelPost('edited news'));
+
+    expect(sink.events[0]).toBeInstanceOf(Message);
+    expect((sink.events[0] as Message).text).toBe('edited news');
+  });
+
+  it('photo() routes to @OnPhoto with a photo and optional caption', async () => {
+    await bot.dispatch(updates.photo('look at this'));
+
+    const message = sink.events[0] as Message;
+    expect(message).toBeInstanceOf(Message);
+    expect(message.photo).toBeDefined();
+    expect(message.caption).toBe('look at this');
+  });
+
+  it('myChatMember() routes to @OnMyChatMember as ChatMemberUpdated', async () => {
+    await bot.dispatch(updates.myChatMember());
+
+    expect(sink.events[0]).toBeInstanceOf(ChatMemberUpdated);
+    expect((sink.events[0] as ChatMemberUpdated).new_chat_member.status).toBe(
+      'member',
+    );
+  });
+
+  it('chatMember() routes to @OnChatMember as ChatMemberUpdated', async () => {
+    await bot.dispatch(updates.chatMember());
+
+    expect(sink.events[0]).toBeInstanceOf(ChatMemberUpdated);
+  });
+
+  it('chatJoinRequest() routes to @OnChatJoinRequest', async () => {
+    await bot.dispatch(updates.chatJoinRequest());
+
+    expect(sink.events[0]).toBeInstanceOf(ChatJoinRequest);
+  });
+
+  it('preCheckoutQuery() routes to @OnPreCheckoutQuery', async () => {
+    await bot.dispatch(updates.preCheckoutQuery('order_42'));
+
+    expect(sink.events[0]).toBeInstanceOf(PreCheckoutQuery);
+    expect((sink.events[0] as PreCheckoutQuery).invoice_payload).toBe(
+      'order_42',
+    );
+  });
+
+  it('shippingQuery() routes to @OnShippingQuery', async () => {
+    await bot.dispatch(updates.shippingQuery('order_42'));
+
+    expect(sink.events[0]).toBeInstanceOf(ShippingQuery);
+    expect((sink.events[0] as ShippingQuery).invoice_payload).toBe('order_42');
+  });
+
+  it('poll() routes to @OnPoll', async () => {
+    await bot.dispatch(updates.poll('Coffee or tea?'));
+
+    expect(sink.events[0]).toBeInstanceOf(Poll);
+    expect((sink.events[0] as Poll).question).toBe('Coffee or tea?');
+  });
+
+  it('pollAnswer() routes to @OnPollAnswer', async () => {
+    await bot.dispatch(updates.pollAnswer([1]));
+
+    expect(sink.events[0]).toBeInstanceOf(PollAnswer);
+    expect((sink.events[0] as PollAnswer).option_ids).toEqual([1]);
+  });
+
+  it('messageReaction() routes to @OnMessageReaction', async () => {
+    await bot.dispatch(updates.messageReaction('👍'));
+
+    expect(sink.events[0]).toBeInstanceOf(MessageReactionUpdated);
+    expect((sink.events[0] as MessageReactionUpdated).new_reaction).toEqual([
+      { type: 'emoji', emoji: '👍' },
+    ]);
+  });
+
+  it('raw() fills update_id and dispatches a hand-built kind', async () => {
+    // The escape hatch: a poll_answer assembled by hand, routed through raw().
+    await bot.dispatch(
+      updates.raw({
+        poll_answer: {
+          poll_id: 'hand_built',
+          option_ids: [0],
+          option_persistent_ids: ['opt_0'],
+        },
+      }),
+    );
+
+    expect(sink.events[0]).toBeInstanceOf(PollAnswer);
+    expect((sink.events[0] as PollAnswer).poll_id).toBe('hand_built');
+  });
+});
+
+describe('UpdateFactory — raw() id handling', () => {
+  it('auto-increments update_id when absent', () => {
+    const factory = new UpdateFactory();
+    const a = factory.raw({
+      poll_answer: { poll_id: 'p', option_ids: [], option_persistent_ids: [] },
+    });
+    const b = factory.raw({
+      poll_answer: { poll_id: 'p', option_ids: [], option_persistent_ids: [] },
+    });
+
+    expect(b.update_id).toBe(a.update_id + 1);
+  });
+
+  it('keeps an explicit update_id', () => {
+    const factory = new UpdateFactory();
+    const update = factory.raw({
+      update_id: 555,
+      poll_answer: { poll_id: 'p', option_ids: [], option_persistent_ids: [] },
+    });
+
+    expect(update.update_id).toBe(555);
+  });
+});

--- a/lib/testing/update-factory.ts
+++ b/lib/testing/update-factory.ts
@@ -1,0 +1,119 @@
+import type { RawUpdate } from '../events/raw-update.types';
+import type { TestChat, TestUser, UpdateOverrides } from './testing.types';
+
+/** The leading slash a bot command carries in message text. */
+const COMMAND_PREFIX = '/';
+
+/**
+ * Builds well-formed fake {@link RawUpdate}s to feed {@link NestgramTestbed.dispatch}.
+ *
+ * Every builder fills in sensible defaults (a private chat, a non-bot sender, an
+ * auto-incrementing `update_id`/`message_id`, a fixed `date`) so a test states
+ * only what matters — `updates.message('hi')` — and overrides the rest through
+ * {@link UpdateOverrides}. The shared `update_id` counter keeps successive updates
+ * distinct without the test tracking ids.
+ *
+ * Exposed as the ready-to-use {@link updates} singleton; instantiate your own
+ * `UpdateFactory` when a test needs an isolated id counter.
+ */
+export class UpdateFactory {
+  private nextId = 1;
+
+  private static readonly DEFAULT_USER: TestUser = {
+    id: 1000,
+    is_bot: false,
+    first_name: 'Test',
+    username: 'test_user',
+    language_code: 'en',
+  };
+
+  private static readonly DEFAULT_CHAT: TestChat = {
+    id: 1000,
+    type: 'private',
+  };
+
+  private static readonly DEFAULT_DATE = 1_700_000_000;
+
+  /** A plain text message. */
+  message(text: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      message: {
+        message_id: overrides?.messageId ?? id,
+        date: overrides?.date ?? UpdateFactory.DEFAULT_DATE,
+        chat: this.chat(overrides),
+        from: this.user(overrides),
+        text,
+      },
+    };
+  }
+
+  /**
+   * A bot command message — `updates.command('start')` → `/start`,
+   * `updates.command('start', 'ref_42')` → `/start ref_42`. The leading slash is
+   * added for you; pass the command without it.
+   */
+  command(
+    command: string,
+    args?: string,
+    overrides?: UpdateOverrides,
+  ): RawUpdate {
+    const text = args
+      ? `${COMMAND_PREFIX}${command} ${args}`
+      : `${COMMAND_PREFIX}${command}`;
+    return this.message(text, overrides);
+  }
+
+  /** A callback query (an inline-button tap), carrying `data`. */
+  callbackQuery(data: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      callback_query: {
+        id: `cb_${id}`,
+        from: this.user(overrides),
+        chat_instance: `ci_${id}`,
+        message: {
+          message_id: overrides?.messageId ?? id,
+          date: overrides?.date ?? UpdateFactory.DEFAULT_DATE,
+          chat: this.chat(overrides),
+          text: '',
+        },
+        data,
+      },
+    };
+  }
+
+  /** An inline query (`@bot query` typed in any chat). */
+  inlineQuery(query: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      inline_query: {
+        id: `iq_${id}`,
+        from: this.user(overrides),
+        query,
+        offset: '',
+      },
+    };
+  }
+
+  private resolveId(overrides?: UpdateOverrides): number {
+    if (overrides?.updateId !== undefined) {
+      return overrides.updateId;
+    }
+    return this.nextId++;
+  }
+
+  private user(overrides?: UpdateOverrides): TestUser {
+    return { ...UpdateFactory.DEFAULT_USER, ...overrides?.from };
+  }
+
+  private chat(overrides?: UpdateOverrides): TestChat {
+    return { ...UpdateFactory.DEFAULT_CHAT, ...overrides?.chat };
+  }
+}
+
+/** A shared {@link UpdateFactory} — the ergonomic `updates.message(...)` entry point. */
+export const updates = new UpdateFactory();

--- a/lib/testing/update-factory.ts
+++ b/lib/testing/update-factory.ts
@@ -1,4 +1,10 @@
-import type { RawUpdate } from '../events/raw-update.types';
+import type {
+  RawChatMember,
+  RawChatMemberUpdated,
+  RawMessage,
+  RawPhotoSize,
+  RawUpdate,
+} from '../events/raw-update.types';
 import type { TestChat, TestUser, UpdateOverrides } from './testing.types';
 
 /** The leading slash a bot command carries in message text. */
@@ -34,18 +40,219 @@ export class UpdateFactory {
 
   private static readonly DEFAULT_DATE = 1_700_000_000;
 
+  /** The chat type a channel post / edited channel post carries. */
+  private static readonly CHANNEL_CHAT_TYPE: TestChat['type'] = 'channel';
+
+  /** The currency a payment-related builder fills in by default. */
+  private static readonly DEFAULT_CURRENCY = 'USD';
+
+  /** The smallest-unit amount a payment-related builder fills in by default. */
+  private static readonly DEFAULT_AMOUNT = 100;
+
+  /** A single {@link RawPhotoSize} the `photo()` builder attaches by default. */
+  private static readonly DEFAULT_PHOTO: RawPhotoSize = {
+    file_id: 'test_photo_file_id',
+    file_unique_id: 'test_photo_unique_id',
+    width: 90,
+    height: 90,
+    file_size: 1234,
+  };
+
   /** A plain text message. */
   message(text: string, overrides?: UpdateOverrides): RawUpdate {
     const id = this.resolveId(overrides);
     return {
       update_id: id,
-      message: {
-        message_id: overrides?.messageId ?? id,
-        date: overrides?.date ?? UpdateFactory.DEFAULT_DATE,
-        chat: this.chat(overrides),
-        from: this.user(overrides),
+      message: this.textMessage(text, id, this.chat(overrides), overrides),
+    };
+  }
+
+  /** An edited message — the same shape as {@link message}, on `edited_message`. */
+  editedMessage(text: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      edited_message: this.textMessage(
         text,
+        id,
+        this.chat(overrides),
+        overrides,
+      ),
+    };
+  }
+
+  /**
+   * A channel post — a message in a `channel` chat with no `from` sender (the
+   * default chat type is overridden to `channel`; pass `overrides.chat` to widen).
+   */
+  channelPost(text: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      channel_post: this.channelMessage(text, id, overrides),
+    };
+  }
+
+  /** An edited channel post — like {@link channelPost}, on `edited_channel_post`. */
+  editedChannelPost(text: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      edited_channel_post: this.channelMessage(text, id, overrides),
+    };
+  }
+
+  /**
+   * A photo message — a `message` carrying a `photo` (a one-element
+   * `PhotoSize[]`), the update `@OnPhoto`/`@OnMedia` match on. Pass `caption`
+   * for an accompanying caption.
+   */
+  photo(caption?: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    const message: RawMessage = {
+      message_id: overrides?.messageId ?? id,
+      date: overrides?.date ?? UpdateFactory.DEFAULT_DATE,
+      chat: this.chat(overrides),
+      from: this.user(overrides),
+      photo: [UpdateFactory.DEFAULT_PHOTO],
+    };
+    if (caption !== undefined) {
+      message.caption = caption;
+    }
+    return { update_id: id, message };
+  }
+
+  /** The bot's own membership changing in a chat (`my_chat_member`). */
+  myChatMember(overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      my_chat_member: this.chatMemberUpdate(overrides),
+    };
+  }
+
+  /** Another member's status changing in a chat (`chat_member`). */
+  chatMember(overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      chat_member: this.chatMemberUpdate(overrides),
+    };
+  }
+
+  /** A request to join a chat that requires approval (`chat_join_request`). */
+  chatJoinRequest(overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    const chat = this.chat(overrides);
+    return {
+      update_id: id,
+      chat_join_request: {
+        chat,
+        from: this.user(overrides),
+        user_chat_id: chat.id,
+        date: overrides?.date ?? UpdateFactory.DEFAULT_DATE,
       },
+    };
+  }
+
+  /** A pre-checkout query the bot must answer before payment (`pre_checkout_query`). */
+  preCheckoutQuery(payload: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      pre_checkout_query: {
+        id: `pcq_${id}`,
+        from: this.user(overrides),
+        currency: UpdateFactory.DEFAULT_CURRENCY,
+        total_amount: UpdateFactory.DEFAULT_AMOUNT,
+        invoice_payload: payload,
+      },
+    };
+  }
+
+  /** A shipping query for a flexible invoice (`shipping_query`). */
+  shippingQuery(payload: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      shipping_query: {
+        id: `sq_${id}`,
+        from: this.user(overrides),
+        invoice_payload: payload,
+        shipping_address: {
+          country_code: 'US',
+          state: 'CA',
+          city: 'San Francisco',
+          street_line1: '1 Market St',
+          street_line2: '',
+          post_code: '94105',
+        },
+      },
+    };
+  }
+
+  /** A poll state update — anonymous polls the bot created (`poll`). */
+  poll(question: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      poll: {
+        id: `poll_${id}`,
+        question,
+        options: [
+          { persistent_id: 'opt_0', text: 'Yes', voter_count: 0 },
+          { persistent_id: 'opt_1', text: 'No', voter_count: 0 },
+        ],
+        total_voter_count: 0,
+        is_closed: false,
+        is_anonymous: true,
+        type: 'regular',
+        allows_multiple_answers: false,
+        allows_revoting: false,
+        members_only: false,
+      },
+    };
+  }
+
+  /** A user's answer in a non-anonymous poll (`poll_answer`). */
+  pollAnswer(optionIds: number[], overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      poll_answer: {
+        poll_id: `poll_${id}`,
+        user: this.user(overrides),
+        option_ids: optionIds,
+        option_persistent_ids: optionIds.map((index) => `opt_${index}`),
+      },
+    };
+  }
+
+  /** A reaction added to or removed from a message (`message_reaction`). */
+  messageReaction(emoji: string, overrides?: UpdateOverrides): RawUpdate {
+    const id = this.resolveId(overrides);
+    return {
+      update_id: id,
+      message_reaction: {
+        chat: this.chat(overrides),
+        message_id: overrides?.messageId ?? id,
+        user: this.user(overrides),
+        date: overrides?.date ?? UpdateFactory.DEFAULT_DATE,
+        old_reaction: [],
+        new_reaction: [{ type: 'emoji', emoji }],
+      },
+    };
+  }
+
+  /**
+   * The escape hatch: pass any hand-built update through unchanged, only filling
+   * `update_id` (auto-incrementing) when absent — the typed "any kind" path for
+   * update kinds without a dedicated builder.
+   */
+  raw(update: Partial<RawUpdate>): RawUpdate {
+    return {
+      ...update,
+      update_id: update.update_id ?? this.nextId++,
     };
   }
 
@@ -96,6 +303,53 @@ export class UpdateFactory {
         query,
         offset: '',
       },
+    };
+  }
+
+  /** A text {@link RawMessage} on a given chat — the shared body of the message builders. */
+  private textMessage(
+    text: string,
+    id: number,
+    chat: TestChat,
+    overrides?: UpdateOverrides,
+  ): RawMessage {
+    return {
+      message_id: overrides?.messageId ?? id,
+      date: overrides?.date ?? UpdateFactory.DEFAULT_DATE,
+      chat,
+      from: this.user(overrides),
+      text,
+    };
+  }
+
+  /** A channel-post {@link RawMessage}: a `channel` chat, no `from` sender. */
+  private channelMessage(
+    text: string,
+    id: number,
+    overrides?: UpdateOverrides,
+  ): RawMessage {
+    return {
+      message_id: overrides?.messageId ?? id,
+      date: overrides?.date ?? UpdateFactory.DEFAULT_DATE,
+      chat: {
+        ...this.chat(overrides),
+        type: overrides?.chat?.type ?? UpdateFactory.CHANNEL_CHAT_TYPE,
+      },
+      text,
+    };
+  }
+
+  /** A `left` → `member` transition — the body shared by my/other chat-member updates. */
+  private chatMemberUpdate(overrides?: UpdateOverrides): RawChatMemberUpdated {
+    const user = this.user(overrides);
+    const oldMember: RawChatMember = { status: 'left', user };
+    const newMember: RawChatMember = { status: 'member', user };
+    return {
+      chat: this.chat(overrides),
+      from: user,
+      date: overrides?.date ?? UpdateFactory.DEFAULT_DATE,
+      old_chat_member: oldMember,
+      new_chat_member: newMember,
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,17 @@
   "author": "Mykyta Voitsekhovskyi <mykyta@kodo.do>",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "default": "./dist/testing/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "homepage": "https://nestgram.vercel.app",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What this does

Adds testing utilities so bot authors can test their routers/scenes **without a Telegram connection**, while exercising the real engine pipeline.

- **`NestgramTestbed`** (`lib/testing/`) — boots the app with no transport (so nothing hits the network), runs updates through the real `UpdateDispatcher` (discovery → matching → guards / interceptors / pipes / exception filters via ECC → result handling), and captures every outgoing API call. The capture seam is an `ApiInterceptor` registered last in the bot's pipeline; it short-circuits before the throttler and `fetch`, so the wire is never touched. **Zero production-code changes** — the only non-`lib/testing/` edits are the barrel re-export and a `package.json` subpath export.
- **Fake-update factory** (`updates.*`) — builders for every routable update kind: `message`, `command`, `callbackQuery`, `inlineQuery`, `editedMessage`, `channelPost`, `editedChannelPost`, `photo`, `myChatMember`, `chatMember`, `chatJoinRequest`, `preCheckoutQuery`, `shippingQuery`, `poll`, `pollAnswer`, `messageReaction` — plus `updates.raw(partial)` for anything without a dedicated builder. Sensible defaults; `UpdateOverrides` tweaks from / chat / ids / date.
- **Assertions & stubs** — `bot.sent`, `bot.lastMessage`, `bot.calls(SendMessage)`, `bot.lastError` (or `dispatch(u, { rethrow: true })`) for guard/error paths, and `bot.onApi(SendMessage, …)` to stub API results. Jest-agnostic: the runtime code imports no test framework and returns plain data.
- **Subpath export** `nestgram/testing` (the main `nestgram` barrel also re-exports it).
- **Docs** — a new `docs/testing.md` page.

## How to verify

```
npm run build && npm run lint && npx jest
```

Full suite green, including the testing specs and a "never calls `fetch`" network-safety test. Minimal usage:

```ts
const bot = await NestgramTestbed.create({ routers: [GreetRouter] });
await bot.dispatch(updates.command('start'));
expect(bot.lastMessage?.text).toBe('Hi Test');
await bot.close();
```

## Notes

- Captures collapse into a single `bot.sent` list — multi-bot fleets are not partitioned per bot yet (follow-up).
- Asserting FSM / session / scene state after a dispatch is not covered yet (follow-up).
