### PR TITLE
feat: inbound rate-limiting (flood control)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,6 +76,8 @@ Everything needed to ship a production bot.
 ## Phase 4 — Scale & DX
 
 - [ ] Multi-instance support (Redis sessions, distributed throttling)
+- [x] Inbound rate-limiting (flood control) — global interceptor, sliding-window
+      per-conversation limiter, `@RateLimit` / `@SkipRateLimit`, `onLimit` reply
 - [ ] CLI / schematics
 - [x] Testing utilities (dispatch fake updates against routers) — `NestgramTestbed`
       + the `updates.*` fake-update factory + captured sends / `onApi` stubs

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,265 @@
+---
+title: Rate limiting (flood control)
+description: Drop inbound floods before the handler runs — a per-conversation sliding-window limiter, with per-route overrides and a custom on-limit reply.
+sidebar:
+  label: Rate limiting
+  group: The Nest pipeline
+  order: 62
+---
+
+A single user hammering your bot — holding the send key, spamming a button,
+running a script — shouldn't get every update handled. **Rate limiting** caps
+how many updates one conversation may trigger in a window, and silently drops
+the rest before your handler ever runs.
+
+:::mental
+update -> within limit? -> handler runs / dropped (no reply)
+:::
+
+This is **inbound** flood control: it protects _your_ handlers from too many
+incoming updates. Don't confuse it with the **outbound** send throttle (the
+built-in that paces your bot's calls to Telegram so _you_ don't hit the API's
+send limits). They sit on opposite ends of the pipeline and solve opposite
+problems — you can run both.
+
+## Enable rate limiting
+
+Import `RateLimitModule` once, alongside `NestgramModule`, with a default rule.
+A rule is `{ limit, windowMs }`: at most `limit` updates per rolling `windowMs`
+milliseconds, per conversation.
+
+:::code[app.module.ts]{mark="11"}
+
+```ts
+import { Module } from '@nestjs/common';
+import { NestgramModule, RateLimitModule } from 'nestgram';
+import { EchoRouter } from './echo.router';
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      token: process.env.BOT_TOKEN ?? '',
+      polling: true,
+    }),
+    RateLimitModule.forRoot({
+      default: { limit: 5, windowMs: 10_000 }, // 5 updates / 10s per user
+    }),
+  ],
+  providers: [EchoRouter],
+})
+export class AppModule {}
+```
+
+:::
+
+The window is a true **sliding window**: each slot frees exactly `windowMs`
+after the hit that filled it, so there's none of a fixed window's
+burst-at-the-boundary doubling.
+
+:::note
+Rate limiting is off until you import the module — there's no flag to flip.
+With no `default` rule and no `@RateLimit` on a route, the limiter passes every
+update straight through.
+:::
+
+## The scope: per user, per chat
+
+By default a counter is keyed per **user, per chat** (plus forum topic and
+business connection when present, and the receiving bot in a multi-bot app) —
+the same `defaultConversationKey` that sessions and the FSM use. So one user
+flooding a group never exhausts another user's budget, and the same user in two
+different chats has two budgets.
+
+Override the scope with a `key` function. Return a string to scope by it, or
+`undefined` to skip the limiter for that update:
+
+:::code[app.module.ts]
+
+```ts
+import { RateLimitModule } from 'nestgram';
+
+// One shared budget for the whole chat (everyone in it counts together).
+RateLimitModule.forRoot({
+  default: {
+    limit: 20,
+    windowMs: 60_000,
+    key: (ctx) => (ctx.chat ? `chat:${ctx.chat.id}` : undefined),
+  },
+});
+```
+
+:::
+
+## Per-route overrides
+
+`@RateLimit({...})` on a handler — or on a whole `@Router()` class — overrides
+the module default for that route. A stricter limit on an expensive command, a
+looser one elsewhere:
+
+:::code[search.router.ts]{mark="6"}
+
+```ts
+import { Router, Command, Message, RateLimit } from 'nestgram';
+
+@Router()
+export class SearchRouter {
+  @Command('search')
+  @RateLimit({ limit: 2, windowMs: 30_000 }) // search is heavy: 2 / 30s
+  search(message: Message) {
+    return 'Searching…';
+  }
+}
+```
+
+:::
+
+`@SkipRateLimit()` exempts a route entirely — handy for cheap, always-allowed
+commands even under a strict module default:
+
+:::code[help.router.ts]{mark="6"}
+
+```ts
+import { Router, Command, Message, SkipRateLimit } from 'nestgram';
+
+@Router()
+export class HelpRouter {
+  @Command('help')
+  @SkipRateLimit() // never limited
+  help(message: Message) {
+    return 'Here to help.';
+  }
+}
+```
+
+:::
+
+Resolution is handler-over-class, and `@SkipRateLimit()` always wins: a method
+marked skip is exempt even if its router class carries a `@RateLimit`.
+
+## What happens on a drop
+
+By default a dropped update is **silent** — the handler never runs and nothing
+is sent back. To tell the user instead, give the rule an `onLimit` callback.
+Return a value and it flows through the normal reply path, exactly like a
+handler's return — a string, or a command object such as `SendMessage`:
+
+:::code[app.module.ts]{mark="6"}
+
+```ts
+import { RateLimitModule } from 'nestgram';
+
+RateLimitModule.forRoot({
+  default: {
+    limit: 5,
+    windowMs: 10_000,
+    onLimit: () => 'Slow down a moment ⏳',
+  },
+});
+```
+
+:::
+
+`onLimit` may be async and receives the execution context, so the warning can
+depend on who or where it is. Return `undefined` (or nothing) to fall back to
+the silent drop. Like `key` and the rule itself, `onLimit` can be set on the
+module default or per-route via `@RateLimit({ ..., onLimit })`.
+
+:::tip
+Sending a warning on _every_ dropped update can itself become spam (and burn
+your send budget). A common pattern is to warn only on the first drop of a
+burst, or to keep it silent and rely on the drop alone.
+:::
+
+## Where the counters live
+
+By default the limiter counts in process memory. Each counter holds at most
+`limit` timestamps, so a single key can't grow unbounded — but the number of
+distinct keys does grow, one entry per conversation ever seen.
+
+For a long-running, many-user bot, bound that with `idleTtlMs` — a key idle
+longer than this is evicted:
+
+:::code[app.module.ts]{mark="6"}
+
+```ts
+import { RateLimitModule } from 'nestgram';
+
+RateLimitModule.forRoot({
+  default: { limit: 5, windowMs: 10_000 },
+  idleTtlMs: 60_000, // forget a conversation after 60s idle
+});
+```
+
+:::
+
+:::caution
+Set `idleTtlMs` **≥ your largest window**. The expiry is sliding (every allowed
+hit refreshes it), so an actively-hitting key never dies — but if `idleTtlMs`
+were shorter than a window, a key still inside an active window could be evicted
+and let a flood through. At or above the window it's lossless: by the time a key
+is evicted its window has already emptied.
+:::
+
+For multiple instances, in-process counters don't add up — each replica limits
+on its own slice of traffic. Supply a shared store instead. The limiter persists
+through the same `KeyValueStore` contract sessions and the FSM use, so a
+Redis-backed store makes one limit hold across the whole fleet (give its native
+key TTL a value ≳ your largest window):
+
+:::code[app.module.ts]
+
+```ts
+import { RateLimitModule } from 'nestgram';
+import { myRedisStore } from './redis-store';
+
+RateLimitModule.forRoot({
+  default: { limit: 5, windowMs: 10_000 },
+  store: myRedisStore, // any KeyValueStore — idleTtlMs is ignored, the store owns expiry
+});
+```
+
+:::
+
+:::note
+Read-modify-write on the counter is not atomic — the same trade-off sessions and
+the FSM already make. Under heavy concurrency a key can briefly exceed its limit
+by the number of in-flight updates. That's fine for protective flood control,
+and a non-issue for long polling, which processes a batch largely in order.
+:::
+
+## Configuring from DI
+
+When the store or limits come from the DI container — a Redis client from
+`ConfigService`, say — use `forRootAsync`, exactly like other Nest dynamic
+modules:
+
+:::code[app.module.ts]
+
+```ts
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { RateLimitModule } from 'nestgram';
+
+RateLimitModule.forRootAsync({
+  imports: [ConfigModule],
+  inject: [ConfigService],
+  useFactory: (config: ConfigService) => ({
+    default: {
+      limit: config.get('RATE_LIMIT', 5),
+      windowMs: 10_000,
+    },
+  }),
+});
+```
+
+:::
+
+## Not a privileged core
+
+The limiter is just one public Nest interceptor, registered globally by the
+module — the kind you could have written yourself. It runs _before_ your
+handler; within the limit it calls the handler as normal, and over the limit it
+short-circuits with the `onLimit` value or nothing at all.
+
+It's deliberately an interceptor, not a guard: a guard returning `false` makes
+Nest throw `ForbiddenException`, which is an error your filters would see — not
+a clean, silent drop. The interceptor simply doesn't invoke the handler.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,6 +17,7 @@ export * from './sessions';
 export * from './i18n';
 export * from './fsm';
 export * from './scenes';
