### PR TITLE
Pluggable update-source seam + default in-process update queue

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,6 +79,13 @@ Everything needed to ship a production bot.
 ## Phase 4 — Scale & DX
 
 - [ ] Multi-instance support (Redis sessions, distributed throttling)
+- [x] Pluggable update-source seam — `forRoot({ source })` factory (per bot,
+      wrap or replace, DI-aware), the public extension point delivery layers are
+      built on (no privileged core)
+- [x] In-process update queue — per-chat FIFO serialization (fixes the same-chat
+      session/FSM race under webhook) + bounded concurrency / backpressure;
+      `updateQueue` option, on by default, built as an `UpdateSource` decorator on
+      the seam. Rung 1 before the distributed `UpdateQueue` port
 - [x] Inbound rate-limiting (flood control) — global interceptor, sliding-window
       per-conversation limiter, `@RateLimit` / `@SkipRateLimit`, `onLimit` reply
 - [ ] CLI / schematics

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -63,8 +63,51 @@ hidden — you could write that interceptor yourself with the same public API.
 ## Swap the update source
 
 `polling: true` is one implementation of a small `UpdateSource` interface
-(`start(onUpdate)` / `stop()`). Provide your own to pull updates from anywhere —
-a queue, a test harness, a custom transport — without touching a single handler.
+(`start(onUpdate)` / `stop()`). Plug in your own with the `source` factory to
+pull updates from anywhere — a message queue, a test harness, a custom transport
+— or to **decorate** the built-in one, without touching a single handler.
+
+The factory runs once per bot and receives the transport the framework would
+otherwise use (`default`), the bot it serves, and a DI lookup:
+
+```ts
+// A decorator: holds the built-in source, intercepts each update.
+class LoggingSource implements UpdateSource {
+  constructor(private inner: UpdateSource) {}
+  start(onUpdate: UpdateListener) {
+    return this.inner.start((update) => {
+      console.log('update', update.update_id);
+      return onUpdate(update);
+    });
+  }
+  stop() {
+    return this.inner.stop();
+  }
+}
+
+NestgramModule.forRoot({
+  token: process.env.BOT_TOKEN,
+  webhook: { url, secretToken },
+  source: ({ default: inner, bot, get }) => {
+    // Wrap the built-in source to add a layer…
+    return new LoggingSource(inner!);
+
+    // …or ignore `inner` and replace ingestion entirely:
+    // return new KafkaUpdateSource(get(KafkaService), bot);
+  },
+});
+```
+
+- **Wrap** — return a decorator that holds `inner`, forwarding `start`/`stop` and
+  intercepting `onUpdate` (e.g. to enqueue, batch, filter, or trace). The
+  framework's own update queue is exactly this — a decorator you could write.
+- **Replace** — ignore `inner` and return your own `UpdateSource`. The
+  `polling`/`webhook` config then only seeds `default`; if you replace a webhook
+  source you also own delivery (register your own receiver) — and drop the
+  ready-made `WebhookController`, since it delivers to the built-in source you
+  replaced, which is never started (updates would be silently dropped).
+- **Per bot** — branch on `ctx.bot.name` in a multi-bot app; the factory is
+  called for each bot with its own `default` and `bot`.
 
 ## Replace a built-in
 

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -286,10 +286,12 @@ for long flows; a higher-level scenes/wizard layer on top of this core is
 the next item on the roadmap.
 :::
 
-:::caution
-**No per-conversation locking.** With long polling, updates are processed
-one at a time, so a user can't race their own flow. The webhook source
-handles updates concurrently — two rapid-fire messages from one user can
-interleave, and the last write wins. Keep wizard handlers fast, and don't
-park slow I/O between reading the state and transitioning it.
+:::note
+**Per-chat serialization is on by default.** The built-in
+[update queue](/docs/how-nestgram-works) runs a chat's updates one at a time in
+arrival order, so two rapid-fire messages from one user can't interleave and
+race their own flow — under both polling and webhook, on a single instance.
+Across multiple instances the same conversation can still land on different
+workers (move to a shared store + queue), so keep transitions fast regardless
+and don't park slow I/O between reading the state and transitioning it.
 :::

--- a/docs/how-nestgram-works.md
+++ b/docs/how-nestgram-works.md
@@ -23,22 +23,70 @@ context — so your bot code stays minimal and obvious.
 Every update takes the same path:
 
 :::mental
-update source -> route table -> match -> Nest pipeline\* -> handler -> reply
+update source -> queue -> route table -> match -> Nest pipeline\* -> handler -> reply
 :::
 
 1. **Update source** — polling or webhook. Pluggable; the rest of the
    pipeline doesn't care where updates come from.
