### PR TITLE
feat: exception → reaction (ReplyException / AnswerException)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,6 +62,9 @@ Everything needed to ship a production bot.
       coerced, greedy last field)
 - [x] Pipes + `class-validator` DTOs for payloads — param pipes run through ECC
       (incl. `ValidationPipe`, with `validateCustomDecorators: true`)
+- [x] Exception → reaction — `throw new ReplyException(...)` /
+      `AnswerException(...)` from a guard/pipe/handler, mapped to a reply by a
+      built-in global `@Catch` filter (toggle with `replyExceptions`)
 
 ## Phase 3 — Conversations
 

--- a/docs/handling-errors.md
+++ b/docs/handling-errors.md
@@ -92,8 +92,8 @@ throw new ReplyException(new SendMessage({ chat_id, text: 'Done.' }));
 ### Answering a callback query
 
 For a button tap, the right reaction is a toast or modal alert, not a chat
-message. `AnswerException` answers the originating callback query — a subclass of
-`ReplyException`, so the same filter catches it:
+message. `AnswerException` answers the originating callback query — it shares the
+same base as `ReplyException`, so the same filter catches it:
 
 ```ts
 // A toast on the button:
@@ -107,11 +107,64 @@ Thrown on a non-callback update, it has no callback to answer, so the filter log
 a warning and does nothing.
 
 :::note[It's a plain `@Catch` filter — no privileged core]
-`ReplyException` handling is just a global `@Catch(ReplyException)` filter
+`ReplyException` handling is just a global `@Catch(ReplyExceptionBase)` filter
 `NestgramModule` registers — exactly the kind you could write yourself. Define
 your own domain exceptions and `@Catch(MyError)` filters the same way; they run
 in the same Nest pipeline, ahead of the framework's own error logging.
 :::
+
+### Sharing a service with HTTP
+
+`ReplyException` lives on the **Telegram layer** — throw it from a handler,
+guard, or interceptor, just as you'd throw `HttpException` from a controller.
+Don't throw it from a domain service you also call over HTTP: that service
+shouldn't know the shape of a Telegram reply.
+
+Instead, throw a plain **domain error** and let each transport map it. It's
+**one `@Catch` filter per transport, not one per error** — and because the
+filter holds the context, it picks the right reaction by update kind:
+
+:::code[telegram-error.filter.ts]
+
+```ts
+import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
+import {
+  CallbackQuery,
+  Message,
+  TelegramExecutionContext,
+  UpdateKind,
+} from 'nestgram';
+
+// Domain layer — transport-agnostic, reused over HTTP and Telegram:
+export abstract class AppError extends Error {}
+export class InsufficientFundsError extends AppError {
+  constructor(readonly shortBy: number) {
+    super(`Not enough funds — short by ${shortBy}.`);
+  }
+}
+
+// Telegram adapter — ONE filter for the whole AppError family:
+@Catch(AppError)
+export class TelegramErrorFilter implements ExceptionFilter {
+  async catch(error: AppError, host: ArgumentsHost): Promise<void> {
+    const ctx = TelegramExecutionContext.of(host);
+    if (ctx.kind === UpdateKind.CallbackQuery) {
+      await (ctx.event as CallbackQuery).alert(error.message);
+    } else {
+      await (ctx.event as Message).answer(error.message);
+    }
+  }
+}
+```
+
+:::
+
+The HTTP side registers its own `@Catch(AppError)` filter mapping the same error
+to, say, a `409` — the service stays oblivious to both. The trade-off is
+fundamental, and you pick per case: a `ReplyException` **knows** its presentation
+(zero filters, but Telegram-coupled), a domain error **doesn't** (reusable across
+transports, at the cost of one filter). A Telegram-only bot wants `ReplyException`
+and no filters at all.
 
 It pairs naturally with [rate limiting](/docs/rate-limiting): an `onLimit`
 callback can `throw new ReplyException('Slow down.')` to warn the flooder instead

--- a/docs/handling-errors.md
+++ b/docs/handling-errors.md
@@ -1,6 +1,6 @@
 ---
 title: Handling errors
-description: React to Telegram API failures with typed ApiException predicates, and silence the edit no-op with ignoreNotModified.
+description: Reply by throwing a ReplyException, react to Telegram API failures with typed ApiException predicates, and silence the edit no-op with ignoreNotModified.
 sidebar:
   label: Handling errors
   group: The Nest pipeline
@@ -15,6 +15,128 @@ from an error thrown _inside_ a handler, which a standard
 
 :::mental
 Telegram rejects the call -> ApiException -> predicate -> react
+:::
+
+## Replying by throwing: `ReplyException`
+
+The other side of error handling is the **handler side** — bailing out of a
+request and telling the user why. Nest's idiom for this is `throw new
+HttpException(...)`; Nestgram's is `throw new ReplyException(...)`. Throw it
+anywhere in the pipeline — a guard, a pipe, an interceptor, or the handler — and
+a built-in global exception filter sends the reply and stops the request. No
+`return`, no threading a "denied" flag back to the handler.
+
+:::mental
+throw ReplyException -> filter catches -> reply sent -> request stops
+:::
+
+A guard is the natural home: deny **and** explain in one `throw`, instead of
+returning `false` (which is silent) and explaining somewhere else.
+
+:::code[admin.guard.ts]{mark="11"}
+
+```ts
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { ReplyException, TelegramExecutionContext } from 'nestgram';
+
+const ADMIN_IDS = [42, 1337];
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const { from } = TelegramExecutionContext.of(context);
+    if (from && ADMIN_IDS.includes(from.id)) {
+      return true;
+    }
+    throw new ReplyException('Only admins can do that.');
+  }
+}
+```
+
+:::
+
+The handler never runs; the user gets the message. The same `throw` works for
+handler-level validation — guard clauses read top-to-bottom instead of nesting:
+
+:::code[rename.router.ts]{mark="9"}
+
+```ts
+import { Command } from 'nestgram';
+import { Message, ReplyException } from 'nestgram';
+
+@Router()
+export class RenameRouter {
+  @Command('rename')
+  rename(message: Message): string {
+    const name = message.text?.split(' ').slice(1).join(' ').trim();
+    if (!name) {
+      throw new ReplyException('Usage: /rename <new name>');
+    }
+    return `Renamed to ${name}.`;
+  }
+}
+```
+
+The reply mirrors a handler's [return value](/docs/replying) exactly: a string
+replies to the same chat, and a command object goes out as-is. Pass reply
+options after the text, or hand it a ready-made command:
+
+```ts
+// Text with reply options (a keyboard, a reply target…):
+throw new ReplyException('Pick one:', { reply_markup: keyboard });
+
+// A full command object — the layer beneath `message.answer(...)`:
+throw new ReplyException(new SendMessage({ chat_id, text: 'Done.' }));
+```
+
+### Answering a callback query
+
+For a button tap, the right reaction is a toast or modal alert, not a chat
+message. `AnswerException` answers the originating callback query — a subclass of
+`ReplyException`, so the same filter catches it:
+
+```ts
+// A toast on the button:
+throw new AnswerException('Too fast — slow down.');
+
+// A modal alert:
+throw new AnswerException('Not allowed', { show_alert: true });
+```
+
+Thrown on a non-callback update, it has no callback to answer, so the filter logs
+a warning and does nothing.
+
+:::note[It's a plain `@Catch` filter — no privileged core]
+`ReplyException` handling is just a global `@Catch(ReplyException)` filter
+`NestgramModule` registers — exactly the kind you could write yourself. Define
+your own domain exceptions and `@Catch(MyError)` filters the same way; they run
+in the same Nest pipeline, ahead of the framework's own error logging.
+:::
+
+It pairs naturally with [rate limiting](/docs/rate-limiting): an `onLimit`
+callback can `throw new ReplyException('Slow down.')` to warn the flooder instead
+of dropping their update silently.
+
+To turn the built-in off — and let `ReplyException`/`AnswerException` propagate
+like any other error — set `replyExceptions: false` on `NestgramModule.forRoot`:
+
+:::code[app.module.ts]{mark="8"}
+
+```ts
+import { Module } from '@nestjs/common';
+import { NestgramModule } from 'nestgram';
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      token: process.env.BOT_TOKEN ?? '',
+      replyExceptions: false,
+    }),
+  ],
+})
+export class AppModule {}
+```
+
 :::
 
 ## The problem with `description`

--- a/docs/handling-errors.md
+++ b/docs/handling-errors.md
@@ -131,27 +131,39 @@ import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
 import {
   CallbackQuery,
   Message,
+  t,
   TelegramExecutionContext,
   UpdateKind,
 } from 'nestgram';
 
-// Domain layer — transport-agnostic, reused over HTTP and Telegram:
-export abstract class AppError extends Error {}
+// Domain layer — transport-agnostic, reused over HTTP and Telegram. Carries a
+// stable `code` and structured fields for rendering, never the user-facing copy:
+export abstract class AppError extends Error {
+  abstract readonly code: string;
+  readonly params: Record<string, string | number> = {};
+}
 export class InsufficientFundsError extends AppError {
+  readonly code = 'insufficient_funds';
+  readonly params: Record<string, string | number>;
   constructor(readonly shortBy: number) {
-    super(`Not enough funds — short by ${shortBy}.`);
+    super(`short by ${shortBy}`); // developer-facing — logs, not the user
+    this.params = { shortBy };
   }
 }
 
-// Telegram adapter — ONE filter for the whole AppError family:
+// Telegram adapter — ONE filter for the whole AppError family. The user-facing
+// copy is rendered here from the `code` (a translation key), so the reply is
+// localized and the domain stays oblivious to it:
 @Catch(AppError)
 export class TelegramErrorFilter implements ExceptionFilter {
   async catch(error: AppError, host: ArgumentsHost): Promise<void> {
     const ctx = TelegramExecutionContext.of(host);
+    const text = t(`errors.${error.code}`, error.params);
+    // Branch by update kind — this transport's own concern, not the domain's:
     if (ctx.kind === UpdateKind.CallbackQuery) {
-      await (ctx.event as CallbackQuery).alert(error.message);
+      await (ctx.event as CallbackQuery).alert(text);
     } else {
-      await (ctx.event as Message).answer(error.message);
+      await (ctx.event as Message).answer(text);
     }
   }
 }
@@ -160,11 +172,98 @@ export class TelegramErrorFilter implements ExceptionFilter {
 :::
 
 The HTTP side registers its own `@Catch(AppError)` filter mapping the same error
-to, say, a `409` — the service stays oblivious to both. The trade-off is
-fundamental, and you pick per case: a `ReplyException` **knows** its presentation
-(zero filters, but Telegram-coupled), a domain error **doesn't** (reusable across
-transports, at the cost of one filter). A Telegram-only bot wants `ReplyException`
-and no filters at all.
+to, say, a `409` and a JSON body — the service stays oblivious to both.
+
+:::note[Two rules keep the seam clean]
+The domain error carries a stable `code` and structured fields; `error.message`
+stays developer-facing (logs). Each transport renders its **own** user copy from
+the `code` — here an [i18n](/docs/i18n) key, so the reply is localized — so adding
+an error is a new translation entry, not a new `if`. Presentation belongs to the
+transport, never the domain.
+
+Branch by **update kind within a transport** — a callback wants an alert, a
+message an answer — as freely as you like; that's the adapter's own business.
+Branching by **transport inside the domain** is the smell this whole pattern
+removes.
+:::
+
+The trade-off is fundamental, and you pick per case: a `ReplyException` **knows**
+its presentation (zero filters, but Telegram-coupled), a domain error **doesn't**
+(reusable across transports, at the cost of one filter). A Telegram-only bot wants
+`ReplyException` and no filters at all.
+
+### When the service already throws `HttpException`
+
+Plenty of existing apps have no neutral domain error — the service throws Nest's
+HTTP shortcuts directly (`throw new NotFoundException(...)`, `ForbiddenException`,
+…). You don't have to refactor them to bolt on a bot. An `HttpException` already
+carries a transport-neutral discriminator — its **status code** — so one filter
+maps the whole family to a reply, and the HTTP app stays untouched:
+
+:::code[telegram-http.filter.ts]
+
+```ts
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  CallbackQuery,
+  Message,
+  t,
+  TelegramExecutionContext,
+  UpdateKind,
+} from 'nestgram';
+
+// The HTTP status is the shared semantic code — key localized copy off it,
+// with a catch-all, so the service is never touched:
+const KEY_BY_STATUS: Partial<Record<number, string>> = {
+  [HttpStatus.FORBIDDEN]: 'forbidden',
+  [HttpStatus.NOT_FOUND]: 'not_found',
+  [HttpStatus.CONFLICT]: 'conflict',
+};
+
+@Catch(HttpException)
+export class TelegramHttpExceptionFilter implements ExceptionFilter {
+  async catch(error: HttpException, host: ArgumentsHost): Promise<void> {
+    const ctx = TelegramExecutionContext.of(host);
+    const text = t(`errors.${KEY_BY_STATUS[error.getStatus()] ?? 'unknown'}`);
+    if (ctx.kind === UpdateKind.CallbackQuery) {
+      await (ctx.event as CallbackQuery).alert(text);
+    } else {
+      await (ctx.event as Message).answer(text);
+    }
+  }
+}
+```
+
+:::
+
+Apply it to the **Telegram side only** — on your routers, via `@UseFilters`:
+
+```ts
+@Router()
+@UseFilters(TelegramHttpExceptionFilter)
+export class SupportRouter {
+  /* … */
+}
+```
+
+:::warn[Don't register this one globally]
+A global `@Catch(HttpException)` filter (`APP_FILTER` / `useGlobalFilters`) runs
+for HTTP requests too and would hijack your existing JSON error responses. Scope
+it with `@UseFilters` on the routers (or a shared base router) so Nest's built-in
+handler keeps serving HTTP byte-for-byte unchanged.
+:::
+
+It's a pragmatic bridge, not a hack: the status code genuinely encodes the
+semantic, so reusing it across transports is honest. That the service throws
+`HttpException` at all is still a transport leak — the cleaner endgame is the
+plain domain error above, mapped per transport. Migrate when you can; until then,
+one filter attaches the bot without touching a line of the existing app.
 
 It pairs naturally with [rate limiting](/docs/rate-limiting): an `onLimit`
 callback can `throw new ReplyException('Slow down.')` to warn the flooder instead

--- a/lib/api/bot.service.ts
+++ b/lib/api/bot.service.ts
@@ -16,7 +16,13 @@ import { ApiError, ApiResponse } from './api-response';
 import { createAttachedData, createInlineData } from './form-data';
 import { ApiCallContext, ApiPipeline, ApiRequest } from './request';
 import { GeneratedBotMethods } from './generated-bot-methods';
-import { ApiMethod, GetMe, GetFile, GetFileOptions } from './methods';
+import {
+  ApiMethod,
+  GetMe,
+  GetFile,
+  GetFileOptions,
+  SendMessageOptions,
+} from './methods';
 
 const TELEGRAM_API_BASE = 'https://api.telegram.org';
 
@@ -34,6 +40,13 @@ export interface CallOptions {
  * target another bot or be aborted: `bot.sendMessage(id, 'hi', { token, signal })`.
  */
 export type MethodOptions<T = unknown> = Partial<T> & CallOptions;
+
+/**
+ * Options for a text reply — a `sendMessage` payload (keyboard, reply target,
+ * parse mode…) plus the per-call controls. The single home for the type the
+ * return-value contract, `ResultHandler`, and `ReplyException` all share.
+ */
+export type ReplyOptions = MethodOptions<SendMessageOptions>;
 
 @Injectable()
 export class BotService extends GeneratedBotMethods {

--- a/lib/builtins/index.ts
+++ b/lib/builtins/index.ts
@@ -4,3 +4,4 @@ export * from './rich-messages';
 export * from './ignore-not-modified';
 export * from './token-validation';
 export * from './auto-answer';
+export * from './reply-exception';

--- a/lib/builtins/reply-exception/index.ts
+++ b/lib/builtins/reply-exception/index.ts
@@ -1,0 +1,1 @@
+export * from './reply-exception.filter';

--- a/lib/builtins/reply-exception/reply-exception.filter.spec.ts
+++ b/lib/builtins/reply-exception/reply-exception.filter.spec.ts
@@ -1,0 +1,156 @@
+import { ArgumentsHost } from '@nestjs/common';
+
+import { ReplyExceptionFilter } from './reply-exception.filter';
+import { ResultHandler } from '../../engine/execution';
+import { UpdateKind } from '../../engine/context';
+import { AnswerException, ReplyException } from '../../exceptions';
+import { SendMessage } from '../../api/methods';
+import type { NestgramModuleOptions } from '../../module/nestgram-module.types';
+
+const REPLY_TEXT = 'Only admins.';
+const ALERT_TEXT = 'Too fast.';
+
+/** A fake event that records its `answer(text, options)` calls. */
+class FakeEvent {
+  readonly answered: Array<{ text?: string; options?: unknown }> = [];
+  answer(text?: string, options?: unknown): Promise<void> {
+    this.answered.push({ text, options });
+    return Promise.resolve();
+  }
+}
+
+/** A fake context with no `answer` (e.g. a poll) — used for the warn path. */
+class AnswerlessContext {
+  readonly kind = UpdateKind.Message;
+  readonly event = {};
+}
+
+interface FakeCtx {
+  kind: UpdateKind;
+  event: FakeEvent;
+}
+
+function host(ctx: unknown): ArgumentsHost {
+  return {
+    getArgByIndex: (index: number) => (index === 1 ? ctx : undefined),
+  } as ArgumentsHost;
+}
+
+function makeCtx(kind: UpdateKind): FakeCtx {
+  return { kind, event: new FakeEvent() };
+}
+
+function filterWith(options: NestgramModuleOptions): {
+  filter: ReplyExceptionFilter;
+  resultHandler: jest.Mocked<ResultHandler>;
+} {
+  const resultHandler = {
+    handle: jest.fn().mockResolvedValue(undefined),
+  } as unknown as jest.Mocked<ResultHandler>;
+  return {
+    filter: new ReplyExceptionFilter(resultHandler, options),
+    resultHandler,
+  };
+}
+
+describe('ReplyExceptionFilter', () => {
+  it('delegates a bare-string ReplyException to ResultHandler (DRY with handler returns)', async () => {
+    const { filter, resultHandler } = filterWith({});
+    const ctx = makeCtx(UpdateKind.Message);
+
+    await filter.catch(new ReplyException(REPLY_TEXT), host(ctx));
+
+    expect(resultHandler.handle).toHaveBeenCalledWith(
+      REPLY_TEXT,
+      ctx,
+      undefined,
+    );
+    expect(ctx.event.answered).toHaveLength(0);
+  });
+
+  it('delegates a command-object ReplyException to ResultHandler', async () => {
+    const { filter, resultHandler } = filterWith({});
+    const ctx = makeCtx(UpdateKind.Message);
+    const command = new SendMessage({ chat_id: 1, text: REPLY_TEXT });
+
+    await filter.catch(new ReplyException(command), host(ctx));
+
+    expect(resultHandler.handle).toHaveBeenCalledWith(command, ctx, undefined);
+  });
+
+  it('delegates a string + options ReplyException to ResultHandler with the options', async () => {
+    const { filter, resultHandler } = filterWith({});
+    const ctx = makeCtx(UpdateKind.Message);
+    const replyMarkup = { force_reply: true } as const;
+
+    await filter.catch(
+      new ReplyException(REPLY_TEXT, { reply_markup: replyMarkup }),
+      host(ctx),
+    );
+
+    expect(resultHandler.handle).toHaveBeenCalledWith(REPLY_TEXT, ctx, {
+      reply_markup: replyMarkup,
+    });
+  });
+
+  it('answers the callback query for AnswerException on a callback update', async () => {
+    const { filter, resultHandler } = filterWith({});
+    const ctx = makeCtx(UpdateKind.CallbackQuery);
+
+    await filter.catch(
+      new AnswerException(ALERT_TEXT, { show_alert: true }),
+      host(ctx),
+    );
+
+    expect(resultHandler.handle).not.toHaveBeenCalled();
+    expect(ctx.event.answered).toEqual([
+      { text: ALERT_TEXT, options: { show_alert: true } },
+    ]);
+  });
+
+  it('ignores AnswerException on a non-callback update (callback-only)', async () => {
+    const { filter, resultHandler } = filterWith({});
+    const ctx = makeCtx(UpdateKind.Message);
+
+    await filter.catch(new AnswerException(ALERT_TEXT), host(ctx));
+
+    expect(resultHandler.handle).not.toHaveBeenCalled();
+    expect(ctx.event.answered).toHaveLength(0);
+  });
+
+  it('does not throw on a context whose event cannot answer (delegated to ResultHandler)', async () => {
+    const { filter, resultHandler } = filterWith({});
+
+    // The "no answer()" warning lives in ResultHandler now; the filter just
+    // delegates and must not surface an error.
+    await expect(
+      filter.catch(
+        new ReplyException(REPLY_TEXT, { reply_markup: { force_reply: true } }),
+        host(new AnswerlessContext()),
+      ),
+    ).resolves.toBeUndefined();
+    expect(resultHandler.handle).toHaveBeenCalled();
+  });
+
+  it('re-throws when replyExceptions is false (self-disabled)', async () => {
+    const { filter, resultHandler } = filterWith({ replyExceptions: false });
+    const exception = new ReplyException(REPLY_TEXT);
+
+    await expect(
+      filter.catch(exception, host(makeCtx(UpdateKind.Message))),
+    ).rejects.toBe(exception);
+    expect(resultHandler.handle).not.toHaveBeenCalled();
+  });
+
+  it('swallows a send failure instead of re-throwing the control-flow exception', async () => {
+    const { filter, resultHandler } = filterWith({});
+    resultHandler.handle.mockRejectedValueOnce(new Error('send failed'));
+
+    await expect(
+      filter.catch(
+        new ReplyException(REPLY_TEXT),
+        host(makeCtx(UpdateKind.Message)),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/lib/builtins/reply-exception/reply-exception.filter.ts
+++ b/lib/builtins/reply-exception/reply-exception.filter.ts
@@ -9,7 +9,11 @@ import {
 
 import { TelegramExecutionContext, UpdateKind } from '../../engine/context';
 import { ResultHandler } from '../../engine/execution';
-import { AnswerException, ReplyException } from '../../exceptions';
+import {
+  AnswerException,
+  ReplyException,
+  ReplyExceptionBase,
+} from '../../exceptions';
 import { Providers } from '../../providers';
 import type { CallbackQuery } from '../../events';
 import type { NestgramModuleOptions } from '../../module/nestgram-module.types';
@@ -28,7 +32,7 @@ import type { NestgramModuleOptions } from '../../module/nestgram-module.types';
  * logging path, just as if the feature didn't exist.
  */
 @Injectable()
-@Catch(ReplyException)
+@Catch(ReplyExceptionBase)
 export class ReplyExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(ReplyExceptionFilter.name);
 
@@ -38,7 +42,10 @@ export class ReplyExceptionFilter implements ExceptionFilter {
     private readonly options: NestgramModuleOptions,
   ) {}
 
-  async catch(exception: ReplyException, host: ArgumentsHost): Promise<void> {
+  async catch(
+    exception: ReplyExceptionBase,
+    host: ArgumentsHost,
+  ): Promise<void> {
     if (this.options.replyExceptions === false) {
       // Self-disabled: let it flow to the dispatcher's catch like any other error.
       throw exception;
@@ -59,7 +66,7 @@ export class ReplyExceptionFilter implements ExceptionFilter {
 
   /** Resolve the exception to its Telegram reaction and dispatch it. */
   private async react(
-    exception: ReplyException,
+    exception: ReplyExceptionBase,
     ctx: TelegramExecutionContext,
   ): Promise<void> {
     if (exception instanceof AnswerException) {
@@ -67,10 +74,16 @@ export class ReplyExceptionFilter implements ExceptionFilter {
       return;
     }
 
-    // String (with or without options) or a command object — the handler
-    // return-value contract exactly. Reuse ResultHandler so reply/command
-    // semantics (and the can't-answer warning) stay in one place.
-    await this.resultHandler.handle(exception.content, ctx, exception.options);
+    if (exception instanceof ReplyException) {
+      // String (with or without options) or a command object — the handler
+      // return-value contract exactly. Reuse ResultHandler so reply/command
+      // semantics (and the can't-answer warning) stay in one place.
+      await this.resultHandler.handle(
+        exception.content,
+        ctx,
+        exception.options,
+      );
+    }
   }
 
   /** Answer the originating callback query (toast/alert). Callback-only. */

--- a/lib/builtins/reply-exception/reply-exception.filter.ts
+++ b/lib/builtins/reply-exception/reply-exception.filter.ts
@@ -1,0 +1,92 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  Inject,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+
+import { TelegramExecutionContext, UpdateKind } from '../../engine/context';
+import { ResultHandler } from '../../engine/execution';
+import { AnswerException, ReplyException } from '../../exceptions';
+import { Providers } from '../../providers';
+import type { CallbackQuery } from '../../events';
+import type { NestgramModuleOptions } from '../../module/nestgram-module.types';
+
+/**
+ * Maps a thrown {@link ReplyException}/{@link AnswerException} to a Telegram
+ * reply — the framework's `HttpException -> filter` idiom. Throw one from a
+ * guard, pipe, interceptor, or handler and this global `@Catch` filter sends the
+ * reaction; the original control-flow exception is consumed, so the dispatcher
+ * sees a clean completion (no error log).
+ *
+ * A plain Nest exception filter (registered globally by `NestgramModule` as an
+ * `APP_FILTER`) that self-disables when `replyExceptions` is `false` — exactly
+ * the kind a bot author could write, proving the "no privileged core" principle.
+ * When off it re-throws, so the exception propagates to the dispatcher's normal
+ * logging path, just as if the feature didn't exist.
+ */
+@Injectable()
+@Catch(ReplyException)
+export class ReplyExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(ReplyExceptionFilter.name);
+
+  constructor(
+    private readonly resultHandler: ResultHandler,
+    @Inject(Providers.NESTGRAM_OPTIONS)
+    private readonly options: NestgramModuleOptions,
+  ) {}
+
+  async catch(exception: ReplyException, host: ArgumentsHost): Promise<void> {
+    if (this.options.replyExceptions === false) {
+      // Self-disabled: let it flow to the dispatcher's catch like any other error.
+      throw exception;
+    }
+
+    const ctx = TelegramExecutionContext.of(host);
+
+    try {
+      await this.react(exception, ctx);
+    } catch (sendError) {
+      // A failed reaction must not become an unhandled rejection nor re-surface
+      // the original control-flow exception (already consumed) — log and stop.
+      this.logger.warn(
+        `Failed to send reply for ${exception.name}: ${sendError}`,
+      );
+    }
+  }
+
+  /** Resolve the exception to its Telegram reaction and dispatch it. */
+  private async react(
+    exception: ReplyException,
+    ctx: TelegramExecutionContext,
+  ): Promise<void> {
+    if (exception instanceof AnswerException) {
+      await this.answerCallback(exception, ctx);
+      return;
+    }
+
+    // String (with or without options) or a command object — the handler
+    // return-value contract exactly. Reuse ResultHandler so reply/command
+    // semantics (and the can't-answer warning) stay in one place.
+    await this.resultHandler.handle(exception.content, ctx, exception.options);
+  }
+
+  /** Answer the originating callback query (toast/alert). Callback-only. */
+  private async answerCallback(
+    exception: AnswerException,
+    ctx: TelegramExecutionContext,
+  ): Promise<void> {
+    if (ctx.kind !== UpdateKind.CallbackQuery) {
+      this.logger.warn(
+        `AnswerException thrown on "${ctx.kind}", but answering is callback-only — ignored`,
+      );
+      return;
+    }
+
+    // An AnswerException always carries a string (its constructor takes `text`).
+    const event = ctx.event as CallbackQuery;
+    await event.answer(exception.text, exception.answerOptions);
+  }
+}

--- a/lib/builtins/reply-exception/reply-exception.integration.spec.ts
+++ b/lib/builtins/reply-exception/reply-exception.integration.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Exercises the `exception -> reaction` feature end to end through the REAL
+ * pipeline ({@link NestgramTestbed}): a thrown {@link ReplyException} from a
+ * handler or a guard is mapped to a Telegram reply by the built-in
+ * {@link ReplyExceptionFilter}, which sits in the same ECC pipeline as the
+ * handler. Also proves the `replyExceptions: false` opt-out and that a plain
+ * error is unaffected.
+ */
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UseGuards,
+} from '@nestjs/common';
+
+import { Action } from '../../decorators/listeners/action.decorator';
+import { Command } from '../../decorators/listeners/command.decorator';
+import { Router } from '../../decorators/injectable/router.decorator';
+import { CallbackQuery } from '../../events/callback-query';
+import { SendMessage } from '../../api/methods';
+import { AnswerException, ReplyException } from '../../exceptions';
+import { NestgramTestbed } from '../../testing/nestgram-testbed';
+import { updates } from '../../testing/update-factory';
+
+const ADMINS_ONLY = 'Only admins can do that.';
+const VALIDATION_REPLY = 'Name is required.';
+const TOO_FAST = 'Too fast — slow down.';
+const COMMAND_TEXT = 'Done via command.';
+const CHAT_ID = 99;
+
+@Injectable()
+class AdminGuard implements CanActivate {
+  canActivate(_context: ExecutionContext): boolean {
+    throw new ReplyException(ADMINS_ONLY);
+  }
+}
+
+@Router()
+class ExceptionRouter {
+  @UseGuards(AdminGuard)
+  @Command('admin')
+  admin(): string {
+    return 'you should never see this';
+  }
+
+  @Command('validate')
+  validate(): void {
+    throw new ReplyException(VALIDATION_REPLY);
+  }
+
+  @Command('saved')
+  saved(): void {
+    throw new ReplyException(COMMAND_TEXT, {
+      reply_markup: { force_reply: true },
+    });
+  }
+
+  @Command('command')
+  command(): void {
+    throw new ReplyException(
+      new SendMessage({ chat_id: CHAT_ID, text: COMMAND_TEXT }),
+    );
+  }
+
+  @Command('boom')
+  boom(): void {
+    throw new Error('plain error');
+  }
+
+  @Action('rate')
+  rate(_query: CallbackQuery): void {
+    throw new AnswerException(TOO_FAST, { show_alert: true });
+  }
+}
+
+describe('ReplyException -> reaction (integration)', () => {
+  let bot: NestgramTestbed;
+
+  afterEach(async () => {
+    await bot?.close();
+  });
+
+  it('replies when a HANDLER throws ReplyException(string)', async () => {
+    bot = await NestgramTestbed.create({ routers: [ExceptionRouter] });
+    await bot.dispatch(updates.command('validate'));
+
+    expect(bot.lastMessage?.text).toBe(VALIDATION_REPLY);
+    expect(bot.lastError).toBeUndefined();
+  });
+
+  it('replies when a GUARD throws and suppresses the handler', async () => {
+    bot = await NestgramTestbed.create({ routers: [ExceptionRouter] });
+    await bot.dispatch(updates.command('admin'));
+
+    // The guard short-circuits before the handler: the only reply is the guard's
+    // ReplyException, never the handler's own return string.
+    expect(bot.calls(SendMessage)).toHaveLength(1);
+    expect(bot.lastMessage?.text).toBe(ADMINS_ONLY);
+    expect(bot.lastError).toBeUndefined();
+  });
+
+  it('applies reply options on a string + options ReplyException', async () => {
+    bot = await NestgramTestbed.create({ routers: [ExceptionRouter] });
+    await bot.dispatch(updates.command('saved'));
+
+    expect(bot.lastMessage?.text).toBe(COMMAND_TEXT);
+    expect(bot.lastMessage?.reply_markup).toEqual({ force_reply: true });
+  });
+
+  it('sends a command-object ReplyException through the bot', async () => {
+    bot = await NestgramTestbed.create({ routers: [ExceptionRouter] });
+    await bot.dispatch(updates.command('command'));
+
+    const sent = bot.calls(SendMessage).at(-1);
+    expect(sent?.payload.chat_id).toBe(CHAT_ID);
+    expect(sent?.payload.text).toBe(COMMAND_TEXT);
+  });
+
+  it('answers the callback query on AnswerException', async () => {
+    bot = await NestgramTestbed.create({ routers: [ExceptionRouter] });
+    await bot.dispatch(updates.callbackQuery('rate'));
+
+    const answer = bot.calls('answerCallbackQuery').at(-1);
+    expect(answer?.payload.text).toBe(TOO_FAST);
+    expect(answer?.payload.show_alert).toBe(true);
+    expect(bot.lastError).toBeUndefined();
+  });
+
+  it('does not reply when replyExceptions is false (exception propagates)', async () => {
+    // The disabled filter re-throws, so the exception flows past it to the
+    // dispatcher's normal logging path — no reply is sent. (It bypasses the
+    // testbed's catch-all CaptureErrorFilter because Nest invokes only the first
+    // matching filter, our @Catch(ReplyException), so `lastError` is not the
+    // observable here — the absence of any reply is.)
+    bot = await NestgramTestbed.create({
+      routers: [ExceptionRouter],
+      replyExceptions: false,
+    });
+    await bot.dispatch(updates.command('validate'));
+
+    expect(bot.lastMessage).toBeUndefined();
+    expect(bot.calls(SendMessage)).toHaveLength(0);
+  });
+
+  it('leaves a non-ReplyException error untouched (still propagates)', async () => {
+    bot = await NestgramTestbed.create({ routers: [ExceptionRouter] });
+    await bot.dispatch(updates.command('boom'));
+
+    expect(bot.lastError).toBeInstanceOf(Error);
+    expect((bot.lastError as Error).message).toBe('plain error');
+    expect(bot.lastMessage).toBeUndefined();
+  });
+});

--- a/lib/engine/context/telegram-execution-context.ts
+++ b/lib/engine/context/telegram-execution-context.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from '@nestjs/common';
+import { ArgumentsHost } from '@nestjs/common';
 
 import { BotService } from '../../api';
 import { User } from '../../events/user';
@@ -68,12 +68,14 @@ export class TelegramExecutionContext {
   }
 
   /**
-   * Read the Nestgram execution context out of a Nest `ExecutionContext`.
+   * Read the Nestgram execution context out of a Nest `ArgumentsHost`.
    *
    * The engine invokes handlers as `invoker(event, ctx)`, so the wrapper is at
-   * argument index 1.
+   * argument index 1. Accepts the broader `ArgumentsHost` (the supertype of
+   * `ExecutionContext`) so an exception filter — which receives an
+   * `ArgumentsHost`, not a full `ExecutionContext` — can read the same wrapper.
    */
-  static of(context: ExecutionContext): TelegramExecutionContext {
-    return context.getArgByIndex(1);
+  static of(host: ArgumentsHost): TelegramExecutionContext {
+    return host.getArgByIndex(1);
   }
 }

--- a/lib/engine/execution/result-handler.ts
+++ b/lib/engine/execution/result-handler.ts
@@ -2,11 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { TelegramExecutionContext } from '../context/telegram-execution-context';
 import { TelegramEvent } from '../context/event-factory';
-import { ApiMethod, SendMessageOptions } from '../../api/methods';
-import type { MethodOptions } from '../../api';
-
-/** Reply options applied when the result is a string (a keyboard, reply target…). */
-type ReplyOptions = MethodOptions<SendMessageOptions>;
+import { ApiMethod } from '../../api/methods';
+import type { ReplyOptions } from '../../api';
 
 /** An event that can reply to itself with optional reply options (e.g. `Message.answer`). */
 interface Answerable {

--- a/lib/engine/execution/result-handler.ts
+++ b/lib/engine/execution/result-handler.ts
@@ -2,11 +2,15 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { TelegramExecutionContext } from '../context/telegram-execution-context';
 import { TelegramEvent } from '../context/event-factory';
-import { ApiMethod } from '../../api/methods';
+import { ApiMethod, SendMessageOptions } from '../../api/methods';
+import type { MethodOptions } from '../../api';
 
-/** An event that can reply to itself (e.g. `Message.answer`). */
+/** Reply options applied when the result is a string (a keyboard, reply target…). */
+type ReplyOptions = MethodOptions<SendMessageOptions>;
+
+/** An event that can reply to itself with optional reply options (e.g. `Message.answer`). */
 interface Answerable {
-  answer(text: string): Promise<unknown>;
+  answer(text: string, options?: ReplyOptions): Promise<unknown>;
 }
 
 /**
@@ -19,16 +23,24 @@ interface Answerable {
  * Non-string, non-command results are ignored silently — `return message.answer(...)`
  * is idiomatic (especially in arrow handlers) and has already sent the message,
  * so its resolved value is nothing for us to act on, not an error.
+ *
+ * The optional `options` apply only to the string case — they let a caller
+ * (e.g. `ReplyExceptionFilter`) reply with a keyboard or reply target while
+ * reusing the same answer/command semantics as a bare handler return.
  */
 @Injectable()
 export class ResultHandler {
   private readonly logger = new Logger(ResultHandler.name);
 
-  async handle(result: unknown, ctx: TelegramExecutionContext): Promise<void> {
+  async handle(
+    result: unknown,
+    ctx: TelegramExecutionContext,
+    options?: ReplyOptions,
+  ): Promise<void> {
     if (typeof result === 'string') {
       const event = ctx.event;
       if (this.isAnswerable(event)) {
-        await event.answer(result);
+        await event.answer(result, options);
       } else {
         this.logger.warn(
           `Handler for "${ctx.kind}" returned a string but its event has no answer()`,

--- a/lib/exceptions/index.ts
+++ b/lib/exceptions/index.ts
@@ -2,3 +2,4 @@ export * from './nestgram.error';
 export * from './api.exception';
 export * from './error-catalog';
 export * from './config.exception';
+export * from './reply.exception';

--- a/lib/exceptions/reply.exception.ts
+++ b/lib/exceptions/reply.exception.ts
@@ -1,0 +1,83 @@
+import { NestgramError } from './nestgram.error';
+import { ApiMethod } from '../api/methods';
+import type { MethodOptions } from '../api';
+import type { SendMessageOptions } from '../api/methods';
+import type { AnswerCallbackQueryOptions } from '../api/methods';
+
+/**
+ * The reply a {@link ReplyException} carries: either a string to send to the
+ * same chat, or a ready-made command object (the pure-data `new SendMessage(...)`
+ * layer beneath `message.answer(...)`). Mirrors a handler's return-value
+ * contract exactly, so the reaction is identical to `return content`.
+ */
+export type ReplyContent = string | ApiMethod<unknown, unknown>;
+
+/** Reply options applied when {@link ReplyException} carries a plain string. */
+export type ReplyOptions = MethodOptions<SendMessageOptions>;
+
+/**
+ * Throw to short-circuit the pipeline (from a guard, pipe, interceptor, or the
+ * handler itself) and reply to the originating chat — the Telegram counterpart
+ * of Nest's `throw new HttpException(...)`. A built-in global `@Catch` filter
+ * (`ReplyExceptionFilter`) maps it to the reply; no privileged core, so a bot
+ * author could register the same filter themselves.
+ *
+ * ```ts
+ * throw new ReplyException('Only admins can do that.');
+ * throw new ReplyException('Saved!', { reply_markup: keyboard });
+ * throw new ReplyException(new SendMessage({ chat_id, text: 'Done.' }));
+ * ```
+ *
+ * Disable the built-in handling with `replyExceptions: false` — the exception
+ * then propagates like any other error (logged by the dispatcher).
+ */
+export class ReplyException extends NestgramError {
+  readonly name: string = 'ReplyException';
+
+  /** The text/command to reply with. */
+  readonly content: ReplyContent;
+
+  /** Reply options, used only when {@link content} is a string. */
+  readonly options?: ReplyOptions;
+
+  constructor(content: ReplyContent, options?: ReplyOptions) {
+    super(
+      typeof content === 'string' ? content : ReplyException.COMMAND_MESSAGE,
+    );
+    this.content = content;
+    this.options = options;
+  }
+
+  /** `Error.message` text used when the reply is a command object, not a string. */
+  private static readonly COMMAND_MESSAGE = 'ReplyException with a command';
+}
+
+/**
+ * Throw to answer the originating callback query with a toast or modal alert —
+ * the callback-only counterpart of {@link ReplyException}. A subclass so a single
+ * `@Catch(ReplyException)` filter covers both; on a non-callback update it has no
+ * effect (the filter logs a warning).
+ *
+ * ```ts
+ * throw new AnswerException('Too fast — slow down.');
+ * throw new AnswerException('Not allowed', { show_alert: true });
+ * ```
+ */
+export class AnswerException extends ReplyException {
+  readonly name: string = 'AnswerException';
+
+  /** The toast/alert text to show on the callback button. */
+  readonly text: string;
+
+  /** Options for the callback answer (e.g. `show_alert`). */
+  readonly answerOptions?: MethodOptions<AnswerCallbackQueryOptions>;
+
+  constructor(
+    text: string,
+    answerOptions?: MethodOptions<AnswerCallbackQueryOptions>,
+  ) {
+    super(text);
+    this.text = text;
+    this.answerOptions = answerOptions;
+  }
+}

--- a/lib/exceptions/reply.exception.ts
+++ b/lib/exceptions/reply.exception.ts
@@ -1,7 +1,6 @@
 import { NestgramError } from './nestgram.error';
 import { ApiMethod } from '../api/methods';
-import type { MethodOptions } from '../api';
-import type { SendMessageOptions } from '../api/methods';
+import type { MethodOptions, ReplyOptions } from '../api';
 import type { AnswerCallbackQueryOptions } from '../api/methods';
 
 /**
@@ -12,8 +11,12 @@ import type { AnswerCallbackQueryOptions } from '../api/methods';
  */
 export type ReplyContent = string | ApiMethod<unknown, unknown>;
 
-/** Reply options applied when {@link ReplyException} carries a plain string. */
-export type ReplyOptions = MethodOptions<SendMessageOptions>;
+/**
+ * Shared base for the reply exceptions, so one `@Catch(ReplyExceptionBase)`
+ * filter covers every kind. Abstract — throw {@link ReplyException} or
+ * {@link AnswerException}, never this.
+ */
+export abstract class ReplyExceptionBase extends NestgramError {}
 
 /**
  * Throw to short-circuit the pipeline (from a guard, pipe, interceptor, or the
@@ -21,6 +24,10 @@ export type ReplyOptions = MethodOptions<SendMessageOptions>;
  * of Nest's `throw new HttpException(...)`. A built-in global `@Catch` filter
  * (`ReplyExceptionFilter`) maps it to the reply; no privileged core, so a bot
  * author could register the same filter themselves.
+ *
+ * Belongs on the Telegram layer (a handler/guard), like `HttpException` in a
+ * controller — not in a domain service shared with HTTP. There, throw a plain
+ * domain error and map it in your own `@Catch` filter per transport.
  *
  * ```ts
  * throw new ReplyException('Only admins can do that.');