+export * from './rate-limit';
 
 // Engine public surface (the update -> dispatch pipeline).
 export * from './engine/matching';

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -1,0 +1,5 @@
+export * from './rate-limit.module';
+export * from './rate-limit.interceptor';
+export * from './rate-limiter';
+export * from './rate-limit.decorators';
+export * from './rate-limit.types';

--- a/lib/rate-limit/rate-limit.decorators.ts
+++ b/lib/rate-limit/rate-limit.decorators.ts
@@ -1,0 +1,28 @@
+import { SetMetadata } from '@nestjs/common';
+
+import { RateLimitMetadata, type RateLimitRule } from './rate-limit.types';
+
+/**
+ * Overrides the module's default rate-limit rule for one route. Place it on a
+ * handler method (just that handler) or on a `@Router()` class (every handler
+ * in it, unless a handler sets its own). Resolution is handler-over-class, and
+ * `@SkipRateLimit()` always wins over it.
+ *
+ * ```ts
+ * @Command('start')
+ * @RateLimit({ limit: 3, windowMs: 10_000 })
+ * start(message: Message) {}
+ * ```
+ */
+export const RateLimit = (
+  rule: RateLimitRule,
+): MethodDecorator & ClassDecorator =>
+  SetMetadata(RateLimitMetadata.RULE, rule);
+
+/**
+ * Exempts a route from rate-limiting entirely. On a handler it exempts that
+ * handler; on a `@Router()` class it exempts every handler in it. Wins over any
+ * `@RateLimit` and over the module default.
+ */
+export const SkipRateLimit = (): MethodDecorator & ClassDecorator =>
+  SetMetadata(RateLimitMetadata.SKIP, true);

--- a/lib/rate-limit/rate-limit.integration.spec.ts
+++ b/lib/rate-limit/rate-limit.integration.spec.ts
@@ -1,0 +1,82 @@
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+import { Command } from '../decorators/listeners/command.decorator';
+import { Router } from '../decorators/injectable/router.decorator';
+import { UpdateDispatcher } from '../engine/dispatcher';
+import { Message } from '../events';
+import { RawUpdate } from '../events/raw-update.types';
+import { NestgramModule } from '../module';
+import { RateLimit, SkipRateLimit } from './rate-limit.decorators';
+import { RateLimitModule } from './rate-limit.module';
+
+const LIMIT = 2;
+const WINDOW_MS = 1_000;
+
+@Router()
+class FloodRouter {
+  readonly limited: number[] = [];
+  readonly free: number[] = [];
+
+  @Command('ping')
+  @RateLimit({ limit: LIMIT, windowMs: WINDOW_MS })
+  ping(message: Message): void {
+    this.limited.push(message.message_id);
+  }
+
+  @Command('status')
+  @SkipRateLimit()
+  status(message: Message): void {
+    this.free.push(message.message_id);
+  }
+}
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({ token: 'TEST' }),
+    RateLimitModule.forRoot({ default: { limit: LIMIT, windowMs: WINDOW_MS } }),
+  ],
+  providers: [FloodRouter],
+})
+class RateLimitAppModule {}
+
+function command(update_id: number, text: string, userId = 7): RawUpdate {
+  return {
+    update_id,
+    message: {
+      message_id: update_id,
+      date: 1,
+      chat: { id: 1, type: 'private' },
+      from: { id: userId, is_bot: false, first_name: 'U' },
+      text,
+    },
+  };
+}
+
+describe('Rate limit (integration)', () => {
+  it('drops a per-user flood past the limit, isolates users, exempts @SkipRateLimit', async () => {
+    const app = await NestFactory.createApplicationContext(RateLimitAppModule, {
+      logger: false,
+    });
+    const dispatcher = app.get(UpdateDispatcher);
+    const router = app.get(FloodRouter);
+
+    // Three /ping from the same user within the window: only the first two run.
+    await dispatcher.dispatch(command(1, '/ping'));
+    await dispatcher.dispatch(command(2, '/ping'));
+    await dispatcher.dispatch(command(3, '/ping')); // dropped, handler not invoked
+    expect(router.limited).toEqual([1, 2]);
+
+    // A different user has their own bucket — not affected by user 7's flood.
+    await dispatcher.dispatch(command(4, '/ping', 9));
+    expect(router.limited).toEqual([1, 2, 4]);
+
+    // @SkipRateLimit handler is never limited, even under user 7's flood.
+    await dispatcher.dispatch(command(5, '/status'));
+    await dispatcher.dispatch(command(6, '/status'));
+    await dispatcher.dispatch(command(7, '/status'));
+    expect(router.free).toEqual([5, 6, 7]);
+
+    await app.close();
+  });
+});