-2. **Context by wrapping** — the raw update is wrapped in a
+2. **Queue** — per-chat FIFO serialization + bounded concurrency (on by
+   default). See [Update delivery & ordering](#update-delivery--ordering).
+3. **Context by wrapping** — the raw update is wrapped in a
    `TelegramExecutionContext`, never mutated. The wrapper carries the resolved
    kind, a lazily-built rich event, and a per-update [state store](/docs/extending).
-3. **Routing** — a route table built once at boot from your `@Router()` classes;
+4. **Routing** — a route table built once at boot from your `@Router()` classes;
    per update it's a lookup, not reflection.
-4. **Match predicates** — `@Command`/`@Action`/`@Hears`/`@On*` decide which
+5. **Match predicates** — `@Command`/`@Action`/`@Hears`/`@On*` decide which
    handler applies.
-5. **The Nest pipeline** — guards → interceptors → pipes → handler → exception
+6. **The Nest pipeline** — guards → interceptors → pipes → handler → exception
    filters, via Nest's `ExternalContextCreator`.
-6. **Result handling** — a returned `string` is replied; a command object is
+7. **Result handling** — a returned `string` is replied; a command object is
    executed; `void` does nothing.
+
+## Update delivery & ordering
+
+Between the source and the dispatcher sits an in-process **update queue**, on by
+default. It does two things:
+
+- **Per-chat serialization.** A chat's updates run **one at a time, in arrival
+  order**. Two quick messages — or rapid taps on an inline keyboard — from the
+  same chat can't overlap, so they never race on that chat's
+  [session](/docs/sessions) or [FSM](/docs/fsm) state. Different chats still run
+  in parallel.
+- **Bounded concurrency.** `maxConcurrency` caps how many updates dispatch at
+  once across all chats. Once the cap is hit, admitting the next update waits for
+  a slot — so the poll loop paces itself instead of fetching unboundedly, and a
+  webhook flood can't spawn unbounded concurrent work.
+
+Without it, polling processed updates strictly one at a time (no cross-chat
+parallelism) and webhook delivery dispatched every update concurrently (the
+race above). The queue fixes both.
+
+Tune or disable it via `forRoot`:
+
+```ts
+NestgramModule.forRoot({
+  token: process.env.BOT_TOKEN,
+  webhook: { url, secretToken },
+  updateQueue: {
+    maxConcurrency: 200, // parallel dispatches across chats (default: generous)
+    // key: (update) => `${update.message?.from?.id}`, // e.g. per-user, not per-chat
+  },
+  // updateQueue: false, // opt out entirely (no serialization, no bound)
+});
+```
+
+The default key is the chat (in a multi-bot app, the bot name is prefixed
+automatically). Return `undefined` from a custom `key` to opt an update out of
+serialization; chat-less updates (`poll_answer`, inline queries, payment
+queries) opt out on their own.
+
+:::caution
+The queue is **per-process**. Across multiple instances, the same conversation
+can still land on different workers and race — move sessions/FSM to a shared
+store and put a distributed queue in front (the `UpdateQueue` port is on the
+roadmap). It also doesn't add durability: like polling today, an update admitted
+but not yet finished is lost on a crash.
+:::
 
 ## The layers
 

--- a/docs/how-nestgram-works.md
+++ b/docs/how-nestgram-works.md
@@ -61,6 +61,10 @@ Without it, polling processed updates strictly one at a time (no cross-chat
 parallelism) and webhook delivery dispatched every update concurrently (the
 race above). The queue fixes both.
 
+It's not privileged machinery: the queue is an `UpdateSource` **decorator** wrapping
+the active transport (one per bot), applied through the same public `source`
+seam you can plug into — see [Swap the update source](/docs/extending#swap-the-update-source).
+
 Tune or disable it via `forRoot`:
 
 ```ts
@@ -75,10 +79,10 @@ NestgramModule.forRoot({
 });
 ```
 
-The default key is the chat (in a multi-bot app, the bot name is prefixed
-automatically). Return `undefined` from a custom `key` to opt an update out of
-serialization; chat-less updates (`poll_answer`, inline queries, payment
-queries) opt out on their own.
+The default key is the chat. There's one queue per bot, so a multi-bot app never
+serializes two bots together even if they share a chat id. Return `undefined`
+from a custom `key` to opt an update out of serialization; chat-less updates
+(`poll_answer`, inline queries, payment queries) opt out on their own.
 
 :::caution
 The queue is **per-process**. Across multiple instances, the same conversation

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -222,9 +222,12 @@ RateLimitModule.forRoot({
 
 :::note
 Read-modify-write on the counter is not atomic — the same trade-off sessions and
-the FSM already make. Under heavy concurrency a key can briefly exceed its limit
-by the number of in-flight updates. That's fine for protective flood control,
-and a non-issue for long polling, which processes a batch largely in order.
+the FSM already make. On a single instance the [update queue](/docs/how-nestgram-works)
+serialises a chat's updates, so a conversation's counter is read-modify-written
+in order and can't be raced by its own in-flight updates. The non-atomicity only
+shows across **multiple instances** sharing a store, where a key can briefly
+exceed its limit by the number of concurrent workers — fine for protective flood
+control.
 :::
 
 ## Configuring from DI

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -296,14 +296,20 @@ The factory returns the same options object `forRoot` takes — `store`, `key`,
 
 ## Concurrent updates
 
+Load → mutate → save isn't atomic on its own, so two updates for the **same
+conversation** running at once could race on the session (last save wins).
+That's exactly what the built-in [update queue](/docs/how-nestgram-works)
+prevents: it serialises a chat's updates — they run one at a time in arrival
+order — while different chats still run in parallel. So rapid taps on an inline
+keyboard from one user are processed in order, and the race can't happen on a
+single instance.
+
 :::caution
-There is no per-key locking yet: load → mutate → save isn't atomic. With
-polling this can't bite — updates are processed one at a time. The webhook
-source dispatches concurrently, so two updates for the **same conversation**
-processed at once can race, and the last save wins. A person typing messages
-won't trigger it; rapid taps on an inline keyboard can. If that matters for
-your flow, serialise per chat in front of the bot — per-key locking is a
-planned improvement.
+Two caveats. First, the queue is per-process — across **multiple instances**
+the same conversation can still land on different workers; move the store to
+Redis and put a shared queue in front (the distributed `UpdateQueue` is on the
+roadmap). Second, if you replace the queue's `key` with something coarser than
+a chat, or set `updateQueue: false`, you opt back out of this guarantee.
 :::
 
 ## Sessions and the FSM

--- a/lib/engine/queue/chat-key.spec.ts
+++ b/lib/engine/queue/chat-key.spec.ts
@@ -1,0 +1,66 @@
+import { RawUpdate } from '../../events/raw-update.types';
+import { defaultChatKey } from './chat-key';
+
+const update = (fields: Partial<RawUpdate>): RawUpdate =>
+  ({ update_id: 1, ...fields } as RawUpdate);
+
+const withChat = (chatId: number) => ({ chat: { id: chatId } } as never);
+
+describe('defaultChatKey', () => {
+  it('keys a plain message by its chat', () => {
+    expect(defaultChatKey(update({ message: withChat(42) }))).toBe('c42');
+  });
+
+  it.each([
+    'edited_message',
+    'channel_post',
+    'edited_channel_post',
+    'business_message',
+    'edited_business_message',
+    'guest_message',
+  ] as const)('keys %s by its chat', (field) => {
+    expect(defaultChatKey(update({ [field]: withChat(7) }))).toBe('c7');
+  });
+
+  it('keys a callback query by the chat of the message its button sits on', () => {
+    const cb = update({
+      callback_query: { message: withChat(99) } as never,
+    });
+    expect(defaultChatKey(cb)).toBe('c99');
+  });
+
+  it('returns undefined for an inline callback query (no message, no chat)', () => {
+    const cb = update({
+      callback_query: { inline_message_id: 'abc' } as never,
+    });
+    expect(defaultChatKey(cb)).toBeUndefined();
+  });
+
+  it.each([
+    'message_reaction',
+    'message_reaction_count',
+    'my_chat_member',
+    'chat_member',
+    'chat_join_request',
+    'chat_boost',
+    'removed_chat_boost',
+    'deleted_business_messages',
+  ] as const)('keys %s by its chat', (field) => {
+    expect(defaultChatKey(update({ [field]: withChat(13) }))).toBe('c13');
+  });
+
+  it.each([
+    'poll',
+    'poll_answer',
+    'inline_query',
+    'pre_checkout_query',
+  ] as const)('returns undefined for the chat-less update %s', (field) => {
+    expect(defaultChatKey(update({ [field]: {} as never }))).toBeUndefined();
+  });
+
+  it('keys a negative (group) chat id', () => {
+    expect(defaultChatKey(update({ message: withChat(-1001234) }))).toBe(
+      'c-1001234',
+    );
+  });
+});

--- a/lib/engine/queue/chat-key.ts
+++ b/lib/engine/queue/chat-key.ts
@@ -1,0 +1,56 @@
+import { RawChat, RawUpdate } from '../../events/raw-update.types';
+
+/**
+ * The default {@link UpdateQueue} serialization key: the chat an update belongs
+ * to, so a chat's updates never overlap (two quick messages can't race on that
+ * chat's session/FSM state). Coarser than the per-conversation session key on
+ * purpose — serializing the whole chat also protects per-chat shared state, and
+ * different users in a 1:1 chat collapse to the same chat anyway.
+ *
+ * Returns `undefined` for chat-less updates (`poll`, `poll_answer`, inline
+ * queries, payment queries, business-connection events) — they touch no chat
+ * state, so they skip serialization and run concurrency-bounded only. Inline
+ * callback queries (no `message`) are likewise chat-less. (A `poll_answer`'s
+ * optional `voter_chat` is deliberately not used: a vote mutates no per-chat
+ * session/FSM state, so there's nothing to serialize on.)
+ *
+ * Operates on the raw wire update (the queue runs before the rich event is
+ * built), so it reads `chat.id` straight off whichever field carries it.
+ */
+export function defaultChatKey(update: RawUpdate): string | undefined {
+  const chat = chatOf(update);
+  return chat ? `c${chat.id}` : undefined;
+}
+
+/** The chat an update carries, across every chat-bearing update field. */
+function chatOf(update: RawUpdate): RawChat | undefined {
+  const message =
+    update.message ??
+    update.edited_message ??
+    update.channel_post ??
+    update.edited_channel_post ??
+    update.business_message ??
+    update.edited_business_message ??
+    update.guest_message;
+  if (message) {
+    return message.chat;
+  }
+
+  // A callback query is scoped to the chat of the message its button sits on;
+  // an inline callback (inline_message_id, no message) has no chat to scope to.
+  const callbackMessage = update.callback_query?.message;
+  if (callbackMessage) {
+    return callbackMessage.chat;
+  }
+
+  return (
+    update.message_reaction?.chat ??
+    update.message_reaction_count?.chat ??
+    update.my_chat_member?.chat ??
+    update.chat_member?.chat ??
+    update.chat_join_request?.chat ??
+    update.chat_boost?.chat ??
+    update.removed_chat_boost?.chat ??
+    update.deleted_business_messages?.chat
+  );
+}

--- a/lib/engine/queue/index.ts
+++ b/lib/engine/queue/index.ts
@@ -1,0 +1,6 @@
+export * from './update-queue';
+export * from './queued-update-source';
+export * from './update-queue.types';
+export * from './update-queue.constants';
+export * from './chat-key';
+export * from './semaphore';

--- a/lib/engine/queue/queued-update-source.spec.ts
+++ b/lib/engine/queue/queued-update-source.spec.ts
@@ -1,0 +1,108 @@
+import { RawUpdate } from '../../events/raw-update.types';
+import { UpdateListener, UpdateSource } from '../source/update-source';
+import { QueuedUpdateSource } from './queued-update-source';
+import { UpdateQueue } from './update-queue';
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+const msg = (chatId: number, id = chatId): RawUpdate =>
+  ({ update_id: id, message: { chat: { id: chatId } } } as RawUpdate);
+
+/** A fake inner source that captures the listener so a test can drive updates. */
+class FakeSource implements UpdateSource {
+  listener?: UpdateListener;
+  stopped = false;
+  async start(onUpdate: UpdateListener): Promise<void> {
+    this.listener = onUpdate;
+  }
+  async stop(): Promise<void> {
+    this.stopped = true;
+  }
+  deliver(update: RawUpdate): void | Promise<void> {
+    return this.listener?.(update);
+  }
+}
+
+describe('QueuedUpdateSource', () => {
+  it('starts the inner source and routes its updates to the listener', async () => {
+    const inner = new FakeSource();
+    const seen: number[] = [];
+    const source = new QueuedUpdateSource(inner, new UpdateQueue());
+
+    await source.start((update) => {
+      seen.push(update.update_id);
+    });
+    expect(inner.listener).toBeDefined();
+
+    await inner.deliver(msg(1));
+    await flush();
+
+    expect(seen).toEqual([1]);
+  });
+
+  it('serializes same-chat updates through the queue', async () => {
+    const inner = new FakeSource();
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+
+    const source = new QueuedUpdateSource(inner, new UpdateQueue());
+    await source.start((update) => {
+      order.push(`start:${update.update_id}`);
+      if (update.update_id === 1) {
+        return new Promise<void>((resolve) => {
+          releaseFirst = () => {
+            order.push('end:1');
+            resolve();
+          };
+        });
+      }
+      return undefined;
+    });
+
+    void inner.deliver(msg(1, 1));
+    void inner.deliver(msg(1, 2)); // same chat → must wait for #1
+    await flush();
+    expect(order).toEqual(['start:1']);
+
+    releaseFirst();
+    await flush();
+    expect(order).toEqual(['start:1', 'end:1', 'start:2']);
+  });
+
+  it('on stop, stops the inner source first, then drains in-flight updates', async () => {
+    const inner = new FakeSource();
+    const queue = new UpdateQueue();
+    const source = new QueuedUpdateSource(inner, queue);
+
+    let finished = false;
+    let release!: () => void;
+    await source.start(
+      () =>
+        new Promise<void>((resolve) => {
+          release = () => {
+            finished = true;
+            resolve();
+          };
+        }),
+    );
+
+    await inner.deliver(msg(1));
+    await flush(); // admitted, dispatch running
+
+    let stopped = false;
+    const stopping = source.stop().then(() => {
+      stopped = true;
+    });
+    await flush();
+
+    expect(inner.stopped).toBe(true); // intake stopped first
+    expect(stopped).toBe(false); // but stop() awaits the drain
+    expect(finished).toBe(false);
+
+    release();
+    await stopping;
+    expect(finished).toBe(true);
+    expect(stopped).toBe(true);
+  });
+});

--- a/lib/engine/queue/queued-update-source.ts
+++ b/lib/engine/queue/queued-update-source.ts
@@ -1,0 +1,34 @@
+import type { UpdateListener, UpdateSource } from '../source/update-source';
+import { UpdateQueue } from './update-queue';
+
+/**
+ * An {@link UpdateSource} decorator that routes a chat's updates through an
+ * {@link UpdateQueue} — per-chat FIFO serialization plus bounded concurrency —
+ * before the real listener. Applied by default over whatever source the
+ * transport seam produces (polling, webhook, or a user's own), one per bot.
+ *
+ * Pure composition over the public `UpdateSource` interface: it holds the inner
+ * source, forwards `start`/`stop`, and wraps the listener so each update is
+ * admitted by the queue first. Nothing privileged — a bot author could write the
+ * same decorator and register it through the `source` factory.
+ *
+ * On `stop` it stops the inner source first (no new updates) then drains the
+ * queue, so in-flight updates finish instead of being dropped mid-shutdown.
+ */
+export class QueuedUpdateSource implements UpdateSource {
+  constructor(
+    private readonly inner: UpdateSource,
+    private readonly queue: UpdateQueue,
+  ) {}
+
+  start(onUpdate: UpdateListener): Promise<void> {
+    return this.inner.start((update) =>
+      this.queue.enqueue(update, () => Promise.resolve(onUpdate(update))),
+    );
+  }
+
+  async stop(): Promise<void> {
+    await this.inner.stop();
+    await this.queue.drain();
+  }
+}

--- a/lib/engine/queue/semaphore.spec.ts
+++ b/lib/engine/queue/semaphore.spec.ts
@@ -1,0 +1,84 @@
+import { Semaphore } from './semaphore';
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+describe('Semaphore', () => {
+  it('rejects a permit count below 1', () => {
+    expect(() => new Semaphore(0)).toThrow(RangeError);
+    expect(() => new Semaphore(-1)).toThrow(RangeError);
+  });
+
+  it('hands out permits immediately while available', async () => {
+    const sem = new Semaphore(2);
+    expect(sem.free).toBe(2);
+
+    await sem.acquire();
+    await sem.acquire();
+
+    expect(sem.free).toBe(0);
+    expect(sem.waiting).toBe(0);
+  });
+
+  it('makes a caller wait once permits run out, resolving on release', async () => {
+    const sem = new Semaphore(1);
+    const release = await sem.acquire();
+
+    let acquired = false;
+    const pending = sem.acquire().then(() => {
+      acquired = true;
+    });
+
+    await flush();
+    expect(acquired).toBe(false);
+    expect(sem.waiting).toBe(1);
+
+    release();
+    await pending;
+    expect(acquired).toBe(true);
+  });
+
+  it('serves waiters in FIFO order', async () => {
+    const sem = new Semaphore(1);
+    const first = await sem.acquire();
+
+    const order: number[] = [];
+    const a = sem.acquire().then((r) => {
+      order.push(1);
+      return r;
+    });
+    const b = sem.acquire().then((r) => {
+      order.push(2);
+      return r;
+    });
+
+    first();
+    const releaseA = await a;
+    releaseA();
+    await b;
+
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('hands a released permit straight to the next waiter (no counter bounce)', async () => {
+    const sem = new Semaphore(1);
+    const release = await sem.acquire();
+
+    const pending = sem.acquire();
+    release();
+    await pending;
+
+    // The waiter took the permit directly, so none returned to the pool.
+    expect(sem.free).toBe(0);
+  });
+
+  it('ignores a double release (no permit leak)', async () => {
+    const sem = new Semaphore(1);
+    const release = await sem.acquire();
+
+    release();
+    release();
+
+    expect(sem.free).toBe(1);
+  });
+});

--- a/lib/engine/queue/semaphore.ts
+++ b/lib/engine/queue/semaphore.ts
@@ -1,0 +1,67 @@
+/**
+ * A counting semaphore: hands out a fixed number of permits and makes callers
+ * wait once they run out. The concurrency primitive behind {@link UpdateQueue} —
+ * `maxConcurrency` permits cap how many updates dispatch at once, and a caller
+ * that can't get one waits (backpressure) instead of piling on.
+ *
+ * Fair (FIFO): waiters are served in arrival order, and a released permit is
+ * handed directly to the next waiter rather than bouncing through the counter,
+ * so a steady stream of waiters can't be starved by latecomers.
+ */
+export class Semaphore {
+  private available: number;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(permits: number) {
+    if (permits < 1) {
+      throw new RangeError(`Semaphore needs at least 1 permit, got ${permits}`);
+    }
+    this.available = permits;
+  }
+
+  /**
+   * Acquire a permit, waiting if none is free. Resolves with a `release` callback
+   * — call it exactly once when done. `release` is idempotent-guarded so a
+   * double-call can't leak extra permits.
+   */
+  acquire(): Promise<() => void> {
+    if (this.available > 0) {
+      this.available--;
+      return Promise.resolve(this.releaseOnce());
+    }
+    return new Promise((resolve) => {
+      this.waiters.push(() => resolve(this.releaseOnce()));
+    });
+  }
+
+  /** Permits not currently held — exposed for tests/observability. */
+  get free(): number {
+    return this.available;
+  }
+
+  /** Callers waiting for a permit — exposed for tests/observability. */
+  get waiting(): number {
+    return this.waiters.length;
+  }
+
+  /**
+   * A `release` bound to one acquisition: hand the permit straight to the next
+   * waiter if there is one, otherwise return it to the pool. Guarded so calling
+   * it twice is a no-op (can't release a permit we no longer hold).
+   */
+  private releaseOnce(): () => void {
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      const next = this.waiters.shift();
+      if (next) {
+        next();
+      } else {
+        this.available++;
+      }
+    };
+  }
+}

--- a/lib/engine/queue/update-queue.constants.ts
+++ b/lib/engine/queue/update-queue.constants.ts
@@ -7,3 +7,11 @@
  * chat-less updates. Tune via `updateQueue.maxConcurrency`.
  */
 export const DEFAULT_MAX_CONCURRENCY = 1000;
+
+/**
+ * Default ceiling on how long {@link UpdateQueue.drain} waits for in-flight
+ * updates on shutdown before abandoning the stragglers (and logging them). Keeps
+ * a wedged handler from hanging `app.close()` forever, while giving normal
+ * handlers ample time to finish. Tune via `updateQueue.drainTimeoutMs`.
+ */
+export const DEFAULT_DRAIN_TIMEOUT_MS = 10_000;

--- a/lib/engine/queue/update-queue.constants.ts
+++ b/lib/engine/queue/update-queue.constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Default cap on updates dispatched in parallel across all chats. Generous on
+ * purpose — it is a runaway guard, not a throughput throttle: Telegram already
+ * bounds inbound concurrency far below this (a polling batch is ≤ 100, a
+ * webhook's `max_connections` defaults to 40), so the default rarely engages and
+ * mainly protects against a misconfigured high `max_connections` or a burst of
+ * chat-less updates. Tune via `updateQueue.maxConcurrency`.
+ */
+export const DEFAULT_MAX_CONCURRENCY = 1000;

--- a/lib/engine/queue/update-queue.spec.ts
+++ b/lib/engine/queue/update-queue.spec.ts
@@ -178,6 +178,21 @@ describe('UpdateQueue', () => {
     expect(drained).toBe(true);
   });
 
+  it('drain() gives up after drainTimeoutMs when a dispatch never finishes', async () => {
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const queue = new UpdateQueue({ drainTimeoutMs: 20 });
+
+    // A wedged handler that never resolves (e.g. awaiting something that won't come).
+    void queue.enqueue(msg(1), () => new Promise<void>(() => undefined));
+    await flush();
+
+    // drain resolves despite the stuck dispatch, and logs the straggler.
+    await queue.drain();
+    expect(Logger.prototype.warn).toHaveBeenCalledTimes(1);
+
+    jest.restoreAllMocks();
+  });
+
   it('drops a key from the table once its chain drains', async () => {
     const queue = new UpdateQueue();
     const order: string[] = [];

--- a/lib/engine/queue/update-queue.spec.ts
+++ b/lib/engine/queue/update-queue.spec.ts
@@ -1,0 +1,200 @@
+import { Logger } from '@nestjs/common';
+
+import { RawUpdate } from '../../events/raw-update.types';
+import { NestgramConfigError } from '../../exceptions';
+import { UpdateQueue } from './update-queue';
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+const msg = (chatId: number): RawUpdate =>
+  ({ update_id: chatId, message: { chat: { id: chatId } } } as RawUpdate);
+
+/**
+ * A dispatch whose start is recorded immediately and whose completion is held
+ * until its returned `finish` is called — so a test can pin the exact order of
+ * starts and ends across serialized/parallel updates.
+ */
+function gatedDispatch(order: string[], id: string) {
+  let finish!: () => void;
+  const dispatch = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      order.push(`start:${id}`);
+      finish = () => {
+        order.push(`end:${id}`);
+        resolve();
+      };
+    });
+  return { dispatch, finish: () => finish() };
+}
+
+describe('UpdateQueue', () => {
+  it.each([0, -1, 1.5, Infinity, NaN])(
+    'rejects a non-positive-integer maxConcurrency (%p)',
+    (maxConcurrency) => {
+      expect(() => new UpdateQueue({ maxConcurrency })).toThrow(
+        NestgramConfigError,
+      );
+    },
+  );
+
+  it('serializes updates for the same chat in arrival order (FIFO)', async () => {
+    const queue = new UpdateQueue();
+    const order: string[] = [];
+    const a = gatedDispatch(order, 'a');
+    const b = gatedDispatch(order, 'b');
+
+    void queue.enqueue(msg(1), a.dispatch);
+    void queue.enqueue(msg(1), b.dispatch);
+    await flush();
+
+    // Second same-chat update must wait — only the first has started.
+    expect(order).toEqual(['start:a']);
+
+    a.finish();
+    await flush();
+    expect(order).toEqual(['start:a', 'end:a', 'start:b']);
+
+    b.finish();
+    await flush();
+    expect(order).toEqual(['start:a', 'end:a', 'start:b', 'end:b']);
+  });
+
+  it('runs updates for different chats in parallel', async () => {
+    const queue = new UpdateQueue();
+    const order: string[] = [];
+    const a = gatedDispatch(order, 'a');
+    const b = gatedDispatch(order, 'b');
+
+    void queue.enqueue(msg(1), a.dispatch);
+    void queue.enqueue(msg(2), b.dispatch);
+    await flush();
+
+    expect(order).toEqual(['start:a', 'start:b']);
+    expect(queue.active).toBe(2);
+  });
+
+  it('resolves enqueue at admission, before the handler finishes', async () => {
+    const queue = new UpdateQueue();
+    let finished = false;
+    let finish!: () => void;
+
+    const admitted = queue.enqueue(
+      msg(1),
+      () =>
+        new Promise<void>((resolve) => {
+          finish = () => {
+            finished = true;
+            resolve();
+          };
+        }),
+    );
+
+    await admitted;
+    // Admitted (slot acquired, dispatch started) but the handler has not completed.
+    expect(finished).toBe(false);
+
+    finish();
+  });
+
+  it('bounds concurrency and backpressures the next update until a slot frees', async () => {
+    const queue = new UpdateQueue({ maxConcurrency: 1 });
+    const order: string[] = [];
+    const a = gatedDispatch(order, 'a');
+    const b = gatedDispatch(order, 'b');
+
+    await queue.enqueue(msg(1), a.dispatch); // admitted, holds the only slot
+    void queue.enqueue(msg(2), b.dispatch); // different chat, but no slot free
+    await flush();
+
+    expect(order).toEqual(['start:a']);
+    expect(queue.active).toBe(1);
+    expect(queue.waiting).toBe(1);
+
+    a.finish();
+    await flush();
+    expect(order).toEqual(['start:a', 'end:a', 'start:b']);
+
+    b.finish();
+  });
+
+  it('dispatches chat-less updates concurrency-bounded but unserialized', async () => {
+    const queue = new UpdateQueue();
+    const order: string[] = [];
+    const a = gatedDispatch(order, 'a');
+    const b = gatedDispatch(order, 'b');
+
+    // poll_answer carries no chat → no serialization key.
+    const pollUpdate = { update_id: 1, poll_answer: {} } as RawUpdate;
+    void queue.enqueue(pollUpdate, a.dispatch);
+    void queue.enqueue({ ...pollUpdate, update_id: 2 }, b.dispatch);
+    await flush();
+
+    expect(order).toEqual(['start:a', 'start:b']);
+  });
+
+  it('keeps the per-chat chain alive when a dispatch throws', async () => {
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    const queue = new UpdateQueue();
+    const order: string[] = [];
+    const after = gatedDispatch(order, 'after');
+
+    void queue.enqueue(msg(1), () => Promise.reject(new Error('boom')));
+    void queue.enqueue(msg(1), after.dispatch);
+    await flush();
+
+    // The failing dispatch did not wedge the chat's chain.
+    expect(order).toEqual(['start:after']);
+    expect(Logger.prototype.error).toHaveBeenCalledTimes(1);
+
+    after.finish();
+    jest.restoreAllMocks();
+  });
+
+  it('drain() resolves only after in-flight dispatches finish', async () => {
+    const queue = new UpdateQueue();
+    const order: string[] = [];
+    const a = gatedDispatch(order, 'a');
+    const b = gatedDispatch(order, 'b'); // different chat, runs in parallel
+
+    void queue.enqueue(msg(1), a.dispatch);
+    void queue.enqueue(msg(2), b.dispatch);
+    await flush();
+
+    let drained = false;
+    const draining = queue.drain().then(() => {
+      drained = true;
+    });
+
+    await flush();
+    expect(drained).toBe(false); // both still running
+
+    a.finish();
+    await flush();
+    expect(drained).toBe(false); // b still running
+
+    b.finish();
+    await draining;
+    expect(drained).toBe(true);
+  });
+
+  it('drops a key from the table once its chain drains', async () => {
+    const queue = new UpdateQueue();
+    const order: string[] = [];
+    const a = gatedDispatch(order, 'a');
+
+    void queue.enqueue(msg(1), a.dispatch);
+    await flush();
+    a.finish();
+    await flush();
+
+    // No work in flight — a fresh same-chat update starts immediately, proving
+    // the chain wasn't left dangling.
+    const order2: string[] = [];
+    const c = gatedDispatch(order2, 'c');
+    void queue.enqueue(msg(1), c.dispatch);
+    await flush();
+    expect(order2).toEqual(['start:c']);
+    c.finish();
+  });
+});

--- a/lib/engine/queue/update-queue.ts
+++ b/lib/engine/queue/update-queue.ts
@@ -4,7 +4,10 @@ import { RawUpdate } from '../../events/raw-update.types';
 import { NestgramConfigError } from '../../exceptions';
 import { defaultChatKey } from './chat-key';
 import { Semaphore } from './semaphore';
-import { DEFAULT_MAX_CONCURRENCY } from './update-queue.constants';
+import {
+  DEFAULT_DRAIN_TIMEOUT_MS,
+  DEFAULT_MAX_CONCURRENCY,
+} from './update-queue.constants';
 import { UpdateQueueOptions } from './update-queue.types';
 
 /** The dispatch to run for one update. The queue only schedules it; it does not
@@ -41,6 +44,7 @@ export class UpdateQueue {
   private readonly logger = new Logger(UpdateQueue.name);
   private readonly semaphore: Semaphore;
   private readonly maxConcurrency: number;
+  private readonly drainTimeoutMs: number;
   private readonly keyOf: (update: RawUpdate) => string | undefined;
 
   /**
@@ -69,6 +73,7 @@ export class UpdateQueue {
     }
     this.maxConcurrency = maxConcurrency;
     this.semaphore = new Semaphore(maxConcurrency);
+    this.drainTimeoutMs = options?.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
     this.keyOf = options?.key ?? defaultChatKey;
   }
 
@@ -100,10 +105,34 @@ export class UpdateQueue {
     return admitted;
   }
 
-  /** Wait for every in-flight dispatch to finish — for graceful shutdown, after
-   *  the source has stopped admitting new updates. */
+  /**
+   * Wait for every in-flight dispatch to finish — for graceful shutdown, after
+   * the source has stopped admitting new updates. Bounded by `drainTimeoutMs` so
+   * a wedged handler can't hang shutdown forever; if the bound is hit the
+   * stragglers are abandoned (and logged).
+   */
   async drain(): Promise<void> {
-    await Promise.allSettled([...this.running]);
+    const settled = await this.withTimeout(
+      Promise.allSettled([...this.running]),
+    );
+    if (!settled) {
+      this.logger.warn(
+        `Shutdown drain timed out after ${this.drainTimeoutMs}ms — ` +
+          `abandoning ${this.running.size} update(s) still in flight`,
+      );
+    }
+  }
+
+  /** Resolve `true` if `work` settles within {@link drainTimeoutMs}, `false` if the
+   *  timeout wins. Always clears the timer so it can't keep the process alive. */
+  private withTimeout(work: Promise<unknown>): Promise<boolean> {
+    let timer!: ReturnType<typeof setTimeout>;
+    const timedOut = new Promise<boolean>((resolve) => {
+      timer = setTimeout(() => resolve(false), this.drainTimeoutMs);
+    });
+    return Promise.race([work.then(() => true), timedOut]).finally(() =>
+      clearTimeout(timer),
+    );
   }
 
   /** Updates dispatching right now (holding a slot). For tests/observability. */

--- a/lib/engine/queue/update-queue.ts
+++ b/lib/engine/queue/update-queue.ts
@@ -1,0 +1,161 @@
+import { Logger } from '@nestjs/common';
+
+import { RawUpdate } from '../../events/raw-update.types';
+import { NestgramConfigError } from '../../exceptions';
+import { defaultChatKey } from './chat-key';
+import { Semaphore } from './semaphore';
+import { DEFAULT_MAX_CONCURRENCY } from './update-queue.constants';
+import { UpdateQueueOptions } from './update-queue.types';
+
+/** The dispatch to run for one update. The queue only schedules it; it does not
+ *  know what dispatch does (it's the source's `onUpdate`, bound to the update). */
+export type QueuedDispatch = () => Promise<void>;
+
+/**
+ * In-process update queue (rung 1 of the queue ladder — no Redis): per-chat FIFO
+ * serialization plus a bounded-concurrency cap. The mechanism behind
+ * {@link QueuedUpdateSource}; constructed once per bot (so the cap is per-bot and
+ * a chat's key never needs bot-name scoping — a queue only ever sees one bot's
+ * updates).
+ *
+ * Two problems it fixes for a single-instance bot:
+ *
+ *   - **Correctness.** Two updates from the same chat (a user firing off two
+ *     quick messages) used to dispatch truly in parallel under webhook delivery,
+ *     racing on that chat's session/FSM state. Here they serialize: a chat's
+ *     updates run one at a time in arrival order. Different chats still run in
+ *     parallel.
+ *   - **Backpressure.** `maxConcurrency` caps how many updates dispatch at once;
+ *     once the cap is hit, admitting the next update waits for a slot. The poll
+ *     loop awaits admission, so it paces itself to the bound instead of fetching
+ *     unboundedly; a webhook controller awaiting delivery is likewise held.
+ *
+ * `enqueue` resolves at ADMISSION — the update's turn in its chat's chain has
+ * come and a slot is free, i.e. dispatch is about to start — NOT when the handler
+ * finishes. Dispatch then runs in the background and frees its slot on
+ * completion. Resolving at admission is what lets the poll loop both parallelize
+ * across chats and apply backpressure without ever waiting on a single slow
+ * handler.
+ */
+export class UpdateQueue {
+  private readonly logger = new Logger(UpdateQueue.name);
+  private readonly semaphore: Semaphore;
+  private readonly maxConcurrency: number;
+  private readonly keyOf: (update: RawUpdate) => string | undefined;
+
+  /**
+   * Per-key tail: the promise of the last enqueued dispatch for a key. The next
+   * update with that key chains after it (FIFO). An entry is removed once its
+   * chain drains, so the map only holds keys with work in flight.
+   */
+  private readonly tails = new Map<string, Promise<void>>();
+
+  /** Every dispatch currently in flight (queued or running), so {@link drain} can
+   *  await them on shutdown. Chat-less updates aren't in `tails`, so this is the
+   *  authoritative set. */
+  private readonly running = new Set<Promise<void>>();
+
+  private static readonly RESOLVED: Promise<void> = Promise.resolve();
+
+  constructor(options?: UpdateQueueOptions) {
+    const maxConcurrency = options?.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
+    // A positive integer: rules out 0/negative, fractions, and Infinity — the
+    // queue is meant to be bounded, and a finite cap keeps `active` accounting
+    // exact. (The Semaphore guards the floor too; this gives a friendlier error.)
+    if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
+      throw new NestgramConfigError(
+        `updateQueue.maxConcurrency must be a positive integer, got ${maxConcurrency}`,
+      );
+    }
+    this.maxConcurrency = maxConcurrency;
+    this.semaphore = new Semaphore(maxConcurrency);
+    this.keyOf = options?.key ?? defaultChatKey;
+  }
+
+  /**
+   * Admit one update for dispatch. Resolves once it is admitted (its chat's chain
+   * has reached it and a concurrency slot is free); the supplied `dispatch` then
+   * runs in the background.
+   */
+  enqueue(update: RawUpdate, dispatch: QueuedDispatch): Promise<void> {
+    const key = this.keyOf(update);
+    const predecessor =
+      key !== undefined
+        ? this.tails.get(key) ?? UpdateQueue.RESOLVED
+        : UpdateQueue.RESOLVED;
+
+    let signalAdmitted!: () => void;
+    const admitted = new Promise<void>((resolve) => {
+      signalAdmitted = resolve;
+    });
+
+    // `process` never rejects (see below), so a chat-less `finished` that is
+    // neither tracked nor awaited can't become an unhandled rejection.
+    const finished = this.process(predecessor, dispatch, signalAdmitted);
+    this.running.add(finished);
+    void finished.finally(() => this.running.delete(finished));
+    if (key !== undefined) {
+      this.track(key, finished);
+    }
+    return admitted;
+  }
+
+  /** Wait for every in-flight dispatch to finish — for graceful shutdown, after
+   *  the source has stopped admitting new updates. */
+  async drain(): Promise<void> {
+    await Promise.allSettled([...this.running]);
+  }
+
+  /** Updates dispatching right now (holding a slot). For tests/observability. */
+  get active(): number {
+    return this.maxConcurrency - this.semaphore.free;
+  }
+
+  /** Updates admitted but waiting for a slot (backpressured). For tests/observability. */
+  get waiting(): number {
+    return this.semaphore.waiting;
+  }
+
+  /**
+   * Wait for the predecessor (per-chat FIFO), take a concurrency slot
+   * (backpressure), signal admission, then run dispatch and free the slot. A
+   * predecessor's outcome is irrelevant to ordering, so its rejection is ignored
+   * — it never breaks the chain. Dispatch is expected to isolate its own errors;
+   * the guard here is a backstop so a throw can never leak a permit or wedge the
+   * chain.
+   *
+   * Resolves and NEVER rejects: every `await` inside is either caught or
+   * (the semaphore) cannot reject. `enqueue` relies on this — it floats the
+   * returned promise for chat-less updates and chains it as a predecessor.
+   */
+  private async process(
+    predecessor: Promise<void>,
+    dispatch: QueuedDispatch,
+    signalAdmitted: () => void,
+  ): Promise<void> {
+    await predecessor.catch(() => undefined);
+    const release = await this.semaphore.acquire();
+    signalAdmitted();
+    try {
+      await dispatch();
+    } catch (error) {
+      this.logger.error(
+        'Update dispatch threw despite per-update isolation',
+        error as Error,
+      );
+    } finally {
+      release();
+    }
+  }
+
+  /** Make `finished` the key's tail, and drop the entry once it drains (if no
+   *  later update has since replaced it as the tail). */
+  private track(key: string, finished: Promise<void>): void {
+    this.tails.set(key, finished);
+    void finished.finally(() => {
+      if (this.tails.get(key) === finished) {
+        this.tails.delete(key);
+      }
+    });
+  }
+}

--- a/lib/engine/queue/update-queue.types.ts
+++ b/lib/engine/queue/update-queue.types.ts
@@ -1,0 +1,27 @@
+import { RawUpdate } from '../../events/raw-update.types';
+
+/**
+ * Tuning for the in-process {@link UpdateQueue}. Pass under
+ * `NestgramModule.forRoot({ updateQueue: { ... } })`, or `false` there to turn
+ * the queue off entirely (dispatch every update immediately, unserialized and
+ * unbounded — the pre-queue behaviour).
+ */
+export interface UpdateQueueOptions {
+  /**
+   * Max updates dispatched in parallel across all chats. Once reached, new
+   * updates wait for a slot — the poll loop stops fetching, a webhook caller is
+   * held — so this doubles as the backpressure threshold. Per-chat order is
+   * always preserved regardless of this value. Defaults to a generous runaway
+   * guard (see `DEFAULT_MAX_CONCURRENCY`).
+   */
+  maxConcurrency?: number;
+  /**
+   * Serialization key for an update: updates sharing a key dispatch one at a time
+   * in arrival order (FIFO), different keys run in parallel. Defaults to keying
+   * by chat. Return `undefined` to opt an update out of serialization (it then
+   * runs concurrency-bounded only). There is one queue per bot, so a key only
+   * needs to be unique within a single bot — two bots that share a chat id never
+   * serialize together regardless.
+   */
+  key?: (update: RawUpdate) => string | undefined;
+}

--- a/lib/engine/queue/update-queue.types.ts
+++ b/lib/engine/queue/update-queue.types.ts
@@ -24,4 +24,10 @@ export interface UpdateQueueOptions {
    * serialize together regardless.
    */
   key?: (update: RawUpdate) => string | undefined;
+  /**
+   * How long graceful shutdown waits for in-flight updates to finish before
+   * abandoning them (ms). Bounds `app.close()` so a wedged handler can't hang it
+   * forever; stragglers are logged. Defaults to `DEFAULT_DRAIN_TIMEOUT_MS`.
+   */
+  drainTimeoutMs?: number;
 }

--- a/lib/engine/source/bot-source.factory.spec.ts
+++ b/lib/engine/source/bot-source.factory.spec.ts
@@ -2,16 +2,22 @@ import { ModuleRef } from '@nestjs/core';
 
 import { BotService } from '../../api';
 import { getWebhookSourceToken } from '../../providers';
+import type { NestgramModuleOptions } from '../../module/nestgram-module.types';
 import { RouteTable } from '../discovery';
 import { AllowedUpdatesResolver } from './allowed-updates.resolver';
 import { BotSourceFactory } from './bot-source.factory';
 import { PollingUpdateSource } from './polling-update-source';
+import { UpdateSource } from './update-source';
 import { WebhookUpdateSource } from './webhook-update-source';
 
-function factory(moduleRef?: ModuleRef): BotSourceFactory {
+function factory(
+  moduleRef?: ModuleRef,
+  options: NestgramModuleOptions = {},
+): BotSourceFactory {
   return new BotSourceFactory(
     new AllowedUpdatesResolver(new RouteTable([])),
     moduleRef ?? ({ get: jest.fn() } as unknown as ModuleRef),
+    options,
   );
 }
 
@@ -47,5 +53,48 @@ describe('BotSourceFactory', () => {
   it('returns null when no transport is configured', () => {
     expect(factory().create(bot, {})).toBeNull();
     expect(factory().create(bot, { polling: false })).toBeNull();
+  });
+
+  describe('user source factory', () => {
+    it('hands the built-in source to the factory to wrap, and uses the result', () => {
+      const wrapped = { start: jest.fn(), stop: jest.fn() } as UpdateSource;
+      const source = jest.fn().mockReturnValue(wrapped);
+
+      const result = factory(undefined, { source }).create(bot, {
+        polling: true,
+      });
+
+      expect(result).toBe(wrapped);
+      const ctx = source.mock.calls[0][0];
+      expect(ctx.default).toBeInstanceOf(PollingUpdateSource);
+      expect(ctx.bot).toBe(bot);
+      expect(typeof ctx.get).toBe('function');
+    });
+
+    it('lets the factory replace ingestion entirely (no transport → default undefined)', () => {
+      const custom = { start: jest.fn(), stop: jest.fn() } as UpdateSource;
+      const source = jest.fn().mockReturnValue(custom);
+
+      const result = factory(undefined, { source }).create(bot, {});
+
+      expect(result).toBe(custom);
+      expect(source.mock.calls[0][0].default).toBeUndefined();
+    });
+
+    it('exposes DI lookup to the factory via ctx.get', () => {
+      const dep = { hi: true };
+      const get = jest.fn().mockReturnValue(dep);
+      const moduleRef = { get } as unknown as ModuleRef;
+      const source = jest.fn().mockReturnValue({
+        start: jest.fn(),
+        stop: jest.fn(),
+      } as UpdateSource);
+
+      factory(moduleRef, { source }).create(bot, { polling: true });
+
+      const resolved = source.mock.calls[0][0].get('SomeToken');
+      expect(resolved).toBe(dep);
+      expect(get).toHaveBeenCalledWith('SomeToken', { strict: false });
+    });
   });
 });

--- a/lib/engine/source/bot-source.factory.spec.ts
+++ b/lib/engine/source/bot-source.factory.spec.ts
@@ -4,11 +4,16 @@ import { BotService } from '../../api';
 import { getWebhookSourceToken } from '../../providers';
 import type { NestgramModuleOptions } from '../../module/nestgram-module.types';
 import { RouteTable } from '../discovery';
+import { QueuedUpdateSource } from '../queue';
 import { AllowedUpdatesResolver } from './allowed-updates.resolver';
 import { BotSourceFactory } from './bot-source.factory';
 import { PollingUpdateSource } from './polling-update-source';
 import { UpdateSource } from './update-source';
 import { WebhookUpdateSource } from './webhook-update-source';
+
+// Most tests disable the default queue to assert on the raw transport / seam
+// result; the queue layer itself is exercised in the dedicated block below.
+const NO_QUEUE: NestgramModuleOptions = { updateQueue: false };
 
 function factory(
   moduleRef?: ModuleRef,
@@ -25,12 +30,12 @@ const bot = { token: 't' } as unknown as BotService;
 
 describe('BotSourceFactory', () => {
   it('builds a PollingUpdateSource for a polling transport', () => {
-    expect(factory().create(bot, { polling: true })).toBeInstanceOf(
-      PollingUpdateSource,
-    );
-    expect(factory().create(bot, { polling: { idleMs: 5 } })).toBeInstanceOf(
-      PollingUpdateSource,
-    );
+    expect(
+      factory(undefined, NO_QUEUE).create(bot, { polling: true }),
+    ).toBeInstanceOf(PollingUpdateSource);
+    expect(
+      factory(undefined, NO_QUEUE).create(bot, { polling: { idleMs: 5 } }),
+    ).toBeInstanceOf(PollingUpdateSource);
   });
 
   it('resolves the per-bot WebhookUpdateSource from DI for a webhook bot', () => {
@@ -38,7 +43,7 @@ describe('BotSourceFactory', () => {
     const get = jest.fn().mockReturnValue(webhookSource);
     const moduleRef = { get } as unknown as ModuleRef;
 
-    const source = factory(moduleRef).create(
+    const source = factory(moduleRef, NO_QUEUE).create(
       bot,
       { webhook: { url: 'https://x/wh' } },
       'sales',
@@ -60,9 +65,10 @@ describe('BotSourceFactory', () => {
       const wrapped = { start: jest.fn(), stop: jest.fn() } as UpdateSource;
       const source = jest.fn().mockReturnValue(wrapped);
 
-      const result = factory(undefined, { source }).create(bot, {
-        polling: true,
-      });
+      const result = factory(undefined, { source, updateQueue: false }).create(
+        bot,
+        { polling: true },
+      );
 
       expect(result).toBe(wrapped);
       const ctx = source.mock.calls[0][0];
@@ -75,7 +81,10 @@ describe('BotSourceFactory', () => {
       const custom = { start: jest.fn(), stop: jest.fn() } as UpdateSource;
       const source = jest.fn().mockReturnValue(custom);
 
-      const result = factory(undefined, { source }).create(bot, {});
+      const result = factory(undefined, { source, updateQueue: false }).create(
+        bot,
+        {},
+      );
 
       expect(result).toBe(custom);
       expect(source.mock.calls[0][0].default).toBeUndefined();
@@ -90,11 +99,41 @@ describe('BotSourceFactory', () => {
         stop: jest.fn(),
       } as UpdateSource);
 
-      factory(moduleRef, { source }).create(bot, { polling: true });
+      factory(moduleRef, { source, updateQueue: false }).create(bot, {
+        polling: true,
+      });
 
       const resolved = source.mock.calls[0][0].get('SomeToken');
       expect(resolved).toBe(dep);
       expect(get).toHaveBeenCalledWith('SomeToken', { strict: false });
+    });
+  });
+
+  describe('default update queue', () => {
+    it('wraps the source in the queue by default', () => {
+      expect(factory().create(bot, { polling: true })).toBeInstanceOf(
+        QueuedUpdateSource,
+      );
+    });
+
+    it('also queues a custom (replacing) source', () => {
+      const custom = { start: jest.fn(), stop: jest.fn() } as UpdateSource;
+      const result = factory(undefined, {
+        source: () => custom,
+      }).create(bot, {});
+
+      expect(result).toBeInstanceOf(QueuedUpdateSource);
+      expect(result).not.toBe(custom);
+    });
+
+    it('skips the queue when updateQueue is false', () => {
+      expect(
+        factory(undefined, NO_QUEUE).create(bot, { polling: true }),
+      ).toBeInstanceOf(PollingUpdateSource);
+    });
+
+    it('still returns null when there is nothing to wrap', () => {
+      expect(factory().create(bot, {})).toBeNull();
     });
   });
 });

--- a/lib/engine/source/bot-source.factory.ts
+++ b/lib/engine/source/bot-source.factory.ts
@@ -1,9 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 
 import { BotService } from '../../api';
-import type { WebhookOptions } from '../../module/nestgram-module.types';
-import { DEFAULT_BOT_NAME, getWebhookSourceToken } from '../../providers';
+import type {
+  NestgramModuleOptions,
+  WebhookOptions,
+} from '../../module/nestgram-module.types';
+import {
+  DEFAULT_BOT_NAME,
+  getWebhookSourceToken,
+  Providers,
+} from '../../providers';
 import { AllowedUpdatesResolver } from './allowed-updates.resolver';
 import { PollingOptions, PollingUpdateSource } from './polling-update-source';
 import { UpdateSource } from './update-source';
@@ -32,12 +39,26 @@ export class BotSourceFactory {
   constructor(
     private readonly allowedUpdatesResolver: AllowedUpdatesResolver,
     private readonly moduleRef: ModuleRef,
+    @Inject(Providers.NESTGRAM_OPTIONS)
+    private readonly options: NestgramModuleOptions,
   ) {}
 
   create(
     botService: BotService,
     transport: BotTransport,
     name: string = DEFAULT_BOT_NAME,
+  ): UpdateSource | null {
+    return this.applyUserSource(
+      this.buildTransport(transport, botService, name),
+      botService,
+    );
+  }
+
+  /** Build the built-in transport source for a bot, or `null` when none is configured. */
+  private buildTransport(
+    transport: BotTransport,
+    botService: BotService,
+    name: string,
   ): UpdateSource | null {
     if (transport.polling) {
       const options =
@@ -55,5 +76,26 @@ export class BotSourceFactory {
       );
     }
     return null;
+  }
+
+  /**
+   * Hand the built-in source (`default`) to the user's `source` factory if one is
+   * configured, so they can wrap or replace it. The single home for the seam —
+   * the single-bot picker delegates here too, so both paths apply it identically.
+   * With no factory, the built-in source passes through unchanged. Returns `null`
+   * only when there is neither a transport nor a custom source (no source to run).
+   */
+  applyUserSource(
+    inner: UpdateSource | null,
+    botService: BotService,
+  ): UpdateSource | null {
+    if (!this.options.source) {
+      return inner;
+    }
+    return this.options.source({
+      default: inner ?? undefined,
+      bot: botService,
+      get: (token) => this.moduleRef.get(token, { strict: false }),
+    });
   }
 }

--- a/lib/engine/source/bot-source.factory.ts
+++ b/lib/engine/source/bot-source.factory.ts
@@ -11,6 +11,7 @@ import {
   getWebhookSourceToken,
   Providers,
 } from '../../providers';
+import { QueuedUpdateSource, UpdateQueue } from '../queue';
 import { AllowedUpdatesResolver } from './allowed-updates.resolver';
 import { PollingOptions, PollingUpdateSource } from './polling-update-source';
 import { UpdateSource } from './update-source';
@@ -48,10 +49,25 @@ export class BotSourceFactory {
     transport: BotTransport,
     name: string = DEFAULT_BOT_NAME,
   ): UpdateSource | null {
-    return this.applyUserSource(
+    return this.decorate(
       this.buildTransport(transport, botService, name),
       botService,
     );
+  }
+
+  /**
+   * Produce the final per-bot source from the built-in transport (`inner`): run
+   * it through the user's `source` factory (wrap/replace), then wrap the result
+   * in the default update queue (per-chat FIFO + bounded concurrency) unless
+   * disabled. The single home for both layers — the single-bot picker delegates
+   * here too, so both paths compose them identically. `null` in → `null` out
+   * (no transport and no custom source = nothing to run).
+   */
+  decorate(
+    inner: UpdateSource | null,
+    botService: BotService,
+  ): UpdateSource | null {
+    return this.applyQueue(this.applyUserSource(inner, botService));
   }
 
   /** Build the built-in transport source for a bot, or `null` when none is configured. */
@@ -80,12 +96,10 @@ export class BotSourceFactory {
 
   /**
    * Hand the built-in source (`default`) to the user's `source` factory if one is
-   * configured, so they can wrap or replace it. The single home for the seam —
-   * the single-bot picker delegates here too, so both paths apply it identically.
-   * With no factory, the built-in source passes through unchanged. Returns `null`
-   * only when there is neither a transport nor a custom source (no source to run).
+   * configured, so they can wrap or replace it. With no factory, the built-in
+   * source passes through unchanged.
    */
-  applyUserSource(
+  private applyUserSource(
     inner: UpdateSource | null,
     botService: BotService,
   ): UpdateSource | null {
@@ -97,5 +111,21 @@ export class BotSourceFactory {
       bot: botService,
       get: (token) => this.moduleRef.get(token, { strict: false }),
     });
+  }
+
+  /**
+   * Wrap a source in the default update queue (one {@link UpdateQueue} per bot),
+   * unless `updateQueue: false` turns it off. Wraps whatever the seam produced —
+   * built-in or custom — so a custom source is queued too unless disabled.
+   */
+  private applyQueue(source: UpdateSource | null): UpdateSource | null {
+    if (source === null || this.options.updateQueue === false) {
+      return source;
+    }
+    const options =
+      typeof this.options.updateQueue === 'object'
+        ? this.options.updateQueue
+        : undefined;
+    return new QueuedUpdateSource(source, new UpdateQueue(options));
   }
 }

--- a/lib/engine/source/update-source.ts
+++ b/lib/engine/source/update-source.ts
@@ -1,4 +1,7 @@
+import { Type } from '@nestjs/common';
+
 import { RawUpdate } from '../../events/raw-update.types';
+import type { BotService } from '../../api';
 
 /** Called once per incoming update. May be async; the source awaits it. */
 export type UpdateListener = (update: RawUpdate) => void | Promise<void>;
@@ -18,3 +21,33 @@ export interface UpdateSource {
   /** Stop delivering and release the transport. Resolves once fully stopped. */
   stop(): Promise<void>;
 }
+
+/**
+ * What an {@link UpdateSourceFactory} receives — everything needed to build a
+ * custom source or decorate the built-in one. Called once per bot, so a
+ * multi-bot app can branch on `bot.name`.
+ */
+export interface UpdateSourceContext {
+  /**
+   * The transport the framework would otherwise use for this bot — polling or
+   * webhook per config, or `undefined` when neither is set. Wrap it to add a
+   * layer (e.g. a queue), or ignore it to replace ingestion entirely.
+   */
+  default?: UpdateSource;
+  /** The bot this source serves — in a multi-bot app, the specific bot. */
+  bot: BotService;
+  /**
+   * Resolve a provider from the DI container, for a custom source's
+   * dependencies (looked up non-strictly, across the whole app).
+   */
+  get: <T>(token: Type<T> | string | symbol) => T;
+}
+
+/**
+ * Builds the update source the engine drives for a bot. Set as
+ * `NestgramModule.forRoot({ source })` to plug in your own transport or to
+ * decorate the built-in one — return `new MyQueuedSource(ctx.default, …)` to
+ * wrap, or your own `UpdateSource` to replace. The single public seam for
+ * owning delivery; the framework's own queue layer is built on it.
+ */
+export type UpdateSourceFactory = (ctx: UpdateSourceContext) => UpdateSource;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -26,6 +26,7 @@ export * from './engine/discovery';
 export * from './engine/execution';
 export * from './engine/dispatcher';
 export * from './engine/source';
+export * from './engine/queue';
 export * from './module';
 
 // Testing utilities (dispatch fake updates against your routers). Jest-agnostic

--- a/lib/module/nestgram-module.types.ts
+++ b/lib/module/nestgram-module.types.ts
@@ -2,6 +2,7 @@ import { ModuleMetadata, Type } from '@nestjs/common';
 
 import { PollingOptions } from '../engine/source';
 import type { UpdateSourceFactory } from '../engine/source';
+import type { UpdateQueueOptions } from '../engine/queue';
 import type { AllowedUpdate } from '../engine/context/update-kind';
 import type { ApiInterceptor } from '../api/request';
 import type { ParseModeValue } from '../api/parse-mode';
@@ -102,6 +103,19 @@ export interface NestgramModuleOptions {
    * built on — no privileged core.
    */
   source?: UpdateSourceFactory;
+  /**
+   * In-process update queue applied over the active source (per bot): per-chat
+   * FIFO serialization plus a bounded concurrency cap. On by default (the
+   * correctness baseline for a single-instance bot) — updates for the SAME chat
+   * dispatch one at a time in arrival order, so two quick messages can't race on
+   * that chat's session/FSM state, while different chats run in parallel up to
+   * `maxConcurrency` (the poll loop paces itself to that bound). Pass an object
+   * to tune, or `false` to dispatch every update immediately with no
+   * serialization or bound (the pre-queue behaviour — reintroduces the race).
+   * It wraps whatever `source` resolves to, so a custom source is queued too
+   * unless you turn this off.
+   */
+  updateQueue?: UpdateQueueOptions | false;
   /**
    * Webhook transport config. When set, the bot registers the webhook with
    * Telegram on boot and receives updates over HTTP instead of polling. You

--- a/lib/module/nestgram-module.types.ts
+++ b/lib/module/nestgram-module.types.ts
@@ -1,6 +1,7 @@
 import { ModuleMetadata, Type } from '@nestjs/common';
 
 import { PollingOptions } from '../engine/source';
+import type { UpdateSourceFactory } from '../engine/source';
 import type { AllowedUpdate } from '../engine/context/update-kind';
 import type { ApiInterceptor } from '../api/request';
 import type { ParseModeValue } from '../api/parse-mode';
@@ -91,6 +92,16 @@ export interface NestgramModuleOptions {
    * receive updates over HTTP instead.
    */
   polling?: boolean | PollingOptions;
+  /**
+   * Plug in your own update source, or decorate the built-in one. Called once
+   * per bot with `{ default, bot, get }` — return `ctx.default` wrapped in your
+   * own `UpdateSource` decorator (e.g. a queue) to add a layer, or your own
+   * `UpdateSource` to replace ingestion entirely (the `polling`/`webhook` config
+   * then only seeds `ctx.default`, which you may ignore). Branch on `ctx.bot.name`
+   * for per-bot behaviour. The public seam the framework's own queue layer is
+   * built on — no privileged core.
+   */
+  source?: UpdateSourceFactory;
   /**
    * Webhook transport config. When set, the bot registers the webhook with
    * Telegram on boot and receives updates over HTTP instead of polling. You

--- a/lib/module/nestgram.module.spec.ts
+++ b/lib/module/nestgram.module.spec.ts
@@ -29,6 +29,7 @@ import {
   WebhookSourceEntry,
   WebhookUpdateSource,
 } from '../engine/source';
+import { QueuedUpdateSource } from '../engine/queue';
 import { NestgramModule } from './nestgram.module';
 
 const originalFetch = global.fetch;
@@ -460,11 +461,15 @@ describe('webhook transport (real-module DI)', () => {
     const app = await NestFactory.createApplicationContext(WebhookAppModule, {
       logger: false,
     });
-    const source = app.get<WebhookUpdateSource>(Providers.UPDATE_SOURCE);
-
-    expect(source).toBeInstanceOf(WebhookUpdateSource);
-    expect(source.verifySecret('s3cret')).toBe(true);
-    expect(source.verifySecret('wrong')).toBe(false);
+    // The active source is the default update queue wrapping the webhook source;
+    // the webhook source itself stays injectable by its class token (what the
+    // controller uses) and still validates the secret.
+    expect(app.get<UpdateSource>(Providers.UPDATE_SOURCE)).toBeInstanceOf(
+      QueuedUpdateSource,
+    );
+    const webhook = app.get(WebhookUpdateSource);
+    expect(webhook.verifySecret('s3cret')).toBe(true);
+    expect(webhook.verifySecret('wrong')).toBe(false);
 
     await app.close();
   });
@@ -811,14 +816,16 @@ describe('custom update source (source seam)', () => {
     // The factory runs exactly once — not also by the (unstarted) UPDATE_SOURCE
     // provider — so a non-idempotent factory can't build a stray instance.
     expect(replacingFactoryCalls).toBe(1);
-    // Drive an update through the listener the framework handed our source.
+    // Drive an update through the listener the framework handed our source. The
+    // default queue wraps it, so dispatch runs in the background after admission.
     await replacingSource.listener?.(messageUpdate(1, 'from-custom-source'));
+    await new Promise((r) => setImmediate(r));
     expect(router.seen.map((m) => m?.text)).toEqual(['from-custom-source']);
 
     await app.close();
   });
 
-  it('wraps the built-in transport: UPDATE_SOURCE is the wrapper over polling', async () => {
+  it('wraps the built-in transport, then the default queue wraps that', async () => {
     global.fetch = (async () => ({
       json: async () => ({ ok: true, result: [] }),
     })) as unknown as typeof fetch;
@@ -827,10 +834,67 @@ describe('custom update source (source seam)', () => {
       WrappedSourceAppModule,
       { logger: false },
     );
-    const source = app.get<UpdateSource>(Providers.UPDATE_SOURCE);
+    // Composition order: default queue on top of the user's source on top of
+    // the polling transport (orthogonal — `source` = ingestion, queue = layer).
+    expect(app.get<UpdateSource>(Providers.UPDATE_SOURCE)).toBeInstanceOf(
+      QueuedUpdateSource,
+    );
+    expect(wrappingSource?.inner).toBeInstanceOf(PollingUpdateSource);
 
-    expect(source).toBe(wrappingSource);
-    expect((source as WrappingSource).inner).toBeInstanceOf(
+    await app.close();
+  });
+});
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({ token: '123456:TEST', polling: { idleMs: 5 } }),
+  ],
+})
+class DefaultQueueAppModule {}
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      token: '123456:TEST',
+      polling: { idleMs: 5 },
+      updateQueue: false,
+    }),
+  ],
+})
+class NoQueueAppModule {}
+
+describe('default update queue', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('wraps the transport in the update queue by default', async () => {
+    global.fetch = (async () => ({
+      json: async () => ({ ok: true, result: [] }),
+    })) as unknown as typeof fetch;
+
+    const app = await NestFactory.createApplicationContext(
+      DefaultQueueAppModule,
+      { logger: false },
+    );
+
+    expect(app.get<UpdateSource>(Providers.UPDATE_SOURCE)).toBeInstanceOf(
+      QueuedUpdateSource,
+    );
+
+    await app.close();
+  });
+
+  it('updateQueue: false dispatches through the bare transport (no queue)', async () => {
+    global.fetch = (async () => ({
+      json: async () => ({ ok: true, result: [] }),
+    })) as unknown as typeof fetch;
+
+    const app = await NestFactory.createApplicationContext(NoQueueAppModule, {
+      logger: false,
+    });
+
+    expect(app.get<UpdateSource>(Providers.UPDATE_SOURCE)).toBeInstanceOf(
       PollingUpdateSource,
     );
 

--- a/lib/module/nestgram.module.spec.ts
+++ b/lib/module/nestgram.module.spec.ts
@@ -22,7 +22,13 @@ import {
 } from '../api/request';
 import type { Observable } from 'rxjs';
 import { Providers } from '../providers';
-import { WebhookSourceEntry, WebhookUpdateSource } from '../engine/source';
+import {
+  PollingUpdateSource,
+  UpdateListener,
+  UpdateSource,
+  WebhookSourceEntry,
+  WebhookUpdateSource,
+} from '../engine/source';
 import { NestgramModule } from './nestgram.module';
 
 const originalFetch = global.fetch;
@@ -717,6 +723,116 @@ describe('multi-bot webhook (forRoot bots: [])', () => {
     // Routing primitives the controllers rely on are wired per bot.
     expect(support?.source.ownsSecret('s')).toBe(true);
     expect(support?.source.ownsSecret('x')).toBe(false);
+
+    await app.close();
+  });
+});
+
+// Custom update source seam: a user-supplied `source` factory can replace
+// ingestion (no polling/webhook) or wrap the built-in transport.
+class RecordingSource implements UpdateSource {
+  started = false;
+  listener?: UpdateListener;
+  async start(onUpdate: UpdateListener): Promise<void> {
+    this.started = true;
+    this.listener = onUpdate;
+  }
+  async stop(): Promise<void> {
+    this.started = false;
+  }
+}
+
+class WrappingSource implements UpdateSource {
+  constructor(readonly inner: UpdateSource) {}
+  start(onUpdate: UpdateListener): Promise<void> {
+    return this.inner.start(onUpdate);
+  }
+  stop(): Promise<void> {
+    return this.inner.stop();
+  }
+}
+
+const replacingSource = new RecordingSource();
+let replacingFactoryCalls = 0;
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      token: '123456:TEST',
+      // No polling/webhook: the custom source IS the transport.
+      source: () => {
+        replacingFactoryCalls += 1;
+        return replacingSource;
+      },
+    }),
+  ],
+  providers: [GreetRouter],
+})
+class CustomSourceAppModule {}
+
+let wrappingSource: WrappingSource | undefined;
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      token: '123456:TEST',
+      polling: { idleMs: 5 },
+      source: ({ default: inner }) => {
+        if (!inner) {
+          throw new Error('expected the polling transport as default');
+        }
+        wrappingSource = new WrappingSource(inner);
+        return wrappingSource;
+      },
+    }),
+  ],
+  providers: [GreetRouter],
+})
+class WrappedSourceAppModule {}
+
+describe('custom update source (source seam)', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('replaces ingestion: the custom source is started and its updates dispatch', async () => {
+    // startFleet warms identity (getMe) before starting the source.
+    global.fetch = (async () => ({
+      json: async () => ({ ok: true, result: { username: 'bot' } }),
+    })) as unknown as typeof fetch;
+
+    const app = await NestFactory.createApplicationContext(
+      CustomSourceAppModule,
+      { logger: false },
+    );
+    const router = app.get(GreetRouter);
+
+    expect(replacingSource.started).toBe(true);
+    // The factory runs exactly once — not also by the (unstarted) UPDATE_SOURCE
+    // provider — so a non-idempotent factory can't build a stray instance.
+    expect(replacingFactoryCalls).toBe(1);
+    // Drive an update through the listener the framework handed our source.
+    await replacingSource.listener?.(messageUpdate(1, 'from-custom-source'));
+    expect(router.seen.map((m) => m?.text)).toEqual(['from-custom-source']);
+
+    await app.close();
+  });
+
+  it('wraps the built-in transport: UPDATE_SOURCE is the wrapper over polling', async () => {
+    global.fetch = (async () => ({
+      json: async () => ({ ok: true, result: [] }),
+    })) as unknown as typeof fetch;
+
+    const app = await NestFactory.createApplicationContext(
+      WrappedSourceAppModule,
+      { logger: false },
+    );
+    const source = app.get<UpdateSource>(Providers.UPDATE_SOURCE);
+
+    expect(source).toBe(wrappingSource);
+    expect((source as WrappingSource).inner).toBeInstanceOf(
+      PollingUpdateSource,
+    );
 
     await app.close();
   });

--- a/lib/module/nestgram.module.ts
+++ b/lib/module/nestgram.module.ts
@@ -107,19 +107,40 @@ export class NestgramModule {
       inject: [Providers.NESTGRAM_OPTIONS, BotService, AllowedUpdatesResolver],
     },
     // The active transport, chosen by config: webhook if configured, else
-    // polling. Bootstrap injects UPDATE_SOURCE and only starts it when a
-    // transport is set.
+    // polling — then run through the user's `source` factory (wrap/replace) via
+    // the same BotSourceFactory the fleet uses, so the seam applies identically.
+    // Bootstrap injects UPDATE_SOURCE and only starts it when a transport is set;
+    // the no-transport-but-custom-source case is handled on the fleet path.
     {
       provide: Providers.UPDATE_SOURCE,
       useFactory: (
         options: NestgramModuleOptions,
         polling: PollingUpdateSource,
         webhook: WebhookUpdateSource,
-      ): UpdateSource => (options.webhook ? webhook : polling),
+        botService: BotService,
+        factory: BotSourceFactory,
+      ): UpdateSource => {
+        const inner = options.webhook
+          ? webhook
+          : options.polling
+          ? polling
+          : null;
+        // No top-level transport: this provider's source is NOT started (the
+        // bootstrap's hasTransport gate is false) — the fleet path owns building
+        // and starting any custom source. Skip the seam here so the user's
+        // `source` factory isn't invoked a second time (building a stray,
+        // never-stopped instance). Resolve to the inert polling placeholder.
+        if (inner === null) {
+          return polling;
+        }
+        return factory.applyUserSource(inner, botService) ?? polling;
+      },
       inject: [
         Providers.NESTGRAM_OPTIONS,
         PollingUpdateSource,
         WebhookUpdateSource,
+        BotService,
+        BotSourceFactory,
       ],
     },
     NestgramBootstrap,

--- a/lib/module/nestgram.module.ts
+++ b/lib/module/nestgram.module.ts
@@ -127,13 +127,15 @@ export class NestgramModule {
           : null;
         // No top-level transport: this provider's source is NOT started (the
         // bootstrap's hasTransport gate is false) — the fleet path owns building
-        // and starting any custom source. Skip the seam here so the user's
+        // and starting any custom source. Skip decoration here so the user's
         // `source` factory isn't invoked a second time (building a stray,
         // never-stopped instance). Resolve to the inert polling placeholder.
         if (inner === null) {
           return polling;
         }
-        return factory.applyUserSource(inner, botService) ?? polling;
+        // Apply the user `source` factory + the default update queue, the same
+        // composition the fleet uses.
+        return factory.decorate(inner, botService) ?? polling;
       },
       inject: [
         Providers.NESTGRAM_OPTIONS,


### PR DESCRIPTION
## Problem

Update delivery was fixed at two extremes: long polling processed updates strictly one at a time (no cross-chat parallelism), while webhook delivery dispatched every update concurrently and unbounded — so two quick updates from the **same chat** could race on that chat's session/FSM state (a latent correctness bug), and a flood could spawn unbounded concurrent work. There was also no public way to plug in or decorate the update source.

## What changed

Two layers, built so the second is a consumer of the first (no privileged core).

**1. Pluggable `source` seam** (`forRoot({ source })`)
- A factory `(ctx: { default, bot, get }) => UpdateSource`, called once per bot.
- **Wrap** the built-in transport (`ctx.default`) to add a layer, or **replace** ingestion entirely (a message bus, a custom transport). `ctx.get` resolves DI deps.
- Single home `BotSourceFactory` — the single-bot picker and the multi-bot fleet both compose through it identically.

**2. Default in-process update queue** (`updateQueue`)
- Shipped as a `QueuedUpdateSource` **decorator** over the seam output (one `UpdateQueue` per bot), so it's exactly what a bot author could write and register through the same `source` seam.
- **Per-chat FIFO**: a chat's updates run one at a time in arrival order (fixes the race); different chats run in parallel.
- **Bounded concurrency** (`maxConcurrency`, default 1000): doubles as backpressure — the poll loop paces itself; a webhook flood can't spawn unbounded work.
- `enqueue` resolves at *admission* (not handler completion), so neither transport waits on a slow handler.
- Graceful shutdown drains in-flight updates after the source stops, bounded by `drainTimeoutMs` (default 10s) so a wedged handler can't hang `app.close()`.
- On by default (correctness baseline, consistent with throttle/auto-answer); `updateQueue: false` restores direct dispatch.

## How to verify

- `npm run build`, `npm run lint`, `npx jest` — green (719 passed + 3 todo); new suites under `lib/engine/queue/` plus integration coverage in `lib/module/nestgram.module.spec.ts` (custom source replace/wrap, default-on, `updateQueue: false`).
- Docs: `docs/extending.md` (Swap the update source), `docs/how-nestgram-works.md` (Update delivery & ordering); the sessions / FSM / rate-limiting concurrency notes are updated to reflect per-chat serialization now holding by default on a single instance.

## Notes

- The queue is per-process: across multiple instances the same conversation can still land on different workers — that's the distributed `UpdateQueue` port (separate, roadmapped), which this seam is designed to host.
- Replacing a webhook source means you own delivery (drop the ready-made `WebhookController`); documented in `extending.md`.