@@ -31,21 +38,26 @@ export type ReplyOptions = MethodOptions<SendMessageOptions>;
  * Disable the built-in handling with `replyExceptions: false` — the exception
  * then propagates like any other error (logged by the dispatcher).
  */
-export class ReplyException extends NestgramError {
+export class ReplyException extends ReplyExceptionBase {
   readonly name: string = 'ReplyException';
 
   /** The text/command to reply with. */
   readonly content: ReplyContent;
 
-  /** Reply options, used only when {@link content} is a string. */
+  /** Reply options, applied only when {@link content} is a string. */
   readonly options?: ReplyOptions;
 
+  /** Reply with text, optionally with a keyboard / reply target / parse mode. */
+  constructor(text: string, options?: ReplyOptions);
+  /** Reply with a ready-made command object (the `new SendMessage(...)` layer). */
+  constructor(command: ApiMethod<unknown, unknown>);
   constructor(content: ReplyContent, options?: ReplyOptions) {
     super(
       typeof content === 'string' ? content : ReplyException.COMMAND_MESSAGE,
     );
     this.content = content;
-    this.options = options;
+    // Options only mean anything for the string case; a command carries its own.
+    this.options = typeof content === 'string' ? options : undefined;
   }
 
   /** `Error.message` text used when the reply is a command object, not a string. */
@@ -54,16 +66,16 @@ export class ReplyException extends NestgramError {
 
 /**
  * Throw to answer the originating callback query with a toast or modal alert —
- * the callback-only counterpart of {@link ReplyException}. A subclass so a single
- * `@Catch(ReplyException)` filter covers both; on a non-callback update it has no
- * effect (the filter logs a warning).
+ * the callback-only counterpart of {@link ReplyException}. Shares
+ * {@link ReplyExceptionBase}, so a single `@Catch(ReplyExceptionBase)` filter
+ * covers both; on a non-callback update it has no effect (the filter warns).
  *
  * ```ts
  * throw new AnswerException('Too fast — slow down.');
  * throw new AnswerException('Not allowed', { show_alert: true });
  * ```
  */
-export class AnswerException extends ReplyException {
+export class AnswerException extends ReplyExceptionBase {
   readonly name: string = 'AnswerException';
 
   /** The toast/alert text to show on the callback button. */

--- a/lib/module/nestgram-module.types.ts
+++ b/lib/module/nestgram-module.types.ts
@@ -109,6 +109,14 @@ export interface NestgramModuleOptions {
    */
   autoAnswerCallbackQueries?: boolean;
   /**
+   * Map a thrown `ReplyException`/`AnswerException` to a Telegram reply or
+   * callback answer via a built-in global `@Catch` filter — the framework's
+   * `HttpException -> filter` idiom. On by default (a thrown `ReplyException`
+   * does the obvious thing out of the box); set `false` to let those exceptions
+   * propagate like any other error (logged by the dispatcher).
+   */
+  replyExceptions?: boolean;
+  /**
    * Default `parse_mode` for outgoing sends. Applied when a call omits
    * `parse_mode`; pass `parse_mode` explicitly on a call to override, or
    * `parse_mode: undefined` to opt that call out.

--- a/lib/module/nestgram.module.ts
+++ b/lib/module/nestgram.module.ts
@@ -1,5 +1,5 @@
 import { DynamicModule, Global, Module, Provider } from '@nestjs/common';
-import { APP_INTERCEPTOR, DiscoveryModule } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR, DiscoveryModule } from '@nestjs/core';
 
 import { BotModule, BotService } from '../api';
 import { BotOptions } from '../api/bot-options';
@@ -33,6 +33,7 @@ import {
   WebhookUpdateSource,
 } from '../engine/source';
 import { AutoAnswerCallbackInterceptor } from '../builtins/auto-answer';
+import { ReplyExceptionFilter } from '../builtins/reply-exception';
 import { NestgramBootstrap } from './nestgram.bootstrap';
 import {
   NestgramModuleAsyncOptions,
@@ -126,6 +127,10 @@ export class NestgramModule {
     // is a global interceptor that self-disables when the option is off, so it
     // stays uniform across forRoot / forRootAsync.
     { provide: APP_INTERCEPTOR, useClass: AutoAnswerCallbackInterceptor },
+    // Maps a thrown ReplyException/AnswerException to a Telegram reply via a
+    // global @Catch filter; self-disables (re-throws) when replyExceptions is
+    // false. Same "public toggleable built-in" shape as the interceptor above.
+    { provide: APP_FILTER, useClass: ReplyExceptionFilter },
   ];
 
   /**

--- a/lib/testing/nestgram-testbed.ts
+++ b/lib/testing/nestgram-testbed.ts
@@ -57,6 +57,12 @@ export interface TestbedOptions extends Pick<ModuleMetadata, 'imports'> {
   /** Auto-answer unanswered callback queries (on by default, as in production). */
   autoAnswerCallbackQueries?: boolean;
   /**
+   * Map a thrown `ReplyException`/`AnswerException` to a reply via the built-in
+   * filter (on by default, as in production). Set `false` to let those
+   * exceptions propagate to {@link NestgramTestbed.lastError}.
+   */
+  replyExceptions?: boolean;
+  /**
    * Extra outbound API interceptors to test alongside the capture seam. They run
    * before the capture, so their request mutations show up in `sent`.
    */
@@ -137,6 +143,7 @@ export class NestgramTestbed {
         NestgramModule.forRoot({
           token: options.token ?? TEST_TOKEN,
           autoAnswerCallbackQueries: options.autoAnswerCallbackQueries,
+          replyExceptions: options.replyExceptions,
           parseMode: options.parseMode,
           // Capture is the last interceptor: after the built-in mutators, just
           // above the throttler/wire — so it records the final request and never


### PR DESCRIPTION
## Problem

Bailing out of an update and telling the user why had no first-class path. From a guard, `return false` is silent; the only way to reply was to thread a flag back to the handler or send manually. Nest solves the analogous case with `throw new HttpException(...)` + an exception filter — Nestgram had no equivalent.

## Change

Throw a framework exception anywhere in the pipeline (guard, pipe, interceptor, handler); a built-in global `@Catch` filter maps it to a Telegram reaction and consumes it, so the dispatcher sees a clean completion.

- **`ReplyException(text, options?)` / `ReplyException(command)`** — replies to the originating chat. The reaction reuses the handler return-value contract (string → reply, command object → sent as-is), so it's identical to `return content`. Overloaded so passing reply options alongside a command object is a compile error.
- **`AnswerException(text, options?)`** — answers the originating callback query (toast / `show_alert`). Shares an abstract `ReplyExceptionBase` with `ReplyException`, so one `@Catch(ReplyExceptionBase)` covers both.
- Registered as a public `APP_FILTER` (no privileged core — a user could write the same). `replyExceptions: false` disables it: the filter re-throws, so the exceptions propagate like any other error (dispatcher logs them).
- `TelegramExecutionContext.of` now also accepts an `ArgumentsHost`, so a filter can resolve the context the same way an interceptor does.

Docs (`docs/handling-errors.md`) cover the layering this enables: `ReplyException` is the Telegram-layer shortcut (zero filters); a service shared with HTTP throws a transport-agnostic domain error mapped by one `@Catch(AppError)` filter per transport (rendering localized copy from a stable `code`); and a pragmatic `@UseFilters`-scoped bridge for apps that already throw `HttpException`.

## How to verify

- `npm run build`, `npm run lint`, `npx jest` — all green (89 suites, 663 tests; new `reply-exception.filter.spec.ts` (unit) + `reply-exception.integration.spec.ts` (real-pipeline via `NestgramTestbed`): handler-thrown and guard-thrown replies, command payloads, callback answers, `replyExceptions: false` propagation, non-`ReplyException` unaffected).
- `cd website && npm run build` — `docs/handling-errors.md` renders; every code sample type-checks against the public API.