--- a/lib/rate-limit/rate-limit.interceptor.spec.ts
+++ b/lib/rate-limit/rate-limit.interceptor.spec.ts
@@ -1,0 +1,243 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { firstValueFrom, of, toArray } from 'rxjs';
+
+import { FakeClock } from '../builtins/throttle/clock.fake';
+import { MemoryStore } from '../store/key-value-store';
+import { RateLimitInterceptor } from './rate-limit.interceptor';
+import {
+  OnRateLimit,
+  RateLimitKey,
+  RateLimitMetadata,
+  RateLimitOptions,
+  RateLimitRule,
+} from './rate-limit.types';
+import { RateLimiter } from './rate-limiter';
+
+const CHAT_ID = 42;
+const HANDLER_RESULT = 'handled';
+
+/**
+ * A fake TelegramExecutionContext exposing what the interceptor and the default
+ * key strategy read: `chat`, `from`, `bot`, and the raw `update`.
+ */
+function tgCtx(chatId: number = CHAT_ID): unknown {
+  const chat = { id: chatId };
+  return {
+    chat,
+    from: { id: 7 },
+    bot: undefined,
+    update: { message: { chat, from: { id: 7 } } },
+  };
+}
+
+/** A context with no chat — the default key strategy returns undefined for it. */
+function noChatCtx(): unknown {
+  return { chat: undefined, from: { id: 7 }, bot: undefined, update: {} };
+}
+
+/** Per-target metadata: index 0 = handler, index 1 = class. */
+interface Meta {
+  rule?: [RateLimitRule | undefined, RateLimitRule | undefined];
+  skip?: [boolean | undefined, boolean | undefined];
+}
+
+function reflectorWith(meta: Meta): Reflector {
+  return {
+    getAllAndOverride: (key: string) => {
+      if (key === RateLimitMetadata.RULE) {
+        return meta.rule?.find((r) => r !== undefined);
+      }
+      if (key === RateLimitMetadata.SKIP) {
+        return meta.skip?.find((s) => s !== undefined);
+      }
+      return undefined;
+    },
+  } as unknown as Reflector;
+}
+
+function contextFor(ctx: unknown): ExecutionContext {
+  return {
+    getArgByIndex: (i: number) => (i === 1 ? ctx : undefined),
+    getHandler: () => () => undefined,
+    getClass: () => class {},
+  } as unknown as ExecutionContext;
+}
+
+/** Records whether next.handle() was subscribed (i.e. the handler ran). */
+function trackedHandler(): { handler: CallHandler; runs: () => number } {
+  let runs = 0;
+  const handler: CallHandler = {
+    handle: () => {
+      runs += 1;
+      return of(HANDLER_RESULT);
+    },
+  };
+  return { handler, runs: () => runs };
+}
+
+function build(
+  options: RateLimitOptions,
+  meta: Meta = {},
+  clock = new FakeClock(),
+): { interceptor: RateLimitInterceptor; clock: FakeClock } {
+  const limiter = new RateLimiter(new MemoryStore(), clock);
+  const interceptor = new RateLimitInterceptor(
+    reflectorWith(meta),
+    limiter,
+    options,
+  );
+  return { interceptor, clock };
+}
+
+/** Subscribe and collect every emitted value, like the engine would. */
+async function emitted(
+  interceptor: RateLimitInterceptor,
+  ctx: unknown,
+  handler: CallHandler,
+): Promise<unknown[]> {
+  return firstValueFrom(
+    interceptor.intercept(contextFor(ctx), handler).pipe(toArray()),
+  );
+}
+
+const RULE: RateLimitRule = { limit: 2, windowMs: 1_000 };
+
+describe('RateLimitInterceptor', () => {
+  it('passes through and lets the handler run while under the limit', async () => {
+    const { interceptor } = build({ default: RULE });
+    const { handler, runs } = trackedHandler();
+
+    expect(await emitted(interceptor, tgCtx(), handler)).toEqual([
+      HANDLER_RESULT,
+    ]);
+    expect(await emitted(interceptor, tgCtx(), handler)).toEqual([
+      HANDLER_RESULT,
+    ]);
+    expect(runs()).toBe(2);
+  });
+
+  it('drops over-limit updates silently — handler never runs, nothing emitted', async () => {
+    const { interceptor } = build({ default: RULE });
+    const { handler, runs } = trackedHandler();
+
+    await emitted(interceptor, tgCtx(), handler);
+    await emitted(interceptor, tgCtx(), handler);
+    const third = await emitted(interceptor, tgCtx(), handler);
+
+    expect(third).toEqual([]); // EMPTY — no reply produced
+    expect(runs()).toBe(2); // the third update never reached the handler
+  });
+
+  it('per-route @RateLimit overrides the module default', async () => {
+    const strict: RateLimitRule = { limit: 1, windowMs: 1_000 };
+    const { interceptor } = build(
+      { default: { limit: 100, windowMs: 1_000 } },
+      { rule: [strict, undefined] },
+    );
+    const { handler, runs } = trackedHandler();
+
+    await emitted(interceptor, tgCtx(), handler);
+    const second = await emitted(interceptor, tgCtx(), handler);
+
+    expect(second).toEqual([]); // strict per-route limit of 1 wins
+    expect(runs()).toBe(1);
+  });
+
+  it('@SkipRateLimit exempts the route entirely', async () => {
+    const { interceptor } = build(
+      { default: { limit: 1, windowMs: 1_000 } },
+      { skip: [true, undefined] },
+    );
+    const { handler, runs } = trackedHandler();
+
+    for (let i = 0; i < 5; i += 1) {
+      expect(await emitted(interceptor, tgCtx(), handler)).toEqual([
+        HANDLER_RESULT,
+      ]);
+    }
+    expect(runs()).toBe(5);
+  });
+
+  it('uses a custom key to scope the counter', async () => {
+    // A constant key collapses every update into one bucket regardless of chat.
+    const key: RateLimitKey = () => 'shared';
+    const { interceptor } = build({ default: { ...RULE, key } });
+    const { handler, runs } = trackedHandler();
+
+    await emitted(interceptor, tgCtx(1), handler);
+    await emitted(interceptor, tgCtx(2), handler);
+    const third = await emitted(interceptor, tgCtx(3), handler); // different chat, same bucket
+
+    expect(third).toEqual([]);
+    expect(runs()).toBe(2);
+  });
+
+  it('emits the onLimit return value as a reply on drop', async () => {
+    const warning = 'Slow down!';
+    const onLimit: OnRateLimit = () => warning;
+    const { interceptor } = build({
+      default: { limit: 1, windowMs: 1_000, onLimit },
+    });
+    const { handler, runs } = trackedHandler();
+
+    await emitted(interceptor, tgCtx(), handler);
+    const second = await emitted(interceptor, tgCtx(), handler);
+
+    expect(second).toEqual([warning]); // flows through the normal reply path
+    expect(runs()).toBe(1); // handler still didn't run
+  });
+
+  it('emits nothing when onLimit returns undefined', async () => {
+    const onLimit: OnRateLimit = () => undefined;
+    const { interceptor } = build({
+      default: { limit: 1, windowMs: 1_000, onLimit },
+    });
+    const { handler } = trackedHandler();
+
+    await emitted(interceptor, tgCtx(), handler);
+    expect(await emitted(interceptor, tgCtx(), handler)).toEqual([]);
+  });
+
+  it('allows again after the window elapses (fake clock)', async () => {
+    const { interceptor, clock } = build({
+      default: { limit: 1, windowMs: 1_000 },
+    });
+    const { handler, runs } = trackedHandler();
+
+    await emitted(interceptor, tgCtx(), handler);
+    expect(await emitted(interceptor, tgCtx(), handler)).toEqual([]); // denied
+
+    await clock.advance(1_001);
+    expect(await emitted(interceptor, tgCtx(), handler)).toEqual([
+      HANDLER_RESULT,
+    ]);
+    expect(runs()).toBe(2);
+  });
+
+  it('passes through when no rule applies (no default, no @RateLimit)', async () => {
+    const { interceptor } = build({});
+    const { handler, runs } = trackedHandler();
+
+    for (let i = 0; i < 5; i += 1) {
+      expect(await emitted(interceptor, tgCtx(), handler)).toEqual([
+        HANDLER_RESULT,
+      ]);
+    }
+    expect(runs()).toBe(5);
+  });
+
+  it('passes through when the key resolves to undefined (no chat)', async () => {
+    // Default key (defaultConversationKey) returns undefined with no chat.
+    const { interceptor } = build({ default: { limit: 1, windowMs: 1_000 } });
+    const { handler, runs } = trackedHandler();
+
+    expect(await emitted(interceptor, noChatCtx(), handler)).toEqual([
+      HANDLER_RESULT,
+    ]);
+    expect(await emitted(interceptor, noChatCtx(), handler)).toEqual([
+      HANDLER_RESULT,
+    ]);
+    expect(runs()).toBe(2); // never limited — nothing to scope to
+  });
+});

