### PR TITLE
ci: advance the release branch to each version tag

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,29 @@
+# Keeps the live docs in step with the released package.
+#
+# Vercel serves the docs from the `release` branch (its Production Branch), not
+# `main` — so merging a feature to `main` only produces a preview deploy, and the
+# public docs never describe an unreleased feature. This workflow advances
+# `release` to each `v*` tag (the tags `npm version` creates at release), so the
+# moment a version is tagged, the docs that ship with it go live.
+#
+# `release` is always an ancestor of the tagged commit (tags are cut from
+# `main`), so the push is a fast-forward.
+name: Docs release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  advance-release-branch:
+    name: Advance the release branch to the tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Fast-forward `release` to the tagged commit
+        run: git push origin "${GITHUB_SHA}:refs/heads/release"


### PR DESCRIPTION
## Problem

Vercel deploys the docs site on every push to `main`, so merging a feature lands its docs on the public site immediately — describing functionality that isn't released on npm yet.

## Change

Decouple the live docs from `main` and tie them to releases:

- The docs site's **Production Branch is now `release`** (Vercel setting). Pushing to `main` produces only a *preview* deploy; the public docs come from `release`.
- This workflow fast-forwards `release` to each `v*` tag. Those tags are what `npm version` creates at release time, so the docs that ship with a version go live the moment it's tagged — no separate manual step.

`release` is always an ancestor of the tagged commit (tags are cut from `main`), so the push is a fast-forward. Uses the default `GITHUB_TOKEN` (`contents: write`); the only input is `GITHUB_SHA`, not untrusted data.

## Notes

- `release` already exists, pinned at `v2.0.0-alpha.2` (the current published version), so the live docs already match npm.
- The workflow only fires for tags whose commit contains this file — i.e. from the next release (`v2.0.0-alpha.3`) onward. Until then, advance `release` manually with `git push origin main:release` at release time.