--- a/lib/rate-limit/rate-limit.interceptor.ts
+++ b/lib/rate-limit/rate-limit.interceptor.ts
@@ -1,0 +1,126 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { defer, EMPTY, from, of, type Observable } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+
+import { TelegramExecutionContext } from '../engine/context';
+import { defaultConversationKey } from '../store/conversation-key';
+import {
+  OnRateLimit,
+  RateLimitKey,
+  RateLimitMetadata,
+  RateLimitOptions,
+  RateLimitRule,
+  RATE_LIMIT_OPTIONS,
+} from './rate-limit.types';
+import { RateLimiter } from './rate-limiter';
+
+/** The rule plus the resolved key/on-limit fallbacks that actually apply. */
+interface ResolvedLimit {
+  rule: RateLimitRule;
+  key: RateLimitKey;
+  onLimit?: OnRateLimit;
+}
+
+/**
+ * Inbound flood control as a global Nest interceptor — the kind a bot author
+ * could have written (no privileged core). Registered via `APP_INTERCEPTOR` by
+ * {@link RateLimitModule}.
+ *
+ * It runs the {@link RateLimiter} BEFORE the handler. Within limit, it
+ * increments the counter and calls `next.handle()` so the update is handled
+ * normally. Over limit, it does NOT call `next.handle()` — so the handler never
+ * runs and no reply is produced — and emits either nothing ({@link EMPTY},
+ * silent drop) or, when an `onLimit` callback returns a value, that value
+ * (which then flows through the normal reply path, e.g. a "slow down" message).
+ *
+ * It is deliberately an interceptor, not a guard: a `CanActivate` returning
+ * `false` makes Nest throw `ForbiddenException`, which is not a silent drop and
+ * would hit the exception filters. An interceptor short-circuits cleanly.
+ *
+ * Pass-through (calls `next.handle()` with no counting) when: the route is
+ * `@SkipRateLimit()`; no rule applies (no module `default`, no `@RateLimit`);
+ * or the resolved key is `undefined` (no chat to scope to).
+ */
+@Injectable()
+export class RateLimitInterceptor implements NestInterceptor {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly limiter: RateLimiter,
+    @Inject(RATE_LIMIT_OPTIONS) private readonly options: RateLimitOptions,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const resolved = this.resolve(context);
+    if (!resolved) {
+      return next.handle();
+    }
+
+    const ctx = TelegramExecutionContext.of(context);
+    const key = resolved.key(ctx);
+    if (key === undefined) {
+      return next.handle();
+    }
+
+    // defer: the limiter is async and stateful, so re-run it per subscription
+    // rather than at assembly time.
+    return defer(() =>
+      from(this.limiter.hit(key, resolved.rule.limit, resolved.rule.windowMs)),
+    ).pipe(
+      mergeMap((allowed) =>
+        allowed ? next.handle() : this.onDenied(ctx, resolved.onLimit),
+      ),
+    );
+  }
+
+  /** Emit the `onLimit` value (if any), else nothing — the handler never ran. */
+  private onDenied(
+    ctx: TelegramExecutionContext,
+    onLimit: OnRateLimit | undefined,
+  ): Observable<unknown> {
+    if (!onLimit) {
+      return EMPTY;
+    }
+    return from(Promise.resolve(onLimit(ctx))).pipe(
+      mergeMap((result) => (result === undefined ? EMPTY : of(result))),
+    );
+  }
+
+  /**
+   * The effective rule for this route, or `undefined` to pass through.
+   * `@SkipRateLimit` wins; otherwise the nearest `@RateLimit` (handler over
+   * class) or the module default. Key/on-limit fall back module-then-default.
+   */
+  private resolve(context: ExecutionContext): ResolvedLimit | undefined {
+    const targets = [context.getHandler(), context.getClass()];
+
+    const skipped = this.reflector.getAllAndOverride<boolean>(
+      RateLimitMetadata.SKIP,
+      targets,
+    );
+    if (skipped) {
+      return undefined;
+    }
+
+    const rule =
+      this.reflector.getAllAndOverride<RateLimitRule>(
+        RateLimitMetadata.RULE,
+        targets,
+      ) ?? this.options.default;
+    if (!rule) {
+      return undefined;
+    }
+
+    return {
+      rule,
+      key: rule.key ?? this.options.key ?? defaultConversationKey,
+      onLimit: rule.onLimit ?? this.options.onLimit,
+    };
+  }
+}

--- a/lib/rate-limit/rate-limit.module.spec.ts
+++ b/lib/rate-limit/rate-limit.module.spec.ts
@@ -1,0 +1,56 @@
+import { FactoryProvider } from '@nestjs/common';
+
+import { KeyValueStore } from '../store/key-value-store';
+import { RateLimitModule } from './rate-limit.module';
+import { RateLimitOptions, RATE_LIMIT_STORE } from './rate-limit.types';
+
+/**
+ * Build the store the module would inject under {@link RATE_LIMIT_STORE} for a
+ * given options object, by invoking that provider's factory directly — no full
+ * Nest bootstrap needed to assert the `idleTtlMs` wiring.
+ */
+function storeFor(options: RateLimitOptions): KeyValueStore {
+  const dynamic = RateLimitModule.forRoot(options);
+  const storeProvider = (dynamic.providers ?? []).find(
+    (p): p is FactoryProvider =>
+      typeof p === 'object' && 'provide' in p && p.provide === RATE_LIMIT_STORE,
+  );
+  if (!storeProvider) {
+    throw new Error('RATE_LIMIT_STORE provider not found');
+  }
+  // The factory injects the resolved options (the value provider in forRoot).
+  return storeProvider.useFactory(options) as KeyValueStore;
+}
+
+describe('RateLimitModule store wiring', () => {
+  it('passes idleTtlMs to the default MemoryStore — a key is forgotten after going idle', () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(0);
+      const idleTtlMs = 1_000;
+      const store = storeFor({ idleTtlMs });
+
+      store.set('k', { hits: [0] });
+      expect(store.get('k')).toEqual({ hits: [0] }); // still within the TTL
+
+      jest.setSystemTime(idleTtlMs + 1); // idle past the TTL
+      expect(store.get('k')).toBeUndefined(); // evicted
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps keys indefinitely when idleTtlMs is unset', () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(0);
+      const store = storeFor({});
+
+      store.set('k', { hits: [0] });
+      jest.setSystemTime(60 * 60 * 1000); // an hour later
+      expect(store.get('k')).toEqual({ hits: [0] }); // never evicted
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/lib/rate-limit/rate-limit.module.ts
+++ b/lib/rate-limit/rate-limit.module.ts
@@ -1,0 +1,100 @@
+import {
+  DynamicModule,
+  Module,
+  ModuleMetadata,
+  Provider,
+} from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+
+import { CLOCK, SystemClock } from '../builtins/throttle/clock';
+import { MemoryStore, type KeyValueStore } from '../store/key-value-store';
+import { RateLimitInterceptor } from './rate-limit.interceptor';
+import {
+  RateLimitOptions,
+  RATE_LIMIT_OPTIONS,
+  RATE_LIMIT_STORE,
+} from './rate-limit.types';
+import { RateLimiter } from './rate-limiter';
+
+/**
+ * Options for `RateLimitModule.forRootAsync` — resolve the store/key/defaults
+ * from DI (e.g. a Redis store built from `ConfigService`) instead of passing
+ * them literally.
+ */
+export interface RateLimitModuleAsyncOptions
+  extends Pick<ModuleMetadata, 'imports'> {
+  inject?: any[];
+  useFactory: (...args: any[]) => Promise<RateLimitOptions> | RateLimitOptions;
+}
+
+/**
+ * Enables inbound rate-limiting (flood control). Import it once alongside
+ * `NestgramModule` — `RateLimitModule.forRoot({ default: { limit, windowMs } })`
+ * — to drop updates from a user/chat that exceeds the limit. Per-route control
+ * via `@RateLimit(...)` / `@SkipRateLimit()`.
+ *
+ * Self-contained, no privileged core: it registers a single public
+ * `APP_INTERCEPTOR` ({@link RateLimitInterceptor}) a user could have written.
+ * Omit the module to keep rate-limiting off entirely.
+ */
+@Module({})
+export class RateLimitModule {
+  private static readonly providers: Provider[] = [
+    // The limiter's own in-scope clock, so it never depends on the throttle
+    // feature's CLOCK provider being present. Tests drive time by constructing
+    // a RateLimiter directly with a fake clock (see rate-limiter.spec.ts).
+    { provide: CLOCK, useClass: SystemClock },
+    RateLimiter,
+    { provide: APP_INTERCEPTOR, useClass: RateLimitInterceptor },
+  ];
+
+  static forRoot(options: RateLimitOptions = {}): DynamicModule {
+    return {
+      module: RateLimitModule,
+      global: true,
+      providers: [
+        { provide: RATE_LIMIT_OPTIONS, useValue: options },
+        {
+          provide: RATE_LIMIT_STORE,
+          useFactory: (resolved: RateLimitOptions) =>
+            RateLimitModule.resolveStore(resolved),
+          inject: [RATE_LIMIT_OPTIONS],
+        },
+        ...this.providers,
+      ],
+    };
+  }
+
+  static forRootAsync(options: RateLimitModuleAsyncOptions): DynamicModule {
+    return {
+      module: RateLimitModule,
+      global: true,
+      imports: options.imports ?? [],
+      providers: [
+        {
+          provide: RATE_LIMIT_OPTIONS,
+          useFactory: options.useFactory,
+          inject: options.inject ?? [],
+        },
+        {
+          provide: RATE_LIMIT_STORE,
+          useFactory: (resolved: RateLimitOptions) =>
+            RateLimitModule.resolveStore(resolved),
+          inject: [RATE_LIMIT_OPTIONS],
+        },
+        ...this.providers,
+      ],
+    };
+  }
+
+  /**
+   * The configured store, or a default {@link MemoryStore}. The default carries
+   * no time-based TTL: per-route windows are unknown here, and a TTL shorter
+   * than a rule's window would evict a live counter and let a flood through.
+   * The {@link RateLimiter}'s lazy prune bounds each entry's size; supply a
+   * Redis-backed store with a native TTL to evict idle keys at scale.
+   */
+  private static resolveStore(options: RateLimitOptions): KeyValueStore {
+    return options.store ?? new MemoryStore();
+  }
+}

--- a/lib/rate-limit/rate-limit.module.ts
+++ b/lib/rate-limit/rate-limit.module.ts
@@ -88,13 +88,17 @@ export class RateLimitModule {
   }
 
   /**
-   * The configured store, or a default {@link MemoryStore}. The default carries
-   * no time-based TTL: per-route windows are unknown here, and a TTL shorter
-   * than a rule's window would evict a live counter and let a flood through.
-   * The {@link RateLimiter}'s lazy prune bounds each entry's size; supply a
-   * Redis-backed store with a native TTL to evict idle keys at scale.
+   * The configured store, or a default {@link MemoryStore} bounded by
+   * `idleTtlMs` when set. `MemoryStore`'s TTL is a sliding expiry refreshed on
+   * each `set`, and every allowed hit does a `set`, so an actively-hitting key
+   * stays alive — only a key idle longer than `idleTtlMs` is evicted. That is
+   * lossless when `idleTtlMs` ≥ the largest window: by the time the key is
+   * evicted its window has already emptied, so the counter would have allowed
+   * the next hit anyway. Left undefined the store keeps every key forever (one
+   * entry per distinct key); set `idleTtlMs` or supply a Redis store at scale.
+   * A custom `store` owns its own expiry, so `idleTtlMs` is ignored for it.
    */
   private static resolveStore(options: RateLimitOptions): KeyValueStore {
-    return options.store ?? new MemoryStore();
+    return options.store ?? new MemoryStore(options.idleTtlMs);
   }
 }

--- a/lib/rate-limit/rate-limit.types.ts
+++ b/lib/rate-limit/rate-limit.types.ts
@@ -51,11 +51,20 @@ export interface RateLimitOptions {
   default?: RateLimitRule;
   /**
    * Persistence for the counters. Default: a process-local {@link MemoryStore}
-   * with no time-based TTL (see {@link RateLimiter} for why). Supply a
-   * Redis-backed store for a multi-instance deploy or to evict idle keys; its
-   * native key TTL should be ≳ the largest window.
+   * (bounded by {@link RateLimitOptions.idleTtlMs} if set, else unbounded —
+   * see {@link RateLimiter}). Supply a Redis-backed store for a multi-instance
+   * deploy; its native key TTL should be ≳ the largest window.
    */
   store?: KeyValueStore;
+  /**
+   * Evict a key's counter after it has been idle this long (ms). Bounds the
+   * default in-memory store's memory. MUST be ≥ your largest window, otherwise
+   * a key still inside an active window could be evicted and let a flood
+   * through. Default: undefined (no eviction — fine for low-cardinality bots;
+   * for many users set this or supply a Redis store). Ignored when a custom
+   * `store` is supplied (that store owns its own expiry).
+   */
+  idleTtlMs?: number;
   /**
    * Default key strategy for every rule that doesn't set its own `key`. Default
    * {@link defaultConversationKey}. Return `undefined` to skip an update.

--- a/lib/rate-limit/rate-limit.types.ts
+++ b/lib/rate-limit/rate-limit.types.ts
@@ -1,0 +1,83 @@
+import type { TelegramExecutionContext } from '../engine/context';
+import type { KeyValueStore } from '../store/key-value-store';
+
+/**
+ * Computes the rate-limit scope key for an update. Default
+ * {@link defaultConversationKey} (bot · chat · user · forum topic · business
+ * connection). Return `undefined` to skip rate-limiting for this update — there
+ * is nothing to scope the counter to.
+ */
+export type RateLimitKey = (
+  ctx: TelegramExecutionContext,
+) => string | undefined;
+
+/**
+ * Called when an update is dropped for exceeding its limit. If it returns a
+ * value (e.g. a `string` or a `SendMessage`), that value is emitted as the
+ * interceptor's result and flows through the normal reply path — so the user
+ * can be warned. If it returns `undefined`/void, nothing is emitted (silent
+ * drop). May be async (return a `Promise` — `unknown` already admits one).
+ */
+export type OnRateLimit = (ctx: TelegramExecutionContext) => unknown;
+
+/**
+ * A single rate-limit rule: at most `limit` updates per rolling `windowMs`.
+ * Used both as the module-level default ({@link RateLimitOptions.default}) and
+ * as the per-route override carried by `@RateLimit(...)`.
+ */
+export interface RateLimitRule {
+  /** Max updates allowed within the window. */
+  limit: number;
+  /** Rolling window length in milliseconds. */
+  windowMs: number;
+  /** Per-route key override. Falls back to the module key, then the default. */
+  key?: RateLimitKey;
+  /** Per-route on-limit override. Falls back to the module callback. */
+  onLimit?: OnRateLimit;
+}
+
+/**
+ * Rate-limit configuration, passed to `RateLimitModule.forRoot`. Every field is
+ * optional: with no `default` and no `@RateLimit` on a route, the interceptor
+ * passes through (no limiting). The store and key strategy are swappable — no
+ * privileged core.
+ */
+export interface RateLimitOptions {
+  /**
+   * The fallback rule applied to every route that has neither its own
+   * `@RateLimit` nor `@SkipRateLimit`. Omit it to limit only the routes you
+   * explicitly decorate.
+   */
+  default?: RateLimitRule;
+  /**
+   * Persistence for the counters. Default: a process-local {@link MemoryStore}
+   * with no time-based TTL (see {@link RateLimiter} for why). Supply a
+   * Redis-backed store for a multi-instance deploy or to evict idle keys; its
+   * native key TTL should be ≳ the largest window.
+   */
+  store?: KeyValueStore;
+  /**
+   * Default key strategy for every rule that doesn't set its own `key`. Default
+   * {@link defaultConversationKey}. Return `undefined` to skip an update.
+   */
+  key?: RateLimitKey;
+  /**
+   * Default on-limit callback for every rule that doesn't set its own
+   * `onLimit`. Default: undefined (silent drop).
+   */
+  onLimit?: OnRateLimit;
+}
+
+/** DI token for the resolved rate-limit settings (provided by the module). */
+export const RATE_LIMIT_OPTIONS = 'nestgram:rate-limit:options';
+
+/** DI token for the {@link KeyValueStore} backing the counters. */
+export const RATE_LIMIT_STORE = 'nestgram:rate-limit:store';
+
+/** Reflect-metadata keys written by the rate-limit decorators. */
+export enum RateLimitMetadata {
+  /** A `@RateLimit(rule)` override on a handler or `@Router()` class. */
+  RULE = 'nestgram:rate-limit:rule',
+  /** A `@SkipRateLimit()` exemption on a handler or `@Router()` class. */
+  SKIP = 'nestgram:rate-limit:skip',
+}

--- a/lib/rate-limit/rate-limiter.spec.ts
+++ b/lib/rate-limit/rate-limiter.spec.ts
@@ -1,0 +1,74 @@
+import { FakeClock } from '../builtins/throttle/clock.fake';
+import { MemoryStore } from '../store/key-value-store';
+import { RateLimiter } from './rate-limiter';
+
+const LIMIT = 3;
+const WINDOW_MS = 1_000;
+const KEY = 'c1:u7';
+
+function build(): { limiter: RateLimiter; clock: FakeClock } {
+  const clock = new FakeClock();
+  const limiter = new RateLimiter(new MemoryStore(), clock);
+  return { limiter, clock };
+}
+
+describe('RateLimiter (sliding window)', () => {
+  it('allows up to the limit, then denies within the window', async () => {
+    const { limiter } = build();
+
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(true);
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(true);
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(true);
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(false);
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(false);
+  });
+
+  it('allows again once the window slides past the oldest hit', async () => {
+    const { limiter, clock } = build();
+
+    await limiter.hit(KEY, LIMIT, WINDOW_MS); // t=0
+    await limiter.hit(KEY, LIMIT, WINDOW_MS); // t=0
+    await limiter.hit(KEY, LIMIT, WINDOW_MS); // t=0
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(false);
+
+    // Slide past the three t=0 hits — all now older than the window.
+    await clock.advance(WINDOW_MS + 1);
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(true);
+  });
+
+  it('is a true sliding window — frees one slot at a time, no boundary burst', async () => {
+    const { limiter, clock } = build();
+
+    await limiter.hit(KEY, LIMIT, WINDOW_MS); // t=0
+    await clock.advance(400);
+    await limiter.hit(KEY, LIMIT, WINDOW_MS); // t=400
+    await clock.advance(400);
+    await limiter.hit(KEY, LIMIT, WINDOW_MS); // t=800 -> at limit
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(false);
+
+    // At t=1001 only the t=0 hit has expired -> exactly one slot frees.
+    await clock.advance(201); // now t=1001
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(true); // fills the freed slot
+    expect(await limiter.hit(KEY, LIMIT, WINDOW_MS)).toBe(false); // t=400/800/1001 full
+  });
+
+  it('scopes counters by key', async () => {
+    const { limiter } = build();
+
+    await limiter.hit('a', 1, WINDOW_MS);
+    expect(await limiter.hit('a', 1, WINDOW_MS)).toBe(false);
+    expect(await limiter.hit('b', 1, WINDOW_MS)).toBe(true);
+  });
+
+  it('does not advance the window on a denied hit', async () => {
+    const { limiter, clock } = build();
+
+    await limiter.hit(KEY, 1, WINDOW_MS); // t=0, fills the single slot
+    await clock.advance(600);
+    expect(await limiter.hit(KEY, 1, WINDOW_MS)).toBe(false); // t=600 denied, not recorded
+
+    // The slot frees WINDOW_MS after the t=0 hit, not after the denied t=600 one.
+    await clock.advance(401); // now t=1001 > 0 + WINDOW_MS
+    expect(await limiter.hit(KEY, 1, WINDOW_MS)).toBe(true);
+  });
+});

--- a/lib/rate-limit/rate-limiter.ts
+++ b/lib/rate-limit/rate-limiter.ts
@@ -30,11 +30,10 @@ interface SlidingWindowEntry {
  *
  * Memory is bounded per key by the lazy prune (an entry never holds more than
  * `limit` timestamps); the only unbounded axis is the number of distinct keys
- * ever seen. The default store carries no time-based TTL on purpose: a TTL
- * shorter than a rule's window would evict a live counter and let a flood slip
- * through, and windows are per-rule and unknown to the store. For a
- * multi-instance deploy, or to evict keys that go idle, supply a Redis-backed
- * store whose native key TTL is ≳ the largest window.
+ * ever seen. Left as-is the default store keeps every key forever — set
+ * `idleTtlMs` (≥ the largest window) to evict keys idle that long, or supply a
+ * Redis-backed store whose native key TTL is ≳ the largest window for a
+ * multi-instance deploy.
  */
 @Injectable()
 export class RateLimiter {

--- a/lib/rate-limit/rate-limiter.ts
+++ b/lib/rate-limit/rate-limiter.ts
@@ -1,0 +1,96 @@
+import { Inject, Injectable, Optional } from '@nestjs/common';
+
+import { Clock, CLOCK, SystemClock } from '../builtins/throttle/clock';
+import type { KeyValueStore } from '../store/key-value-store';
+import { RATE_LIMIT_STORE } from './rate-limit.types';
+
+/** The persisted shape of one key's counter: the timestamps of recent hits. */
+interface SlidingWindowEntry {
+  hits: number[];
+}
+
+/**
+ * Store-backed sliding-window counter, the heart of inbound flood control.
+ *
+ * Non-blocking: {@link hit} answers allow/deny immediately — it never waits for
+ * a token to free (that is the outbound send-throttle's job, and the wrong
+ * model here). On each call it loads the key's recent-hit timestamps, prunes
+ * those older than the window, and allows iff the remaining count is below the
+ * limit — a true sliding window, so it has none of a fixed window's
+ * burst-at-boundary doubling.
+ *
+ * Persistence is a swappable {@link KeyValueStore}: the default {@link
+ * MemoryStore} is process-local; a Redis-backed store makes the limit hold
+ * across replicas. Read-modify-write is NOT atomic — the same guarantee
+ * sessions and FSM already accept. Under concurrency several updates can read
+ * the same pre-write count and all be allowed, so a key can briefly exceed its
+ * limit by up to the in-flight count; acceptable for protective flood control,
+ * and a non-issue for the largely-sequential per-batch processing of long
+ * polling.
+ *
+ * Memory is bounded per key by the lazy prune (an entry never holds more than
+ * `limit` timestamps); the only unbounded axis is the number of distinct keys
+ * ever seen. The default store carries no time-based TTL on purpose: a TTL
+ * shorter than a rule's window would evict a live counter and let a flood slip
+ * through, and windows are per-rule and unknown to the store. For a
+ * multi-instance deploy, or to evict keys that go idle, supply a Redis-backed
+ * store whose native key TTL is ≳ the largest window.
+ */
+@Injectable()
+export class RateLimiter {
+  private readonly clock: Clock;
+
+  constructor(
+    @Inject(RATE_LIMIT_STORE) private readonly store: KeyValueStore,
+    // Optional so the limiter never hard-depends on the throttle feature's
+    // CLOCK provider. RateLimitModule provides a SystemClock in-scope; tests
+    // construct the limiter directly with a fake clock.
+    @Optional() @Inject(CLOCK) clock?: Clock,
+  ) {
+    this.clock = clock ?? new SystemClock();
+  }
+
+  /**
+   * Record an attempt against `key` and report whether it is allowed. When
+   * allowed, the hit is persisted; when denied, the window is left unchanged so
+   * a flood can't keep pushing the window forward.
+   */
+  async hit(key: string, limit: number, windowMs: number): Promise<boolean> {
+    const now = this.clock.now();
+    const cutoff = now - windowMs;
+
+    const entry = await this.load(key);
+    const recent = entry.hits.filter((at) => at > cutoff);
+
+    if (recent.length >= limit) {
+      // Persist the prune so an idle-then-flooding key doesn't carry stale
+      // timestamps forever, but don't add this denied hit to the window.
+      if (recent.length !== entry.hits.length) {
+        await this.store.set(key, {
+          hits: recent,
+        } satisfies SlidingWindowEntry);
+      }
+      return false;
+    }
+
+    recent.push(now);
+    await this.store.set(key, { hits: recent } satisfies SlidingWindowEntry);
+    return true;
+  }
+
+  private async load(key: string): Promise<SlidingWindowEntry> {
+    const raw = await this.store.get(key);
+    if (RateLimiter.isEntry(raw)) {
+      return raw;
+    }
+    return { hits: [] };
+  }
+
+  private static isEntry(value: unknown): value is SlidingWindowEntry {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      Array.isArray((value as SlidingWindowEntry).hits)
+    );
+  }
+}


### PR DESCRIPTION
## Problem

Nestgram has an outbound send-throttle (respecting Telegram's API limits), but nothing limits how often a *user* can trigger handlers. A spamming user could hammer expensive handlers (LLM calls, media generation) or flood state-changing flows unchecked.

## Change

Inbound flood control as a self-contained, opt-in module — no privileged core, the kind of interceptor a bot author could have written themselves.

- **`RateLimitModule.forRoot({ default: { limit, windowMs } })`** / `forRootAsync` — mirrors `SessionModule`. Omit the module → rate-limiting is off.
- **Global default + per-route override:** `@RateLimit({ limit, windowMs, key?, onLimit? })` on a handler or `@Router()` class; `@SkipRateLimit()` to exempt. Precedence: skip → nearest `@RateLimit` → module default.
- **Scope:** keyed by `defaultConversationKey` (bot · chat · user · forum topic · business connection) by default; overridable per-module or per-route via `key`. A `key` returning `undefined` passes the update through.
- **On limit:** silent drop by default. An optional `onLimit(ctx)` may return a `string`/`SendMessage` that flows through the normal reply path to warn the user.
- **Counter:** a non-blocking sliding-window log backed by the swappable `KeyValueStore`. On a denied hit the window is not advanced, so a sustained flood can't push it forward. Read-modify-write is non-atomic by design — the same guarantee sessions/FSM already accept.
- **Storage:** default in-memory `MemoryStore`; supply a Redis-backed store for multi-instance deployments. An optional `idleTtlMs` bounds the in-memory store's memory by evicting idle keys (must be ≥ the largest window).

Implemented as an `APP_INTERCEPTOR`, not a guard: a `CanActivate` returning `false` makes Nest throw `ForbiddenException` (not a silent drop, and it would hit the exception filters); an interceptor short-circuits cleanly.

Docs: new `docs/rate-limiting.md`; ROADMAP Phase 4 entry marked done.

## How to verify

- `npm run build`, `npm run lint`, `npx jest` — all green (87 suites, 648 tests; 18 new across 4 rate-limit specs covering under/over limit, per-route override, skip, custom key, `onLimit`, window reset, pass-through, and `idleTtlMs` eviction).
- `cd website && npm run build` — `docs/rate-limiting.md` renders under "The Nest pipeline".