### PR TITLE
feat(keyboards): pipeline builder, Button values, editing & dead-end buttons

### DIFF
--- a/docs/commands-and-keyboards.md
+++ b/docs/commands-and-keyboards.md
@@ -155,6 +155,58 @@ the `buy` press — and carrying typed data in a button (`buy:42`-style)
 without magic strings — is the next page,
 [Callbacks →](/docs/callbacks).
 
+### Dynamic keyboards
+
+When the buttons come from data, a button is a value (`Button`) and `.map()`
+lays a collection out — no hand-rolled loop:
+
+:::code[catalog.router.ts]
+
+```ts
+import { InlineKeyboard, Button } from 'nestgram';
+
+const keyboard = new InlineKeyboard()
+  .columns(2)
+  .map(products, (p) => Button.text(p.name, 'buy/:id', { id: p.id }))
+  .row(Button.url('Catalog', 'https://shop.dev'));
+```
+
+:::
+
+`.map(items, fn)` runs `fn` per item — return a `Button` to add it, or a falsy
+value to skip one (so a conditional button needs no separate filter).
+`.columns(n)` wraps the result into a grid and `.row(...buttons)` lays an
+explicit row. `.add(...buttons)` is the universal inlet: every Bot API kind has
+a `Button` constructor (`Button.webApp`, `Button.switchInline`,
+`Button.copyText`, `Button.pay`, …), so `.add(Button.pay('Pay'))` reaches the
+ones without a fluent shortcut.
+
+### Editing a keyboard
+
+Often you already have a keyboard — the one on the message a button press came
+from — and just want to tweak it: flip a checkbox, relabel, drop a button.
+`InlineKeyboard.from(markup)` adopts it (a copy — the original is untouched) and
+you address a button by its **route**, the same string that built and routes it:
+
+:::code[todo.router.ts]
+
+```ts
+import { InlineKeyboard } from 'nestgram';
+
+const next = InlineKeyboard.from(markup)
+  .setText(`toggle/${id}`, '☑ Done') // a concrete route → one button
+  .remove('cancel'); // drop a button
+
+// send it back: query.message.editReplyMarkup(next)
+```
+
+:::
+
+A concrete route (`toggle/3`) addresses one button; a template (`toggle/:id`)
+addresses all that fit, with the captured params passed to the patch. You can
+also address by predicate (`.update((b) => b.label === 'Old', …)`), by visible
+text (`.replaceText('Old', 'New')`), or by position (`.updateAt(row, col, …)`).
+
 ### Colouring buttons
 
 Telegram lets a button carry a `style`: `primary` (blue), `success` (green) or
@@ -204,9 +256,14 @@ return message.answer('Menu:', { reply_markup: keyboard });
 :::
 
 `.resize()` and `.oneTime()` map to the Telegram `resize_keyboard` and
-`one_time_keyboard` flags, and `.placeholder()` sets the grey
-`input_field_placeholder` — named for discoverability, but the underlying
-markup is exactly what the API expects.
+`one_time_keyboard` flags, `.persistent()` to `is_persistent`, and
+`.placeholder()` sets the grey `input_field_placeholder` — named for
+discoverability, but the underlying markup is exactly what the API expects.
+
+Beyond plain `.text()` there's a method per Bot API button kind —
+`.requestContact()`, `.requestLocation()`, `.requestPoll()`, `.webApp()`,
+`.requestUsers()` and `.requestChat()` — each taking the same trailing `hidden`
+flag.
 
 ## answer vs reply
 

--- a/docs/commands-and-keyboards.md
+++ b/docs/commands-and-keyboards.md
@@ -166,20 +166,55 @@ lays a collection out — no hand-rolled loop:
 import { InlineKeyboard, Button } from 'nestgram';
 
 const keyboard = new InlineKeyboard()
-  .columns(2)
   .map(products, (p) => Button.text(p.name, 'buy/:id', { id: p.id }))
+  .split(2)
   .row(Button.url('Catalog', 'https://shop.dev'));
 ```
 
 :::
 
-`.map(items, fn)` runs `fn` per item — return a `Button` to add it, or a falsy
-value to skip one (so a conditional button needs no separate filter).
-`.columns(n)` wraps the result into a grid and `.row(...buttons)` lays an
-explicit row. `.add(...buttons)` is the universal inlet: every Bot API kind has
-a `Button` constructor (`Button.webApp`, `Button.switchInline`,
-`Button.copyText`, `Button.pay`, …), so `.add(Button.pay('Pay'))` reaches the
-ones without a fluent shortcut.
+Buttons accumulate, then a layout method commits them: `.split(n)` cuts the
+accumulated buttons into rows of `n`, `.spread()` is one per row, and `.row()`
+commits a single row — so `.map(...).split(2)` reads the same as
+`.text().text().split(2)`. `.map(items, fn)` runs `fn` per item; return a
+`Button` to add it, or a falsy value to skip one. `.add(...buttons)` is the
+universal inlet: every Bot API kind has a `Button` constructor (`Button.webApp`,
+`Button.switchInline`, `Button.copyText`, `Button.pay`, …), so
+`.add(Button.pay('Pay'))` reaches the ones without a fluent shortcut.
+
+### Conditional buttons & sections
+
+`.if(condition)` keeps the **last unit** — a button, a row, a `.split()` section
+or a `.group()` — only when `condition` is true. One verb for every scope:
+
+:::code[menu.router.ts]
+
+```ts
+new InlineKeyboard()
+  .map(items, (i) => Button.text(i.label, 'pick/:id', { id: i.id }))
+  .split(3) // a 3-wide grid for everyone
+  .group((kb) => kb.text('Stats', 'stats').text('Ban', 'ban').split(2))
+  .if(isAdmin); // ...plus an admin block, only for admins
+```
+
+:::
+
+Inside `.map()` you condition a single button with `Button.if(...)` — and
+`.else(...)` gives it a fallback when hidden (a label becomes a dead-end button,
+or pass a full `Button`):
+
+:::code[shop.router.ts]
+
+```ts
+.map(products, (p) =>
+  Button.text(p.name, 'buy/:id', { id: p.id }).if(p.inStock).else('Sold out'),
+);
+```
+
+:::
+
+Use `Button.if()` for the per-item filter inside `.map()`, and the builder's
+`.if()` for a whole row, section or group.
 
 ### Editing a keyboard
 
@@ -210,27 +245,25 @@ text (`.replaceText('Old', 'New')`), or by position (`.updateAt(row, col, …)`)
 ### Colouring buttons
 
 Telegram lets a button carry a `style`: `primary` (blue), `success` (green) or
-`danger` (red). A colour modifier styles the **next** button only, so it reads
-like a label on the button it precedes:
+`danger` (red). A colour modifier styles the button **just added**, so it reads
+like a label on the button it follows:
 
-:::code[confirm.router.ts]{mark="2,4"}
+:::code[confirm.router.ts]{mark="2,3"}
 
 ```ts
 const keyboard = new InlineKeyboard()
-  .success()
   .text('Confirm', 'confirm')
-  .danger()
+  .success()
   .text('Cancel', 'cancel')
+  .danger()
   .text('Later', 'later'); // no modifier → the app's default style
 ```
 
 :::
 
-The modifier is one-shot (`Later` above stays default) and is consumed even
-when the button is hidden — so a conditional button never leaks its colour onto
-the next one: `.danger().text('Delete', 'del', !canDelete)` simply drops when
-`canDelete` is false. The same `.primary()`/`.success()`/`.danger()` work on a
-`ReplyKeyboard`.
+A `Button` value styles the same way — `Button.text('Delete', 'del').danger()` —
+so it works inside `.map()`/`.add()` too. The same
+`.primary()`/`.success()`/`.danger()` work on a `ReplyKeyboard`.
 
 ## Reply keyboards
 
@@ -262,8 +295,8 @@ discoverability, but the underlying markup is exactly what the API expects.
 
 Beyond plain `.text()` there's a method per Bot API button kind —
 `.requestContact()`, `.requestLocation()`, `.requestPoll()`, `.webApp()`,
-`.requestUsers()` and `.requestChat()` — each taking the same trailing `hidden`
-flag.
+`.requestUsers()` and `.requestChat()` — and the same `.split(n)`/`.row()`
+layout and `.if(cond)` conditionals as an inline keyboard.
 
 ## answer vs reply
 

--- a/lib/__target__/acceptance.spec.ts
+++ b/lib/__target__/acceptance.spec.ts
@@ -43,6 +43,7 @@ import {
   User,
 } from '..';
 import { RawUpdate } from '../events/raw-update.types';
+import { NOOP_CALLBACK_DATA } from '../keyboards/noop.constants';
 
 @Injectable()
 class CounterService {
@@ -137,8 +138,9 @@ describe('Phase 1 acceptance (booted app)', () => {
   });
 
   it('discovers @Router providers into the route table — no routers list', () => {
-    // 4 listeners across one discovered router (start, hears, refresh, echo).
-    expect(app.get(RouteTable).size).toBe(4);
+    // 4 listeners across one discovered router (start, hears, refresh, echo),
+    // plus the built-in no-op button route (Button.noop / .else).
+    expect(app.get(RouteTable).size).toBe(5);
   });
 
   it('@Command matches a bare /start (exact arity) and injects @Sender', async () => {
@@ -496,6 +498,18 @@ describe('@OnUnhandled (booted app)', () => {
     expect(
       warn.mock.calls.some((call) => String(call[0]).includes('no-such-route')),
     ).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('does not warn for a built-in no-op button — it is a handled route', async () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    await dispatcher.dispatch(callbackUpdate(4, NOOP_CALLBACK_DATA));
+    expect(
+      warn.mock.calls.some((call) =>
+        String(call[0]).includes(NOOP_CALLBACK_DATA),
+      ),
+    ).toBe(false);
+    expect(router.seen).toEqual([]); // matched the noop route, never @OnUnhandled
     warn.mockRestore();
   });
 });

--- a/lib/builtins/index.ts
+++ b/lib/builtins/index.ts
@@ -6,3 +6,4 @@ export * from './token-validation';
 export * from './auto-answer';
 export * from './reply-exception';
 export * from './unhandled';
+export * from './noop';

--- a/lib/builtins/noop/index.ts
+++ b/lib/builtins/noop/index.ts
@@ -1,0 +1,1 @@
+export * from './noop-button.handler';

--- a/lib/builtins/noop/noop-button.handler.ts
+++ b/lib/builtins/noop/noop-button.handler.ts
@@ -1,0 +1,19 @@
+import { Router } from '../../decorators/injectable/router.decorator';
+import { Action } from '../../decorators/listeners/action.decorator';
+import { NOOP_CALLBACK_DATA } from '../../keyboards/noop.constants';
+
+/**
+ * Handles a no-op (dead-end) button — `Button.noop()` and `.else('label')`. The
+ * press matches this route, so the auto-answer interceptor stops the spinner and
+ * the dead-button warning never fires (the route is handled, on purpose); the
+ * handler itself does nothing.
+ *
+ * Public and unprivileged — a user could have written the same `@Action`.
+ */
+@Router()
+export class NoopButtonHandler {
+  @Action(NOOP_CALLBACK_DATA)
+  noop(): void {
+    // A dead-end button does nothing but get answered.
+  }
+}

--- a/lib/keyboards/button.spec.ts
+++ b/lib/keyboards/button.spec.ts
@@ -69,6 +69,17 @@ describe('Button', () => {
       expect(Button.url('Docs', 'https://x.dev').callbackData).toBeUndefined();
     });
 
+    it('withText() returns a relabelled copy, keeping the rest', () => {
+      const base = Button.text('☐ Milk', 'toggle/:id', { id: 1 });
+      const checked = base.withText('☑ Milk');
+
+      expect(checked.toJSON()).toEqual({
+        text: '☑ Milk',
+        callback_data: 'toggle/1',
+      });
+      expect(base.label).toBe('☐ Milk');
+    });
+
     it('from() adopts a raw Telegram button as a value', () => {
       const raw = { text: 'Old', callback_data: 'toggle/3' };
       const button = Button.from(raw);

--- a/lib/keyboards/button.spec.ts
+++ b/lib/keyboards/button.spec.ts
@@ -1,4 +1,5 @@
 import { Button } from './button';
+import { NOOP_CALLBACK_DATA } from './noop.constants';
 
 describe('Button', () => {
   describe('constructors map to the Bot API button shape', () => {
@@ -89,6 +90,46 @@ describe('Button', () => {
       // A copy — mutating the returned JSON does not touch the source.
       button.toJSON().text = 'Changed';
       expect(raw.text).toBe('Old');
+    });
+  });
+
+  describe('conditional (.if / .else) and noop', () => {
+    const buy = Button.text('Buy', 'buy/:id', { id: 1 });
+
+    it('resolve() returns the button itself when .if(true)', () => {
+      const shown = buy.if(true);
+      expect(shown.resolve()).toBe(shown);
+      expect(shown.resolve()?.toJSON()).toEqual({
+        text: 'Buy',
+        callback_data: 'buy/1',
+      });
+    });
+
+    it('resolve() is null when .if(false) with no fallback', () => {
+      expect(buy.if(false).resolve()).toBeNull();
+    });
+
+    it('.else(label) yields a noop dead-end button when hidden', () => {
+      expect(buy.if(false).else('Sold out').resolve()?.toJSON()).toEqual({
+        text: 'Sold out',
+        callback_data: NOOP_CALLBACK_DATA,
+      });
+    });
+
+    it('.else(Button) yields the given fallback when hidden', () => {
+      const fallback = Button.url('Notify', 'https://x.dev');
+      expect(buy.if(false).else(fallback).resolve()).toBe(fallback);
+    });
+
+    it('an unhidden button ignores its .else()', () => {
+      expect(buy.if(true).else('Sold out').resolve()?.label).toBe('Buy');
+    });
+
+    it('Button.noop(label) is a dead-end button', () => {
+      expect(Button.noop('Nothing').toJSON()).toEqual({
+        text: 'Nothing',
+        callback_data: NOOP_CALLBACK_DATA,
+      });
     });
   });
 });

--- a/lib/keyboards/button.spec.ts
+++ b/lib/keyboards/button.spec.ts
@@ -1,0 +1,83 @@
+import { Button } from './button';
+
+describe('Button', () => {
+  describe('constructors map to the Bot API button shape', () => {
+    it('text — assembles a callback route with parameters', () => {
+      expect(
+        Button.text('Done', 'reminder/done/:id', { id: 42 }).toJSON(),
+      ).toEqual({ text: 'Done', callback_data: 'reminder/done/42' });
+    });
+
+    it('text — keeps a parameterless route as the literal callback_data', () => {
+      expect(Button.text('Refresh', 'refresh').toJSON()).toEqual({
+        text: 'Refresh',
+        callback_data: 'refresh',
+      });
+    });
+
+    it('url / webApp / loginUrl', () => {
+      expect(Button.url('Docs', 'https://x.dev').toJSON()).toEqual({
+        text: 'Docs',
+        url: 'https://x.dev',
+      });
+      expect(Button.webApp('Open', 'https://app.dev').toJSON()).toEqual({
+        text: 'Open',
+        web_app: { url: 'https://app.dev' },
+      });
+      expect(Button.loginUrl('Sign in', 'https://auth.dev').toJSON()).toEqual({
+        text: 'Sign in',
+        login_url: { url: 'https://auth.dev' },
+      });
+    });
+
+    it('switchInline / switchInlineCurrent / copyText / pay', () => {
+      expect(Button.switchInline('Share', 'hi').toJSON()).toEqual({
+        text: 'Share',
+        switch_inline_query: 'hi',
+      });
+      expect(Button.switchInlineCurrent('Here').toJSON()).toEqual({
+        text: 'Here',
+        switch_inline_query_current_chat: '',
+      });
+      expect(Button.copyText('Copy', 'ABC123').toJSON()).toEqual({
+        text: 'Copy',
+        copy_text: { text: 'ABC123' },
+      });
+      expect(Button.pay('Pay').toJSON()).toEqual({ text: 'Pay', pay: true });
+    });
+  });
+
+  describe('styling returns a copy, never mutating the original', () => {
+    it('stamps the style on the copy and leaves the source unstyled', () => {
+      const base = Button.text('Delete', 'del/:id', { id: 1 });
+      const danger = base.danger();
+
+      expect(danger.toJSON()).toEqual({
+        text: 'Delete',
+        callback_data: 'del/1',
+        style: 'danger',
+      });
+      expect(base.toJSON().style).toBeUndefined();
+    });
+  });
+
+  describe('introspection and adoption', () => {
+    it('exposes label and callbackData', () => {
+      const button = Button.text('Buy', 'buy/:id', { id: 7 });
+      expect(button.label).toBe('Buy');
+      expect(button.callbackData).toBe('buy/7');
+      expect(Button.url('Docs', 'https://x.dev').callbackData).toBeUndefined();
+    });
+
+    it('from() adopts a raw Telegram button as a value', () => {
+      const raw = { text: 'Old', callback_data: 'toggle/3' };
+      const button = Button.from(raw);
+
+      expect(button.label).toBe('Old');
+      expect(button.callbackData).toBe('toggle/3');
+      // A copy — mutating the returned JSON does not touch the source.
+      button.toJSON().text = 'Changed';
+      expect(raw.text).toBe('Old');
+    });
+  });
+});

--- a/lib/keyboards/button.ts
+++ b/lib/keyboards/button.ts
@@ -103,6 +103,11 @@ export class Button {
     return this.spec.callback_data;
   }
 
+  /** A copy with a different label, keeping everything else — for editing. */
+  withText(text: string): Button {
+    return new Button({ ...this.spec, text });
+  }
+
   /** A copy styled blue — the main / affirmative action. */
   primary(): Button {
     return this.withStyle(ButtonStyle.Primary);

--- a/lib/keyboards/button.ts
+++ b/lib/keyboards/button.ts
@@ -1,0 +1,129 @@
+import type {
+  RawInlineKeyboardButton,
+  RawLoginUrl,
+} from '../events/raw-update.types';
+import { CallbackRoutePattern } from '../callback-data';
+import { ButtonStyle, ButtonStyleValue } from './button-style';
+import { RouteParamValues } from './route-params.types';
+
+/**
+ * One inline keyboard button, as an immutable value.
+ *
+ * A button is a first-class thing you can create, style, map over a collection,
+ * and hand to a keyboard — so a dynamic keyboard reads as data flowing through
+ * operators rather than a hand-rolled loop:
+ *
+ * ```ts
+ * new InlineKeyboard()
+ *   .map(products, (p) => Button.text(p.name, 'buy/:id', { id: p.id }))
+ *   .columns(2)
+ *   .row(Button.url('Catalog', site), Button.switchInline('Share'));
+ * ```
+ *
+ * One static constructor per Bot API inline-button kind; the colour modifiers
+ * (`.primary()`/`.success()`/`.danger()`) return a styled copy, so a `Button` is
+ * never mutated in place.
+ *
+ * @see https://core.telegram.org/bots/api#inlinekeyboardbutton
+ */
+export class Button {
+  private constructor(private readonly spec: RawInlineKeyboardButton) {}
+
+  /**
+   * A callback button. Two forms, one mechanism: the framework assembles the
+   * route, checking and escaping the parameters —
+   * `Button.text('Done', 'reminder/done/:id', { id })` (the template-literal
+   * types require every `:param`) — or you interpolate it yourself —
+   * `` Button.text('Done', `reminder/done/${id}`) ``. Route the press with
+   * `@Action('reminder/done/:id')` + `@Param('id')`.
+   */
+  static text<T extends string>(
+    label: string,
+    route: T,
+    ...params: RouteParamValues<T>
+  ): Button {
+    const callbackData =
+      params.length > 0 ? CallbackRoutePattern.build(route, params[0]) : route;
+    return new Button({ text: label, callback_data: callbackData });
+  }
+
+  /** A URL button: pressing it opens the link. */
+  static url(label: string, url: string): Button {
+    return new Button({ text: label, url });
+  }
+
+  /** A Web App button: pressing it opens the Mini App at `url`. */
+  static webApp(label: string, url: string): Button {
+    return new Button({ text: label, web_app: { url } });
+  }
+
+  /** A login button: pressing it authorizes the user (Telegram Login). */
+  static loginUrl(label: string, url: string | RawLoginUrl): Button {
+    return new Button({
+      text: label,
+      login_url: typeof url === 'string' ? { url } : url,
+    });
+  }
+
+  /** Switch to inline mode in another chat, pre-filling `query`. */
+  static switchInline(label: string, query = ''): Button {
+    return new Button({ text: label, switch_inline_query: query });
+  }
+
+  /** Switch to inline mode in the current chat, pre-filling `query`. */
+  static switchInlineCurrent(label: string, query = ''): Button {
+    return new Button({
+      text: label,
+      switch_inline_query_current_chat: query,
+    });
+  }
+
+  /** Copy `text` to the clipboard when pressed. */
+  static copyText(label: string, text: string): Button {
+    return new Button({ text: label, copy_text: { text } });
+  }
+
+  /** A pay button — valid only as the first button of an invoice message. */
+  static pay(label: string): Button {
+    return new Button({ text: label, pay: true });
+  }
+
+  /** Adopt a raw Telegram button as a value — for editing an existing keyboard. */
+  static from(raw: RawInlineKeyboardButton): Button {
+    return new Button({ ...raw });
+  }
+
+  /** The button's visible label. */
+  get label(): string {
+    return this.spec.text;
+  }
+
+  /** The button's `callback_data`, when it is a callback button. */
+  get callbackData(): string | undefined {
+    return this.spec.callback_data;
+  }
+
+  /** A copy styled blue — the main / affirmative action. */
+  primary(): Button {
+    return this.withStyle(ButtonStyle.Primary);
+  }
+
+  /** A copy styled green — a positive, confirming action. */
+  success(): Button {
+    return this.withStyle(ButtonStyle.Success);
+  }
+
+  /** A copy styled red — a destructive or cancelling action. */
+  danger(): Button {
+    return this.withStyle(ButtonStyle.Danger);
+  }
+
+  /** A fresh copy of the raw button — what the keyboard serializes. */
+  toJSON(): RawInlineKeyboardButton {
+    return { ...this.spec };
+  }
+
+  private withStyle(style: ButtonStyleValue): Button {
+    return new Button({ ...this.spec, style });
+  }
+}

--- a/lib/keyboards/button.ts
+++ b/lib/keyboards/button.ts
@@ -4,6 +4,7 @@ import type {
 } from '../events/raw-update.types';
 import { CallbackRoutePattern } from '../callback-data';
 import { ButtonStyle, ButtonStyleValue } from './button-style';
+import { NOOP_CALLBACK_DATA } from './noop.constants';
 import { RouteParamValues } from './route-params.types';
 
 /**
@@ -15,19 +16,24 @@ import { RouteParamValues } from './route-params.types';
  *
  * ```ts
  * new InlineKeyboard()
- *   .map(products, (p) => Button.text(p.name, 'buy/:id', { id: p.id }))
- *   .columns(2)
- *   .row(Button.url('Catalog', site), Button.switchInline('Share'));
+ *   .map(products, (p) =>
+ *     Button.text(p.name, 'buy/:id', { id: p.id }).if(p.inStock).else('Sold out'),
+ *   )
+ *   .split(2);
  * ```
  *
  * One static constructor per Bot API inline-button kind; the colour modifiers
- * (`.primary()`/`.success()`/`.danger()`) return a styled copy, so a `Button` is
- * never mutated in place.
+ * (`.primary()`/`.success()`/`.danger()`) and `.if()`/`.else()` all return a new
+ * value, so a `Button` is never mutated in place.
  *
  * @see https://core.telegram.org/bots/api#inlinekeyboardbutton
  */
 export class Button {
-  private constructor(private readonly spec: RawInlineKeyboardButton) {}
+  private constructor(
+    private readonly spec: RawInlineKeyboardButton,
+    private readonly hidden = false,
+    private readonly fallback?: Button,
+  ) {}
 
   /**
    * A callback button. Two forms, one mechanism: the framework assembles the
@@ -89,6 +95,11 @@ export class Button {
     return new Button({ text: label, pay: true });
   }
 
+  /** A dead-end button — pressing it does nothing (a built-in just answers it). */
+  static noop(label: string): Button {
+    return new Button({ text: label, callback_data: NOOP_CALLBACK_DATA });
+  }
+
   /** Adopt a raw Telegram button as a value — for editing an existing keyboard. */
   static from(raw: RawInlineKeyboardButton): Button {
     return new Button({ ...raw });
@@ -104,9 +115,41 @@ export class Button {
     return this.spec.callback_data;
   }
 
+  /**
+   * Keep this button only when `condition` is true; otherwise it is dropped when
+   * added to a keyboard (or replaced by {@link else}). Lets `.map()` filter and
+   * conditional buttons read in one line.
+   */
+  if(condition: boolean): Button {
+    return new Button(this.spec, !condition, this.fallback);
+  }
+
+  /**
+   * The button to show in place of this one when {@link if} hid it — a label (a
+   * dead-end {@link noop}, e.g. `'Sold out'`) or a full replacement `Button`.
+   */
+  else(fallback: string | Button): Button {
+    return new Button(
+      this.spec,
+      this.hidden,
+      typeof fallback === 'string' ? Button.noop(fallback) : fallback,
+    );
+  }
+
+  /**
+   * Resolve the conditional for the keyboard: the button to render, or `null`
+   * when it was hidden with no fallback.
+   */
+  resolve(): Button | null {
+    if (!this.hidden) {
+      return this;
+    }
+    return this.fallback ?? null;
+  }
+
   /** A copy with a different label, keeping everything else — for editing. */
   withText(text: string): Button {
-    return new Button({ ...this.spec, text });
+    return new Button({ ...this.spec, text }, this.hidden, this.fallback);
   }
 
   /** A copy styled blue — the main / affirmative action. */
@@ -130,6 +173,6 @@ export class Button {
   }
 
   private withStyle(style: ButtonStyleValue): Button {
-    return new Button({ ...this.spec, style });
+    return new Button({ ...this.spec, style }, this.hidden, this.fallback);
   }
 }

--- a/lib/keyboards/button.ts
+++ b/lib/keyboards/button.ts
@@ -40,10 +40,11 @@ export class Button {
   static text<T extends string>(
     label: string,
     route: T,
-    ...params: RouteParamValues<T>
+    ...[params]: RouteParamValues<T>
   ): Button {
-    const callbackData =
-      params.length > 0 ? CallbackRoutePattern.build(route, params[0]) : route;
+    const callbackData = params
+      ? CallbackRoutePattern.build(route, params)
+      : route;
     return new Button({ text: label, callback_data: callbackData });
   }
 

--- a/lib/keyboards/index.ts
+++ b/lib/keyboards/index.ts
@@ -1,4 +1,5 @@
 export * from './button-style';
+export * from './button';
 export * from './keyboard-builder';
 export * from './inline-keyboard';
 export * from './reply-keyboard';

--- a/lib/keyboards/inline-keyboard.edit.spec.ts
+++ b/lib/keyboards/inline-keyboard.edit.spec.ts
@@ -1,0 +1,143 @@
+import { Button } from './button';
+import { InlineKeyboard } from './inline-keyboard';
+
+const markup = () => ({
+  inline_keyboard: [
+    [
+      { text: '☐ Milk', callback_data: 'toggle/1' },
+      { text: '☐ Bread', callback_data: 'toggle/2' },
+    ],
+    [
+      { text: 'Done', callback_data: 'done' },
+      { text: 'Cancel', callback_data: 'cancel' },
+    ],
+  ],
+});
+
+describe('InlineKeyboard — editing an existing keyboard', () => {
+  it('from() adopts a native markup and serializes it back', () => {
+    expect(InlineKeyboard.from(markup()).toJSON()).toEqual(markup());
+  });
+
+  it('from() copies — edits never reach back into the source markup', () => {
+    const source = markup();
+    InlineKeyboard.from(source).setText('toggle/1', '☑ Milk');
+    expect(source.inline_keyboard[0][0].text).toBe('☐ Milk');
+  });
+
+  it('from() deep-copies — a nested object is not shared with the source', () => {
+    const source = {
+      inline_keyboard: [[{ text: 'App', web_app: { url: 'a' } }]],
+    };
+    const adopted = InlineKeyboard.from(source).toJSON();
+
+    const button = adopted.inline_keyboard[0][0];
+    if (button.web_app) {
+      button.web_app.url = 'b';
+    }
+    expect(source.inline_keyboard[0][0].web_app.url).toBe('a');
+  });
+
+  describe('route addressing', () => {
+    it('a concrete route updates exactly one button', () => {
+      const result = InlineKeyboard.from(markup())
+        .setText('toggle/1', '☑ Milk')
+        .toJSON();
+
+      expect(result.inline_keyboard[0]).toEqual([
+        { text: '☑ Milk', callback_data: 'toggle/1' },
+        { text: '☐ Bread', callback_data: 'toggle/2' },
+      ]);
+    });
+
+    it('a templated route updates all that fit, with captured params', () => {
+      const result = InlineKeyboard.from(markup())
+        .update('toggle/:id', (button, { id }) =>
+          Button.from({ ...button.toJSON(), text: `#${id}` }),
+        )
+        .toJSON();
+
+      expect(result.inline_keyboard[0]).toEqual([
+        { text: '#1', callback_data: 'toggle/1' },
+        { text: '#2', callback_data: 'toggle/2' },
+      ]);
+    });
+  });
+
+  it('predicate addressing matches on any button field', () => {
+    const result = InlineKeyboard.from(markup())
+      .update(
+        (button) => button.label === 'Done',
+        (button) => Button.from({ ...button.toJSON(), text: 'Save' }),
+      )
+      .toJSON();
+
+    expect(result.inline_keyboard[1][0]).toEqual({
+      text: 'Save',
+      callback_data: 'done',
+    });
+  });
+
+  it('replaceText addresses by visible label', () => {
+    const result = InlineKeyboard.from(markup())
+      .replaceText('Cancel', 'Back')
+      .toJSON();
+
+    expect(result.inline_keyboard[1][1]).toEqual({
+      text: 'Back',
+      callback_data: 'cancel',
+    });
+  });
+
+  it('remove drops the matched button and collapses an emptied row', () => {
+    const result = InlineKeyboard.from(markup()).remove('toggle/:id').toJSON();
+
+    expect(result.inline_keyboard).toEqual([
+      [
+        { text: 'Done', callback_data: 'done' },
+        { text: 'Cancel', callback_data: 'cancel' },
+      ],
+    ]);
+  });
+
+  describe('position addressing', () => {
+    it('updateAt replaces the button at (row, col)', () => {
+      const result = InlineKeyboard.from(markup())
+        .updateAt(1, 0, (button) =>
+          Button.from({ ...button.toJSON(), text: 'OK' }),
+        )
+        .toJSON();
+
+      expect(result.inline_keyboard[1][0].text).toBe('OK');
+    });
+
+    it('removeAt drops the button at (row, col)', () => {
+      const result = InlineKeyboard.from(markup()).removeAt(0, 0).toJSON();
+
+      expect(result.inline_keyboard[0]).toEqual([
+        { text: '☐ Bread', callback_data: 'toggle/2' },
+      ]);
+    });
+  });
+
+  it('row() adds a footer to an adopted keyboard', () => {
+    const result = InlineKeyboard.from(markup())
+      .row(Button.text('Next', 'page/:n', { n: 2 }))
+      .toJSON();
+
+    expect(result.inline_keyboard[2]).toEqual([
+      { text: 'Next', callback_data: 'page/2' },
+    ]);
+  });
+
+  it('the toggle scenario reads cleanly end to end', () => {
+    // A user tapped Milk; flip just that checkbox and send the markup back.
+    const id = 1;
+    const result = InlineKeyboard.from(markup())
+      .setText(`toggle/${id}`, '☑ Milk')
+      .toJSON();
+
+    expect(result.inline_keyboard[0][0].text).toBe('☑ Milk');
+    expect(result.inline_keyboard[0][1].text).toBe('☐ Bread');
+  });
+});

--- a/lib/keyboards/inline-keyboard.sugar.spec.ts
+++ b/lib/keyboards/inline-keyboard.sugar.spec.ts
@@ -1,9 +1,10 @@
 import { Button } from './button';
 import { InlineKeyboard } from './inline-keyboard';
+import { NOOP_CALLBACK_DATA } from './noop.constants';
 
 describe('InlineKeyboard — Button sugar', () => {
   describe('.map', () => {
-    it('turns a collection into buttons, laid into a grid by .columns', () => {
+    it('turns a collection into buttons, laid into a grid by .split', () => {
       const items = [
         { id: 1, name: 'Milk' },
         { id: 2, name: 'Bread' },
@@ -11,8 +12,8 @@ describe('InlineKeyboard — Button sugar', () => {
       ];
 
       const markup = new InlineKeyboard()
-        .columns(2)
         .map(items, (i) => Button.text(i.name, 'pick/:id', { id: i.id }))
+        .split(2)
         .toJSON();
 
       expect(markup).toEqual({
@@ -26,7 +27,22 @@ describe('InlineKeyboard — Button sugar', () => {
       });
     });
 
-    it('drops an item when the callback returns a falsy value', () => {
+    it('.map().split() equals .text().text().split()', () => {
+      const viaMap = new InlineKeyboard()
+        .map([1, 2, 3], (n) => Button.text(`#${n}`, `n/${n}`))
+        .split(2)
+        .toJSON();
+      const viaText = new InlineKeyboard()
+        .text('#1', 'n/1')
+        .text('#2', 'n/2')
+        .text('#3', 'n/3')
+        .split(2)
+        .toJSON();
+
+      expect(viaMap).toEqual(viaText);
+    });
+
+    it('drops an item when the callback returns falsy', () => {
       const markup = new InlineKeyboard()
         .map([1, 2, 3], (n) =>
           n === 2 ? null : Button.text(`#${n}`, `n/${n}`),
@@ -39,14 +55,40 @@ describe('InlineKeyboard — Button sugar', () => {
       ]);
     });
 
-    it('passes the index to the callback', () => {
+    it('filters per item with Button.if(...)', () => {
+      const products = [
+        { id: 1, name: 'A', inStock: true },
+        { id: 2, name: 'B', inStock: false },
+      ];
+
       const markup = new InlineKeyboard()
-        .map(['a', 'b'], (label, index) => Button.text(label, `at/${index}`))
+        .map(products, (p) =>
+          Button.text(p.name, 'buy/:id', { id: p.id }).if(p.inStock),
+        )
         .toJSON();
 
       expect(markup.inline_keyboard[0]).toEqual([
-        { text: 'a', callback_data: 'at/0' },
-        { text: 'b', callback_data: 'at/1' },
+        { text: 'A', callback_data: 'buy/1' },
+      ]);
+    });
+
+    it('replaces a hidden button with its .else() fallback', () => {
+      const markup = new InlineKeyboard()
+        .map(
+          [
+            { id: 1, name: 'A', inStock: true },
+            { id: 2, name: 'B', inStock: false },
+          ],
+          (p) =>
+            Button.text(p.name, 'buy/:id', { id: p.id })
+              .if(p.inStock)
+              .else('Sold out'),
+        )
+        .toJSON();
+
+      expect(markup.inline_keyboard[0]).toEqual([
+        { text: 'A', callback_data: 'buy/1' },
+        { text: 'Sold out', callback_data: NOOP_CALLBACK_DATA },
       ]);
     });
   });
@@ -65,49 +107,39 @@ describe('InlineKeyboard — Button sugar', () => {
       ]);
     });
 
-    it('keeps a styled Button value over a pending colour modifier', () => {
+    it('keeps a styled Button value', () => {
       const markup = new InlineKeyboard()
-        .primary() // pending modifier...
-        .add(Button.text('Delete', 'del').danger()) // ...but the value is explicit
+        .add(Button.text('Delete', 'del').danger())
         .toJSON();
 
       expect(markup.inline_keyboard[0][0].style).toBe('danger');
     });
   });
 
-  describe('.row(...buttons)', () => {
-    it('lays exactly those buttons into one row, ignoring .columns', () => {
+  describe('.group', () => {
+    it('appends an irregular block of rows', () => {
       const markup = new InlineKeyboard()
-        .columns(1)
-        .row(
-          Button.text('A', 'a'),
-          Button.text('B', 'b'),
-          Button.text('C', 'c'),
+        .text('Home', 'home')
+        .row()
+        .group((kb) =>
+          kb
+            .text('a', 'a')
+            .text('b', 'b')
+            .text('c', 'c')
+            .row()
+            .text('d', 'd')
+            .row(),
         )
         .toJSON();
 
       expect(markup.inline_keyboard).toEqual([
+        [{ text: 'Home', callback_data: 'home' }],
         [
-          { text: 'A', callback_data: 'a' },
-          { text: 'B', callback_data: 'b' },
-          { text: 'C', callback_data: 'c' },
+          { text: 'a', callback_data: 'a' },
+          { text: 'b', callback_data: 'b' },
+          { text: 'c', callback_data: 'c' },
         ],
-      ]);
-    });
-
-    it('reads as map body + an explicit footer row', () => {
-      const markup = new InlineKeyboard()
-        .columns(2)
-        .map([1, 2], (n) => Button.text(`#${n}`, `n/${n}`))
-        .row(Button.url('Help', 'https://x.dev'))
-        .toJSON();
-
-      expect(markup.inline_keyboard).toEqual([
-        [
-          { text: '#1', callback_data: 'n/1' },
-          { text: '#2', callback_data: 'n/2' },
-        ],
-        [{ text: 'Help', url: 'https://x.dev' }],
+        [{ text: 'd', callback_data: 'd' }],
       ]);
     });
   });
@@ -127,14 +159,6 @@ describe('InlineKeyboard — Button sugar', () => {
         { text: 'Here', switch_inline_query_current_chat: '' },
         { text: 'Copy', copy_text: { text: 'CODE' } },
       ]);
-    });
-
-    it('honours the trailing hidden flag', () => {
-      const markup = new InlineKeyboard()
-        .webApp('App', 'https://app.dev', true)
-        .toJSON();
-
-      expect(markup.inline_keyboard).toEqual([]);
     });
   });
 });

--- a/lib/keyboards/inline-keyboard.sugar.spec.ts
+++ b/lib/keyboards/inline-keyboard.sugar.spec.ts
@@ -1,0 +1,140 @@
+import { Button } from './button';
+import { InlineKeyboard } from './inline-keyboard';
+
+describe('InlineKeyboard — Button sugar', () => {
+  describe('.map', () => {
+    it('turns a collection into buttons, laid into a grid by .columns', () => {
+      const items = [
+        { id: 1, name: 'Milk' },
+        { id: 2, name: 'Bread' },
+        { id: 3, name: 'Eggs' },
+      ];
+
+      const markup = new InlineKeyboard()
+        .columns(2)
+        .map(items, (i) => Button.text(i.name, 'pick/:id', { id: i.id }))
+        .toJSON();
+
+      expect(markup).toEqual({
+        inline_keyboard: [
+          [
+            { text: 'Milk', callback_data: 'pick/1' },
+            { text: 'Bread', callback_data: 'pick/2' },
+          ],
+          [{ text: 'Eggs', callback_data: 'pick/3' }],
+        ],
+      });
+    });
+
+    it('drops an item when the callback returns a falsy value', () => {
+      const markup = new InlineKeyboard()
+        .map([1, 2, 3], (n) =>
+          n === 2 ? null : Button.text(`#${n}`, `n/${n}`),
+        )
+        .toJSON();
+
+      expect(markup.inline_keyboard[0]).toEqual([
+        { text: '#1', callback_data: 'n/1' },
+        { text: '#3', callback_data: 'n/3' },
+      ]);
+    });
+
+    it('passes the index to the callback', () => {
+      const markup = new InlineKeyboard()
+        .map(['a', 'b'], (label, index) => Button.text(label, `at/${index}`))
+        .toJSON();
+
+      expect(markup.inline_keyboard[0]).toEqual([
+        { text: 'a', callback_data: 'at/0' },
+        { text: 'b', callback_data: 'at/1' },
+      ]);
+    });
+  });
+
+  describe('.add — universal Button inlet', () => {
+    it('adds any Bot API button kind through Button values', () => {
+      const markup = new InlineKeyboard()
+        .add(Button.webApp('Open', 'https://app.dev'))
+        .add(Button.pay('Pay'), Button.switchInline('Share', 'hi'))
+        .toJSON();
+
+      expect(markup.inline_keyboard[0]).toEqual([
+        { text: 'Open', web_app: { url: 'https://app.dev' } },
+        { text: 'Pay', pay: true },
+        { text: 'Share', switch_inline_query: 'hi' },
+      ]);
+    });
+
+    it('keeps a styled Button value over a pending colour modifier', () => {
+      const markup = new InlineKeyboard()
+        .primary() // pending modifier...
+        .add(Button.text('Delete', 'del').danger()) // ...but the value is explicit
+        .toJSON();
+
+      expect(markup.inline_keyboard[0][0].style).toBe('danger');
+    });
+  });
+
+  describe('.row(...buttons)', () => {
+    it('lays exactly those buttons into one row, ignoring .columns', () => {
+      const markup = new InlineKeyboard()
+        .columns(1)
+        .row(
+          Button.text('A', 'a'),
+          Button.text('B', 'b'),
+          Button.text('C', 'c'),
+        )
+        .toJSON();
+
+      expect(markup.inline_keyboard).toEqual([
+        [
+          { text: 'A', callback_data: 'a' },
+          { text: 'B', callback_data: 'b' },
+          { text: 'C', callback_data: 'c' },
+        ],
+      ]);
+    });
+
+    it('reads as map body + an explicit footer row', () => {
+      const markup = new InlineKeyboard()
+        .columns(2)
+        .map([1, 2], (n) => Button.text(`#${n}`, `n/${n}`))
+        .row(Button.url('Help', 'https://x.dev'))
+        .toJSON();
+
+      expect(markup.inline_keyboard).toEqual([
+        [
+          { text: '#1', callback_data: 'n/1' },
+          { text: '#2', callback_data: 'n/2' },
+        ],
+        [{ text: 'Help', url: 'https://x.dev' }],
+      ]);
+    });
+  });
+
+  describe('full-type fluent shortcuts', () => {
+    it('webApp / switchInline / switchInlineCurrent / copyText', () => {
+      const markup = new InlineKeyboard()
+        .webApp('App', 'https://app.dev')
+        .switchInline('Share', 'q')
+        .switchInlineCurrent('Here')
+        .copyText('Copy', 'CODE')
+        .toJSON();
+
+      expect(markup.inline_keyboard[0]).toEqual([
+        { text: 'App', web_app: { url: 'https://app.dev' } },
+        { text: 'Share', switch_inline_query: 'q' },
+        { text: 'Here', switch_inline_query_current_chat: '' },
+        { text: 'Copy', copy_text: { text: 'CODE' } },
+      ]);
+    });
+
+    it('honours the trailing hidden flag', () => {
+      const markup = new InlineKeyboard()
+        .webApp('App', 'https://app.dev', true)
+        .toJSON();
+
+      expect(markup.inline_keyboard).toEqual([]);
+    });
+  });
+});

--- a/lib/keyboards/inline-keyboard.ts
+++ b/lib/keyboards/inline-keyboard.ts
@@ -8,6 +8,13 @@ import { KeyboardBuilder } from './keyboard-builder';
 import { RouteParamArgs } from './route-params.types';
 
 /**
+ * How an edit addresses a button: a **route** (`'toggle/3'` for one, `'toggle/:id'`
+ * for all that fit) or a predicate over the `Button`. Position addressing uses
+ * `.updateAt()`/`.removeAt()` instead.
+ */
+type ButtonMatcher = string | ((button: Button) => boolean);
+
+/**
  * Fluent builder for an inline keyboard (buttons attached under a message).
  *
  * Three ways in, one model — a button is a value ({@link Button}):
@@ -140,8 +147,108 @@ export class InlineKeyboard extends KeyboardBuilder<RawInlineKeyboardButton> {
     return this;
   }
 
+  /**
+   * Adopt an existing keyboard (a native `reply_markup` from an incoming update)
+   * for editing — change a button, drop one, append a row, then send it back
+   * with `editReplyMarkup`. The source markup is left untouched.
+   *
+   * ```ts
+   * InlineKeyboard.from(query.message.reply_markup)
+   *   .setText(`toggle/${id}`, `☑ ${label}`)
+   *   .row(Button.text('Done', 'done'));
+   * ```
+   */
+  static from(markup: RawInlineKeyboardMarkup): InlineKeyboard {
+    const keyboard = new InlineKeyboard();
+    keyboard.adopt(markup.inline_keyboard);
+    return keyboard;
+  }
+
+  /**
+   * Replace every button the matcher selects. The matcher is a **route** (a
+   * concrete `'toggle/3'` hits one button; a template `'toggle/:id'` hits all
+   * that fit, with the captured params passed to `patch`) or a predicate over
+   * the `Button`. Addresses a button without caring where it sits in the grid.
+   */
+  update(
+    matcher: ButtonMatcher,
+    patch: (button: Button, params: Record<string, string>) => Button,
+  ): this {
+    const test = InlineKeyboard.matcher(matcher);
+    for (const row of this.rows) {
+      for (let index = 0; index < row.length; index++) {
+        const params = test(row[index]);
+        if (params !== null) {
+          row[index] = patch(Button.from(row[index]), params).toJSON();
+        }
+      }
+    }
+    return this;
+  }
+
+  /** Change the label of every button the matcher selects (a common `update`). */
+  setText(matcher: ButtonMatcher, text: string): this {
+    return this.update(matcher, (button) => button.withText(text));
+  }
+
+  /**
+   * Relabel a button found by its current text. A convenience for the i18n-free
+   * quick case; prefer a route (`setText('toggle/3', …)`) when you have one —
+   * labels drift and are localised, a route is the stable key.
+   */
+  replaceText(oldText: string, newText: string): this {
+    return this.setText((button) => button.label === oldText, newText);
+  }
+
+  /** Remove every button the matcher selects, collapsing rows left empty. */
+  remove(matcher: ButtonMatcher): this {
+    const test = InlineKeyboard.matcher(matcher);
+    for (let row = 0; row < this.rows.length; row++) {
+      this.rows[row] = this.rows[row].filter((button) => test(button) === null);
+    }
+    this.compactRows();
+    return this;
+  }
+
+  /** Replace the button at a grid position (row, column) — position addressing. */
+  updateAt(row: number, col: number, patch: (button: Button) => Button): this {
+    const target = this.rows[row]?.[col];
+    if (target !== undefined) {
+      this.rows[row][col] = patch(Button.from(target)).toJSON();
+    }
+    return this;
+  }
+
+  /** Remove the button at a grid position, collapsing a row left empty. */
+  removeAt(row: number, col: number): this {
+    if (this.rows[row]?.[col] !== undefined) {
+      this.rows[row].splice(col, 1);
+      this.compactRows();
+    }
+    return this;
+  }
+
   toJSON(): RawInlineKeyboardMarkup {
     return { inline_keyboard: this.filledRows };
+  }
+
+  /**
+   * Compile a matcher into a test: given a raw button, return the captured route
+   * params when it matches, or `null`. A route string compiles to a pattern (so
+   * a concrete route matches one button, a templated route matches many); a
+   * predicate matches with no captured params.
+   */
+  private static matcher(
+    matcher: ButtonMatcher,
+  ): (button: RawInlineKeyboardButton) => Record<string, string> | null {
+    if (typeof matcher === 'function') {
+      return (button) => (matcher(Button.from(button)) ? {} : null);
+    }
+    const pattern = CallbackRoutePattern.compile(matcher);
+    return (button) =>
+      button.callback_data === undefined
+        ? null
+        : pattern.match(button.callback_data);
   }
 
   /** Push one `Button` through the column flow, honoring a trailing `hidden` flag. */

--- a/lib/keyboards/inline-keyboard.ts
+++ b/lib/keyboards/inline-keyboard.ts
@@ -1,33 +1,38 @@
+import type {
+  RawInlineKeyboardButton,
+  RawInlineKeyboardMarkup,
+} from '../events/raw-update.types';
 import { CallbackRoutePattern } from '../callback-data';
-import { ButtonStyleValue } from './button-style';
+import { Button } from './button';
 import { KeyboardBuilder } from './keyboard-builder';
 import { RouteParamArgs } from './route-params.types';
-
-interface InlineButton {
-  text: string;
-  callback_data?: string;
-  url?: string;
-  style?: ButtonStyleValue;
-}
 
 /**
  * Fluent builder for an inline keyboard (buttons attached under a message).
  *
- * Buttons go into the current row; `.row()` starts a new one, or `.columns(n)`
- * auto-wraps into a grid. A trailing `hidden` flag drops the button (handy for
- * conditional buttons: `.text('Admin', 'admin', !isAdmin)`). A colour modifier
+ * Three ways in, one model — a button is a value ({@link Button}):
+ *
+ * - **fluent shortcuts** for the everyday kinds — `.text()`, `.url()`,
+ *   `.webApp()`, `.switchInline()` — each with a trailing `hidden` flag for
+ *   conditional buttons (`.text('Admin', 'admin', !isAdmin)`);
+ * - **`.add(...buttons)`** takes `Button` values directly — the universal inlet,
+ *   so every Bot API kind is reachable (`.add(Button.pay('Pay'))`);
+ * - **`.map(items, fn)`** turns a collection into buttons, so a dynamic keyboard
+ *   reads as data, not a loop.
+ *
+ * `.row()` starts a new row (`.row(...buttons)` lays an explicit one),
+ * `.columns(n)` auto-wraps into a grid, and a colour modifier
  * (`.primary()`/`.success()`/`.danger()`) styles the next button. Pass the
- * instance as `reply_markup` — `JSON.stringify` calls `toJSON()`, serializing to
- * the Telegram `{ inline_keyboard }` shape.
+ * instance as `reply_markup` — `JSON.stringify` calls `toJSON()`.
  *
  * ```ts
  * new InlineKeyboard()
+ *   .map(products, (p) => Button.text(p.name, 'buy/:id', { id: p.id }))
  *   .columns(2)
- *   .primary().text('Buy', 'buy')
- *   .text('Info', 'info');
+ *   .row(Button.url('Catalog', site));
  * ```
  */
-export class InlineKeyboard extends KeyboardBuilder<InlineButton> {
+export class InlineKeyboard extends KeyboardBuilder<RawInlineKeyboardButton> {
   /**
    * A callback button. Two forms, one mechanism — a safe default and a terse
    * shortcut, like `SendMessage` vs `message.answer`:
@@ -64,11 +69,84 @@ export class InlineKeyboard extends KeyboardBuilder<InlineButton> {
 
   /** A URL button: pressing it opens the link. */
   url(label: string, url: string, hidden = false): this {
-    this.push({ text: label, url }, hidden);
+    return this.add1(Button.url(label, url), hidden);
+  }
+
+  /** A Web App button: pressing it opens the Mini App at `url`. */
+  webApp(label: string, url: string, hidden = false): this {
+    return this.add1(Button.webApp(label, url), hidden);
+  }
+
+  /** Switch to inline mode in another chat, pre-filling `query`. */
+  switchInline(label: string, query = '', hidden = false): this {
+    return this.add1(Button.switchInline(label, query), hidden);
+  }
+
+  /** Switch to inline mode in the current chat, pre-filling `query`. */
+  switchInlineCurrent(label: string, query = '', hidden = false): this {
+    return this.add1(Button.switchInlineCurrent(label, query), hidden);
+  }
+
+  /** Copy `text` to the clipboard when pressed. */
+  copyText(label: string, text: string, hidden = false): this {
+    return this.add1(Button.copyText(label, text), hidden);
+  }
+
+  /**
+   * Add `Button` values into the current flow (honoring `.columns()`). The
+   * universal inlet — every Bot API button kind is reachable as a `Button`,
+   * including the special ones (`.add(Button.pay('Pay'))`).
+   */
+  add(...buttons: Button[]): this {
+    for (const button of buttons) {
+      this.push(button.toJSON());
+    }
     return this;
   }
 
-  toJSON(): { inline_keyboard: InlineButton[][] } {
+  /**
+   * Turn a collection into buttons. `fn` returns a `Button` for each item, or a
+   * falsy value to drop it — so conditional buttons need no separate filter. The
+   * buttons feed the current flow, so `.columns(n)` lays them into a grid.
+   *
+   * ```ts
+   * .columns(2).map(items, (i) => Button.text(i.label, 'pick/:id', { id: i.id }))
+   * ```
+   */
+  map<T>(
+    items: readonly T[],
+    fn: (item: T, index: number) => Button | null | undefined | false,
+  ): this {
+    items.forEach((item, index) => {
+      const button = fn(item, index);
+      if (button) {
+        this.push(button.toJSON());
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Start a new row. With buttons, lay exactly those into it (ignoring
+   * `.columns()`) — an explicit row; with none, just open a fresh row for the
+   * buttons that follow.
+   */
+  row(...buttons: Button[]): this {
+    if (buttons.length === 0) {
+      return super.row();
+    }
+    this.pushRow(buttons.map((button) => button.toJSON()));
+    super.row();
+    return this;
+  }
+
+  toJSON(): RawInlineKeyboardMarkup {
     return { inline_keyboard: this.filledRows };
+  }
+
+  /** Push one `Button` through the column flow, honoring a trailing `hidden` flag. */
+  private add1(button: Button, hidden: boolean): this {
+    this.push(button.toJSON(), hidden);
+    return this;
   }
 }

--- a/lib/keyboards/inline-keyboard.ts
+++ b/lib/keyboards/inline-keyboard.ts
@@ -5,7 +5,7 @@ import type {
 import { CallbackRoutePattern } from '../callback-data';
 import { Button } from './button';
 import { KeyboardBuilder } from './keyboard-builder';
-import { RouteParamArgs } from './route-params.types';
+import { RouteParamValues } from './route-params.types';
 
 /**
  * How an edit addresses a button: a **route** (`'toggle/3'` for one, `'toggle/:id'`
@@ -17,25 +17,24 @@ type ButtonMatcher = string | ((button: Button) => boolean);
 /**
  * Fluent builder for an inline keyboard (buttons attached under a message).
  *
- * Three ways in, one model — a button is a value ({@link Button}):
+ * A button is a value ({@link Button}); the keyboard accumulates buttons and a
+ * layout method arranges them:
  *
  * - **fluent shortcuts** for the everyday kinds — `.text()`, `.url()`,
- *   `.webApp()`, `.switchInline()` — each with a trailing `hidden` flag for
- *   conditional buttons (`.text('Admin', 'admin', !isAdmin)`);
+ *   `.webApp()`, `.switchInline()`, …;
  * - **`.add(...buttons)`** takes `Button` values directly — the universal inlet,
  *   so every Bot API kind is reachable (`.add(Button.pay('Pay'))`);
- * - **`.map(items, fn)`** turns a collection into buttons, so a dynamic keyboard
- *   reads as data, not a loop.
+ * - **`.map(items, fn)`** turns a collection into buttons.
  *
- * `.row()` starts a new row (`.row(...buttons)` lays an explicit one),
- * `.columns(n)` auto-wraps into a grid, and a colour modifier
- * (`.primary()`/`.success()`/`.danger()`) styles the next button. Pass the
- * instance as `reply_markup` — `JSON.stringify` calls `toJSON()`.
+ * `.split(n)` lays the accumulated buttons into rows of `n`, `.spread()` is one
+ * per row, `.row(...buttons)` commits a single row, and `.if(cond)` keeps the
+ * last button/row/section. Pass the instance as `reply_markup` — `JSON.stringify`
+ * calls `toJSON()`.
  *
  * ```ts
  * new InlineKeyboard()
  *   .map(products, (p) => Button.text(p.name, 'buy/:id', { id: p.id }))
- *   .columns(2)
+ *   .split(2)
  *   .row(Button.url('Catalog', site));
  * ```
  */
@@ -51,100 +50,88 @@ export class InlineKeyboard extends KeyboardBuilder<RawInlineKeyboardButton> {
    *   — terse, no parameter check, no escaping (fine for the numeric-id case).
    *
    * Pressing the button sends the resulting `callback_data` back; route it with
-   * `@Action('reminder/done/:id')` + `@Param('id')`.
+   * `@Action('reminder/done/:id')` + `@Param('id')`. Hide it with a trailing
+   * `.if(cond)`.
    */
   text<T extends string>(
     label: string,
     route: T,
-    ...rest: RouteParamArgs<T>
-  ): this;
-  text(
-    label: string,
-    route: string,
-    paramsOrHidden?: Record<string, string | number> | boolean,
-    hidden = false,
+    ...[params]: RouteParamValues<T>
   ): this {
-    const assembled = typeof paramsOrHidden === 'object';
-    const callbackData = assembled
-      ? CallbackRoutePattern.build(route, paramsOrHidden)
+    const callbackData = params
+      ? CallbackRoutePattern.build(route, params)
       : route;
-    const isHidden =
-      typeof paramsOrHidden === 'boolean' ? paramsOrHidden : hidden;
-    this.push({ text: label, callback_data: callbackData }, isHidden);
+    this.pushButton({ text: label, callback_data: callbackData });
     return this;
   }
 
   /** A URL button: pressing it opens the link. */
-  url(label: string, url: string, hidden = false): this {
-    return this.add1(Button.url(label, url), hidden);
+  url(label: string, url: string): this {
+    this.pushButton(Button.url(label, url).toJSON());
+    return this;
   }
 
   /** A Web App button: pressing it opens the Mini App at `url`. */
-  webApp(label: string, url: string, hidden = false): this {
-    return this.add1(Button.webApp(label, url), hidden);
+  webApp(label: string, url: string): this {
+    this.pushButton(Button.webApp(label, url).toJSON());
+    return this;
   }
 
   /** Switch to inline mode in another chat, pre-filling `query`. */
-  switchInline(label: string, query = '', hidden = false): this {
-    return this.add1(Button.switchInline(label, query), hidden);
+  switchInline(label: string, query = ''): this {
+    this.pushButton(Button.switchInline(label, query).toJSON());
+    return this;
   }
 
   /** Switch to inline mode in the current chat, pre-filling `query`. */
-  switchInlineCurrent(label: string, query = '', hidden = false): this {
-    return this.add1(Button.switchInlineCurrent(label, query), hidden);
+  switchInlineCurrent(label: string, query = ''): this {
+    this.pushButton(Button.switchInlineCurrent(label, query).toJSON());
+    return this;
   }
 
   /** Copy `text` to the clipboard when pressed. */
-  copyText(label: string, text: string, hidden = false): this {
-    return this.add1(Button.copyText(label, text), hidden);
-  }
-
-  /**
-   * Add `Button` values into the current flow (honoring `.columns()`). The
-   * universal inlet — every Bot API button kind is reachable as a `Button`,
-   * including the special ones (`.add(Button.pay('Pay'))`).
-   */
-  add(...buttons: Button[]): this {
-    for (const button of buttons) {
-      this.push(button.toJSON());
-    }
+  copyText(label: string, text: string): this {
+    this.pushButton(Button.copyText(label, text).toJSON());
     return this;
   }
 
   /**
-   * Turn a collection into buttons. `fn` returns a `Button` for each item, or a
-   * falsy value to drop it — so conditional buttons need no separate filter. The
-   * buttons feed the current flow, so `.columns(n)` lays them into a grid.
+   * Add `Button` values into the current row. The universal inlet — every Bot API
+   * button kind is reachable as a `Button`, including the special ones
+   * (`.add(Button.pay('Pay'))`). A button hidden by `.if(false)` is dropped (or
+   * replaced by its `.else(...)`).
+   */
+  add(...buttons: Button[]): this {
+    this.pushButtons(InlineKeyboard.resolve(buttons));
+    return this;
+  }
+
+  /**
+   * Turn a collection into buttons. `fn` returns a `Button` for each item (or a
+   * falsy value to drop it); a `Button.if(false)` is dropped too, so conditional
+   * buttons read in one line.
    *
    * ```ts
-   * .columns(2).map(items, (i) => Button.text(i.label, 'pick/:id', { id: i.id }))
+   * .map(items, (i) => Button.text(i.label, 'pick/:id', { id: i.id }).if(i.ok)).split(2)
    * ```
    */
   map<T>(
     items: readonly T[],
     fn: (item: T, index: number) => Button | null | undefined | false,
   ): this {
-    items.forEach((item, index) => {
-      const button = fn(item, index);
-      if (button) {
-        this.push(button.toJSON());
-      }
-    });
+    const buttons = items
+      .map((item, index) => fn(item, index))
+      .filter((button): button is Button => Boolean(button));
+    this.pushButtons(InlineKeyboard.resolve(buttons));
     return this;
   }
 
-  /**
-   * Start a new row. With buttons, lay exactly those into it (ignoring
-   * `.columns()`) — an explicit row; with none, just open a fresh row for the
-   * buttons that follow.
-   */
+  /** Commit the accumulated buttons (plus any given here) as a single row. */
   row(...buttons: Button[]): this {
-    if (buttons.length === 0) {
-      return super.row();
+    if (buttons.length > 0) {
+      this.add(...buttons);
     }
-    this.pushRow(buttons.map((button) => button.toJSON()));
-    super.row();
-    return this;
+    return super.row();
   }
 
   /**
@@ -232,6 +219,14 @@ export class InlineKeyboard extends KeyboardBuilder<RawInlineKeyboardButton> {
     return { inline_keyboard: this.filledRows };
   }
 
+  /** Resolve each button's `.if()`/`.else()` into the raw buttons to render. */
+  private static resolve(buttons: Button[]): RawInlineKeyboardButton[] {
+    return buttons
+      .map((button) => button.resolve())
+      .filter((button): button is Button => button !== null)
+      .map((button) => button.toJSON());
+  }
+
   /**
    * Compile a matcher into a test: given a raw button, return the captured route
    * params when it matches, or `null`. A route string compiles to a pattern (so
@@ -249,11 +244,5 @@ export class InlineKeyboard extends KeyboardBuilder<RawInlineKeyboardButton> {
       button.callback_data === undefined
         ? null
         : pattern.match(button.callback_data);
-  }
-
-  /** Push one `Button` through the column flow, honoring a trailing `hidden` flag. */
-  private add1(button: Button, hidden: boolean): this {
-    this.push(button.toJSON(), hidden);
-    return this;
   }
 }

--- a/lib/keyboards/keyboard-builder.ts
+++ b/lib/keyboards/keyboard-builder.ts
@@ -67,7 +67,9 @@ export abstract class KeyboardBuilder<TButton extends StyleableButton> {
     if (hidden) {
       return;
     }
-    if (style !== undefined) {
+    // A button that brought its own style (a styled `Button` value) keeps it —
+    // the pending modifier only fills an unstyled button.
+    if (style !== undefined && button.style === undefined) {
       button.style = style;
     }
     const current = this.rows[this.rows.length - 1];
@@ -76,6 +78,11 @@ export abstract class KeyboardBuilder<TButton extends StyleableButton> {
     } else {
       current.push(button);
     }
+  }
+
+  /** Append a complete row of buttons, ignoring the column limit (an explicit row). */
+  protected pushRow(buttons: TButton[]): void {
+    this.rows.push(buttons);
   }
 
   /** Rows with at least one button (drops the seed row and all-hidden rows). */

--- a/lib/keyboards/keyboard-builder.ts
+++ b/lib/keyboards/keyboard-builder.ts
@@ -85,6 +85,29 @@ export abstract class KeyboardBuilder<TButton extends StyleableButton> {
     this.rows.push(buttons);
   }
 
+  /**
+   * Replace the builder's rows with a deep copy of `rows` — how `.from(markup)`
+   * adopts an existing keyboard for editing. The deep copy (including nested
+   * `web_app`/`copy_text`/… objects) is what lets edits never reach back into the
+   * source markup; an empty input keeps one open row.
+   */
+  protected adopt(rows: TButton[][]): void {
+    this.rows.length = 0;
+    for (const row of rows) {
+      this.rows.push(row.map((button) => structuredClone(button)));
+    }
+    if (this.rows.length === 0) {
+      this.rows.push([]);
+    }
+  }
+
+  /** Drop emptied rows, keeping at least one open row for further edits. */
+  protected compactRows(): void {
+    const kept = this.rows.filter((row) => row.length > 0);
+    this.rows.length = 0;
+    this.rows.push(...(kept.length > 0 ? kept : [[]]));
+  }
+
   /** Rows with at least one button (drops the seed row and all-hidden rows). */
   protected get filledRows(): TButton[][] {
     return this.rows.filter((row) => row.length > 0);

--- a/lib/keyboards/keyboard-builder.ts
+++ b/lib/keyboards/keyboard-builder.ts
@@ -1,103 +1,125 @@
 import { NestgramConfigError } from '../exceptions/config.exception';
-import { ButtonStyle, StyleableButton } from './button-style';
+import { ButtonStyle, ButtonStyleValue, StyleableButton } from './button-style';
+
+/** What `.if()` targets: the buttons added since `from` in `pending`, or rows added since `from`. */
+type LastUnit =
+  | { readonly kind: 'pending'; readonly from: number }
+  | { readonly kind: 'rows'; readonly from: number };
 
 /**
- * Shared row layout for the keyboard builders.
+ * Shared layout engine for the keyboard builders.
  *
- * Buttons go into the current row; `.row()` forces a new one. `.columns(n)`
- * switches on auto-wrap: once a row holds `n` buttons, the next button starts a
- * fresh row — so you get an even grid without sprinkling `.row()` calls. Hidden
- * buttons are simply never added, so they don't take a grid slot and an
- * all-hidden row collapses away on serialize.
- *
- * A colour modifier (`.primary()`/`.success()`/`.danger()`) styles the NEXT
- * button only — it sets a pending style the next button consumes, so
- * `.danger().text('Delete', 'del')` reads as "this one button is red".
+ * Buttons accumulate in `pending` (the current, unfinished row); a layout method
+ * commits them into rows. `.split(n)` cuts the accumulated buttons into rows of
+ * `n` (`.map(...).split(2)` reads the same as `.text().text().split(2)`),
+ * `.spread()` is one per row, and `.row()` commits them as a single row. `.group`
+ * builds a block of rows in a sub-builder. Every unit — a button, a row, a split
+ * section or a group — can be kept conditionally with a trailing `.if(cond)`. A
+ * colour modifier (`.primary()`/`.success()`/`.danger()`) styles the button just
+ * added (postfix), so `.text('Delete', 'del').danger()` reads "this one is red".
  */
 export abstract class KeyboardBuilder<TButton extends StyleableButton> {
-  protected readonly rows: TButton[][] = [[]];
-  private columnLimit?: number;
-  private pendingStyle?: ButtonStyle;
+  protected readonly rows: TButton[][] = [];
+  protected readonly pending: TButton[] = [];
+  private lastUnit?: LastUnit;
 
-  /**
-   * Auto-wrap into rows of `count` (a grid). The limit applies to every
-   * subsequent button, including any already in the current (in-progress) row —
-   * call it right after `.row()` (or first) for a clean grid. `count` must be ≥ 1.
-   */
-  columns(count: number): this {
+  /** Lay the accumulated buttons into rows of `count` columns. `count` must be ≥ 1. */
+  split(count: number): this {
     if (count < 1) {
-      throw new NestgramConfigError('columns(count) requires count >= 1');
+      throw new NestgramConfigError('split(count) requires count >= 1');
     }
-    this.columnLimit = count;
+    this.flushInto(count);
     return this;
   }
 
-  /** Force a new row; subsequent buttons go into it. */
+  /** One accumulated button per row — a vertical list (`split(1)`). */
+  spread(): this {
+    return this.split(1);
+  }
+
+  /** Commit the accumulated buttons as a single row. */
   row(): this {
-    this.rows.push([]);
-    return this;
-  }
-
-  /** Style the next button blue — the main / affirmative action. */
-  primary(): this {
-    this.pendingStyle = ButtonStyle.Primary;
-    return this;
-  }
-
-  /** Style the next button green — a positive, confirming action. */
-  success(): this {
-    this.pendingStyle = ButtonStyle.Success;
-    return this;
-  }
-
-  /** Style the next button red — a destructive or cancelling action. */
-  danger(): this {
-    this.pendingStyle = ButtonStyle.Danger;
+    this.flushInto(Math.max(this.pending.length, 1));
     return this;
   }
 
   /**
-   * Append a button, honoring the current column limit. A pending colour is
-   * consumed here whether or not the button is shown — so a hidden button takes
-   * its intended style down with it instead of leaking it onto the next one.
+   * Keep the last unit only when `condition` is true. The unit is whatever was
+   * just produced: a button (after `.text()`/`.add()`/`.map()`), a row (after
+   * `.row()`), a split section (after `.split()`) or a group (after `.group()`).
    */
-  protected push(button: TButton, hidden = false): void {
-    const style = this.pendingStyle;
-    this.pendingStyle = undefined;
-    if (hidden) {
-      return;
+  if(condition: boolean): this {
+    // A unit is consumed by `.if()` either way, so a following `.if()` can't
+    // re-target it (`.text(...).if(true).if(false)` keeps the button).
+    const unit = this.lastUnit;
+    this.lastUnit = undefined;
+    if (condition || unit === undefined) {
+      return this;
     }
-    // A button that brought its own style (a styled `Button` value) keeps it —
-    // the pending modifier only fills an unstyled button.
-    if (style !== undefined && button.style === undefined) {
-      button.style = style;
-    }
-    const current = this.rows[this.rows.length - 1];
-    if (this.columnLimit !== undefined && current.length >= this.columnLimit) {
-      this.rows.push([button]);
+    if (unit.kind === 'pending') {
+      this.pending.length = unit.from;
     } else {
-      current.push(button);
+      this.rows.length = unit.from;
     }
+    return this;
   }
 
-  /** Append a complete row of buttons, ignoring the column limit (an explicit row). */
-  protected pushRow(buttons: TButton[]): void {
-    this.rows.push(buttons);
+  /**
+   * Build a block of rows in a sub-builder, then append it — for an irregular
+   * section (rows of different widths). Pair with `.if()` to show it
+   * conditionally: `.group((kb) => kb.row(...).text(...)).if(isAdmin)`.
+   */
+  group(build: (keyboard: this) => void): this {
+    const SubBuilder = this.constructor as new () => this;
+    const sub = new SubBuilder();
+    build(sub);
+    const from = this.rows.length;
+    for (const row of sub.drainRows()) {
+      this.rows.push(row);
+    }
+    this.lastUnit = { kind: 'rows', from };
+    return this;
+  }
+
+  /** Style the just-added button blue — the main / affirmative action. */
+  primary(): this {
+    return this.style(ButtonStyle.Primary);
+  }
+
+  /** Style the just-added button green — a positive, confirming action. */
+  success(): this {
+    return this.style(ButtonStyle.Success);
+  }
+
+  /** Style the just-added button red — a destructive or cancelling action. */
+  danger(): this {
+    return this.style(ButtonStyle.Danger);
+  }
+
+  /** Accumulate one button into the current row (a single `.if()`-able unit). */
+  protected pushButton(button: TButton): void {
+    const from = this.pending.length;
+    this.pending.push(button);
+    this.lastUnit = { kind: 'pending', from };
+  }
+
+  /** Accumulate a batch of buttons as one `.if()`-able unit (`.add()`/`.map()`). */
+  protected pushButtons(buttons: TButton[]): void {
+    const from = this.pending.length;
+    this.pending.push(...buttons);
+    this.lastUnit = { kind: 'pending', from };
   }
 
   /**
    * Replace the builder's rows with a deep copy of `rows` — how `.from(markup)`
    * adopts an existing keyboard for editing. The deep copy (including nested
    * `web_app`/`copy_text`/… objects) is what lets edits never reach back into the
-   * source markup; an empty input keeps one open row.
+   * source markup.
    */
   protected adopt(rows: TButton[][]): void {
     this.rows.length = 0;
     for (const row of rows) {
       this.rows.push(row.map((button) => structuredClone(button)));
-    }
-    if (this.rows.length === 0) {
-      this.rows.push([]);
     }
   }
 
@@ -108,8 +130,39 @@ export abstract class KeyboardBuilder<TButton extends StyleableButton> {
     this.rows.push(...(kept.length > 0 ? kept : [[]]));
   }
 
-  /** Rows with at least one button (drops the seed row and all-hidden rows). */
+  /** The final rows — committed rows plus any still-accumulated buttons as a last row. */
   protected get filledRows(): TButton[][] {
-    return this.rows.filter((row) => row.length > 0);
+    const all =
+      this.pending.length > 0 ? [...this.rows, this.pending] : this.rows;
+    // Copy each row so a serialized snapshot never aliases the builder's arrays.
+    return all.filter((row) => row.length > 0).map((row) => [...row]);
+  }
+
+  private style(style: ButtonStyleValue): this {
+    const last = this.pending[this.pending.length - 1];
+    if (last !== undefined) {
+      last.style = style;
+    }
+    return this;
+  }
+
+  private flushInto(perRow: number): void {
+    if (this.pending.length === 0) {
+      this.lastUnit = undefined;
+      return;
+    }
+    const batch = this.pending.splice(0);
+    const from = this.rows.length;
+    for (let index = 0; index < batch.length; index += perRow) {
+      this.rows.push(batch.slice(index, index + perRow));
+    }
+    this.lastUnit = { kind: 'rows', from };
+  }
+
+  private drainRows(): TButton[][] {
+    if (this.pending.length > 0) {
+      this.flushInto(this.pending.length);
+    }
+    return this.rows;
   }
 }

--- a/lib/keyboards/keyboards.spec.ts
+++ b/lib/keyboards/keyboards.spec.ts
@@ -1,3 +1,4 @@
+import { Button } from './button';
 import { InlineKeyboard } from './inline-keyboard';
 import { ReplyKeyboard } from './reply-keyboard';
 import { RemoveKeyboard } from './remove-keyboard';
@@ -10,8 +11,8 @@ function serialize(markup: unknown): unknown {
   return JSON.parse(JSON.stringify(markup));
 }
 
-describe('InlineKeyboard', () => {
-  it('lays buttons into rows', () => {
+describe('InlineKeyboard layout', () => {
+  it('commits accumulated buttons as a row with .row()', () => {
     const kb = new InlineKeyboard()
       .text('Buy', 'buy:1')
       .text('Info', 'info:1')
@@ -29,8 +30,8 @@ describe('InlineKeyboard', () => {
     });
   });
 
-  it('drops empty trailing rows', () => {
-    const kb = new InlineKeyboard().text('Only', 'x').row();
+  it('flushes leftover accumulated buttons as a final row', () => {
+    const kb = new InlineKeyboard().text('Only', 'x');
     expect(serialize(kb)).toEqual({
       inline_keyboard: [[{ text: 'Only', callback_data: 'x' }]],
     });
@@ -44,18 +45,15 @@ describe('InlineKeyboard', () => {
     );
   });
 
-  it('columns(n) auto-wraps buttons into a grid (uneven last row)', () => {
+  it('.split(n) cuts the accumulated buttons into rows of n (uneven last row)', () => {
     const kb = new InlineKeyboard()
-      .columns(2)
       .text('a', '1')
       .text('b', '2')
       .text('c', '3')
       .text('d', '4')
-      .text('e', '5');
+      .text('e', '5')
+      .split(2);
 
-    expect(
-      (serialize(kb) as { inline_keyboard: unknown[][] }).inline_keyboard,
-    ).toHaveLength(3);
     expect(serialize(kb)).toEqual({
       inline_keyboard: [
         [
@@ -71,33 +69,25 @@ describe('InlineKeyboard', () => {
     });
   });
 
-  it('columns coexists with an explicit row()', () => {
-    const kb = new InlineKeyboard()
-      .text('top', 't')
-      .row()
-      .columns(2)
-      .text('a', '1')
-      .text('b', '2')
-      .text('c', '3');
-
+  it('.spread() lays one button per row', () => {
+    const kb = new InlineKeyboard().text('a', '1').text('b', '2').spread();
     expect(serialize(kb)).toEqual({
       inline_keyboard: [
-        [{ text: 'top', callback_data: 't' }],
-        [
-          { text: 'a', callback_data: '1' },
-          { text: 'b', callback_data: '2' },
-        ],
-        [{ text: 'c', callback_data: '3' }],
+        [{ text: 'a', callback_data: '1' }],
+        [{ text: 'b', callback_data: '2' }],
       ],
     });
   });
 
-  it('columns set mid-row counts buttons already in that row', () => {
+  it('each .split() is its own section — different widths compose', () => {
     const kb = new InlineKeyboard()
       .text('a', '1')
-      .columns(2)
       .text('b', '2')
-      .text('c', '3');
+      .split(2)
+      .text('c', '3')
+      .text('d', '4')
+      .text('e', '5')
+      .split(3);
 
     expect(serialize(kb)).toEqual({
       inline_keyboard: [
@@ -105,39 +95,45 @@ describe('InlineKeyboard', () => {
           { text: 'a', callback_data: '1' },
           { text: 'b', callback_data: '2' },
         ],
-        [{ text: 'c', callback_data: '3' }],
+        [
+          { text: 'c', callback_data: '3' },
+          { text: 'd', callback_data: '4' },
+          { text: 'e', callback_data: '5' },
+        ],
       ],
     });
   });
 
-  it('columns(0) is rejected', () => {
-    expect(() => new InlineKeyboard().columns(0)).toThrow(NestgramConfigError);
+  it('.split(0) is rejected', () => {
+    expect(() => new InlineKeyboard().text('a', '1').split(0)).toThrow(
+      NestgramConfigError,
+    );
   });
 
-  it('hidden buttons are excluded (and an all-hidden row collapses)', () => {
-    const kb = new InlineKeyboard()
-      .text('keep', 'k')
-      .text('drop', 'd', true)
-      .row()
-      .text('gone', 'g', 1 > 0) // any boolean expression
-      .row()
-      .text('last', 'l');
-
+  it('.row(...buttons) commits an explicit row', () => {
+    const kb = new InlineKeyboard().row(
+      Button.text('A', 'a'),
+      Button.text('B', 'b'),
+    );
     expect(serialize(kb)).toEqual({
       inline_keyboard: [
-        [{ text: 'keep', callback_data: 'k' }],
-        [{ text: 'last', callback_data: 'l' }],
+        [
+          { text: 'A', callback_data: 'a' },
+          { text: 'B', callback_data: 'b' },
+        ],
       ],
     });
   });
+});
 
-  it('a colour modifier styles the next button only (one-shot)', () => {
+describe('InlineKeyboard colours (postfix)', () => {
+  it('styles the just-added button', () => {
     const kb = new InlineKeyboard()
-      .primary()
       .text('Buy', 'buy')
+      .primary()
       .text('Info', 'info')
-      .danger()
-      .url('Cancel', 'https://x');
+      .url('Cancel', 'https://x')
+      .danger();
 
     expect(serialize(kb)).toEqual({
       inline_keyboard: [
@@ -152,12 +148,12 @@ describe('InlineKeyboard', () => {
 
   it('exposes all three styles', () => {
     const kb = new InlineKeyboard()
-      .primary()
       .text('p', '1')
-      .success()
+      .primary()
       .text('s', '2')
-      .danger()
-      .text('d', '3');
+      .success()
+      .text('d', '3')
+      .danger();
 
     expect(serialize(kb)).toEqual({
       inline_keyboard: [
@@ -169,36 +165,94 @@ describe('InlineKeyboard', () => {
       ],
     });
   });
+});
 
-  it('a hidden styled button does not leak its style onto the next', () => {
+describe('InlineKeyboard .if() conditionals', () => {
+  it('drops the last button when false, keeps it when true', () => {
     const kb = new InlineKeyboard()
-      .danger()
-      .text('drop', 'd', true)
-      .text('keep', 'k');
-
-    expect(serialize(kb)).toEqual({
-      inline_keyboard: [[{ text: 'keep', callback_data: 'k' }]],
-    });
-  });
-
-  it('a colour modifier attaches to the next button across a row break', () => {
-    const kb = new InlineKeyboard().primary().row().text('X', 'x');
-    expect(serialize(kb)).toEqual({
-      inline_keyboard: [[{ text: 'X', callback_data: 'x', style: 'primary' }]],
-    });
-  });
-
-  it('a styled button keeps its style when columns wraps it to a new row', () => {
-    const kb = new InlineKeyboard()
-      .columns(1)
-      .text('a', '1')
-      .danger()
-      .text('b', '2');
+      .text('keep', 'k')
+      .text('admin', 'a')
+      .if(false)
+      .text('also', 'b')
+      .if(true);
 
     expect(serialize(kb)).toEqual({
       inline_keyboard: [
-        [{ text: 'a', callback_data: '1' }],
-        [{ text: 'b', callback_data: '2', style: 'danger' }],
+        [
+          { text: 'keep', callback_data: 'k' },
+          { text: 'also', callback_data: 'b' },
+        ],
+      ],
+    });
+  });
+
+  it('consumes the unit, so a passing .if() is not re-targeted by a later .if()', () => {
+    const kb = new InlineKeyboard()
+      .text('a', 'a')
+      .if(true)
+      .if(false) // targets nothing — the button above was already kept
+      .split(1);
+
+    expect(serialize(kb)).toEqual({
+      inline_keyboard: [[{ text: 'a', callback_data: 'a' }]],
+    });
+  });
+
+  it('drops a whole row when false', () => {
+    const kb = new InlineKeyboard()
+      .text('top', 't')
+      .row()
+      .row(Button.text('secret', 's'))
+      .if(false);
+
+    expect(serialize(kb)).toEqual({
+      inline_keyboard: [[{ text: 'top', callback_data: 't' }]],
+    });
+  });
+
+  it('drops a whole split section when false', () => {
+    const kb = new InlineKeyboard()
+      .text('a', '1')
+      .text('b', '2')
+      .split(2)
+      .text('x', 'x')
+      .text('y', 'y')
+      .split(2)
+      .if(false);
+
+    expect(serialize(kb)).toEqual({
+      inline_keyboard: [
+        [
+          { text: 'a', callback_data: '1' },
+          { text: 'b', callback_data: '2' },
+        ],
+      ],
+    });
+  });
+
+  it('drops a whole group when false (irregular admin section)', () => {
+    const build = (isAdmin: boolean) =>
+      new InlineKeyboard()
+        .text('Home', 'home')
+        .row()
+        .group((kb) =>
+          kb
+            .row(Button.text('a', 'a'), Button.text('b', 'b'))
+            .row(Button.text('c', 'c')),
+        )
+        .if(isAdmin);
+
+    expect(serialize(build(false))).toEqual({
+      inline_keyboard: [[{ text: 'Home', callback_data: 'home' }]],
+    });
+    expect(serialize(build(true))).toEqual({
+      inline_keyboard: [
+        [{ text: 'Home', callback_data: 'home' }],
+        [
+          { text: 'a', callback_data: 'a' },
+          { text: 'b', callback_data: 'b' },
+        ],
+        [{ text: 'c', callback_data: 'c' }],
       ],
     });
   });
@@ -222,13 +276,8 @@ describe('ReplyKeyboard', () => {
     });
   });
 
-  it('supports columns grid and hidden buttons', () => {
-    const kb = new ReplyKeyboard()
-      .columns(2)
-      .text('a')
-      .text('skip', true)
-      .text('b')
-      .text('c');
+  it('.split(n) lays a grid', () => {
+    const kb = new ReplyKeyboard().text('a').text('b').text('c').split(2);
 
     expect(serialize(kb)).toEqual({
       keyboard: [[{ text: 'a' }, { text: 'b' }], [{ text: 'c' }]],
@@ -240,8 +289,8 @@ describe('ReplyKeyboard', () => {
     expect(serialize(kb)).toEqual({ keyboard: [[{ text: 'Hi' }]] });
   });
 
-  it('styles a button via a colour modifier', () => {
-    const kb = new ReplyKeyboard().success().text('Confirm').text('Plain');
+  it('styles a button via a postfix colour modifier', () => {
+    const kb = new ReplyKeyboard().text('Confirm').success().text('Plain');
     expect(serialize(kb)).toEqual({
       keyboard: [[{ text: 'Confirm', style: 'success' }, { text: 'Plain' }]],
     });
@@ -256,7 +305,8 @@ describe('ReplyKeyboard', () => {
       .webApp('App', 'https://app.dev')
       .row()
       .requestUsers('Pick', { request_id: 1, max_quantity: 3 })
-      .requestChat('Chat', { request_id: 2, chat_is_channel: false });
+      .requestChat('Chat', { request_id: 2, chat_is_channel: false })
+      .row();
 
     expect(serialize(kb)).toEqual({
       keyboard: [
@@ -318,11 +368,6 @@ describe('InlineKeyboard callback routes (.text assemble form)', () => {
     });
   });
 
-  it('honours the hidden flag after the parameters', () => {
-    const kb = new InlineKeyboard().text('Done', 'done/:id', { id: 1 }, true);
-    expect(serialize(kb)).toEqual({ inline_keyboard: [] });
-  });
-
   it('passes an interpolated string through unchanged (terse form)', () => {
     const id = 7;
     const kb = new InlineKeyboard().text('Done', `reminder/done/${id}`);
@@ -331,14 +376,8 @@ describe('InlineKeyboard callback routes (.text assemble form)', () => {
     });
   });
 
-  it('keeps the raw two-argument form (no params)', () => {
-    const kb = new InlineKeyboard().text('Buy', 'buy:1', true);
-    expect(serialize(kb)).toEqual({ inline_keyboard: [] });
-  });
-
   it('requires every parameter at the type level', () => {
-    // Compile-time assertions only — declared, never invoked (the calls would
-    // throw at runtime; here we just assert the type checker rejects them).
+    // Compile-time assertions only — declared, never invoked.
     const assertTypes = () => {
       // @ts-expect-error — missing the `id` parameter the template declares.
       new InlineKeyboard().text('Done', 'reminder/done/:id');

--- a/lib/keyboards/keyboards.spec.ts
+++ b/lib/keyboards/keyboards.spec.ts
@@ -246,6 +246,46 @@ describe('ReplyKeyboard', () => {
       keyboard: [[{ text: 'Confirm', style: 'success' }, { text: 'Plain' }]],
     });
   });
+
+  it('covers the request/web_app button kinds', () => {
+    const kb = new ReplyKeyboard()
+      .requestContact('Phone')
+      .requestLocation('Where')
+      .row()
+      .requestPoll('Quiz', 'quiz')
+      .webApp('App', 'https://app.dev')
+      .row()
+      .requestUsers('Pick', { request_id: 1, max_quantity: 3 })
+      .requestChat('Chat', { request_id: 2, chat_is_channel: false });
+
+    expect(serialize(kb)).toEqual({
+      keyboard: [
+        [
+          { text: 'Phone', request_contact: true },
+          { text: 'Where', request_location: true },
+        ],
+        [
+          { text: 'Quiz', request_poll: { type: 'quiz' } },
+          { text: 'App', web_app: { url: 'https://app.dev' } },
+        ],
+        [
+          { text: 'Pick', request_users: { request_id: 1, max_quantity: 3 } },
+          {
+            text: 'Chat',
+            request_chat: { request_id: 2, chat_is_channel: false },
+          },
+        ],
+      ],
+    });
+  });
+
+  it('persistent maps to is_persistent', () => {
+    const kb = new ReplyKeyboard().text('Hi').persistent();
+    expect(serialize(kb)).toEqual({
+      keyboard: [[{ text: 'Hi' }]],
+      is_persistent: true,
+    });
+  });
 });
 
 describe('InlineKeyboard callback routes (.text assemble form)', () => {

--- a/lib/keyboards/noop.constants.ts
+++ b/lib/keyboards/noop.constants.ts
@@ -1,0 +1,7 @@
+/**
+ * The reserved `callback_data` of a no-op (dead-end) button — `Button.noop()` and
+ * `.else('label')`. A built-in handler matches it and just answers the query, so
+ * the press stops the button's spinner without doing anything and the dead-button
+ * warning never fires (the route is handled, on purpose).
+ */
+export const NOOP_CALLBACK_DATA = '__nestgram_noop__';

--- a/lib/keyboards/reply-keyboard.ts
+++ b/lib/keyboards/reply-keyboard.ts
@@ -12,16 +12,16 @@ type PollType = 'quiz' | 'regular';
 /**
  * Fluent builder for a custom reply keyboard (buttons under the input field).
  *
- * Buttons go into the current row; `.row()` starts a new one, or `.columns(n)`
- * auto-wraps into a grid. Beyond plain `.text()` buttons there is a method per
- * Bot API kind — `.requestContact()`, `.requestLocation()`, `.requestPoll()`,
- * `.webApp()`, `.requestUsers()`, `.requestChat()` — each with a trailing
- * `hidden` flag. The flags (`.resize()`/`.oneTime()`/`.persistent()`/
+ * Buttons accumulate in the current row; `.split(n)` lays them into rows of `n`,
+ * `.spread()` is one per row, and `.row()` commits a single row. Beyond plain
+ * `.text()` there is a method per Bot API kind — `.requestContact()`,
+ * `.requestLocation()`, `.requestPoll()`, `.webApp()`, `.requestUsers()`,
+ * `.requestChat()`. The flags (`.resize()`/`.oneTime()`/`.persistent()`/
  * `.selective()`/`.placeholder()`) map to the Telegram markup options. Pass the
  * instance as `reply_markup` — `toJSON()` serializes to `{ keyboard, ... }`.
  *
  * ```ts
- * new ReplyKeyboard().text('My orders').row().text('Help').resize().oneTime();
+ * new ReplyKeyboard().text('My orders').text('Help').row().resize().oneTime();
  * ```
  */
 export class ReplyKeyboard extends KeyboardBuilder<RawKeyboardButton> {
@@ -32,46 +32,45 @@ export class ReplyKeyboard extends KeyboardBuilder<RawKeyboardButton> {
   private placeholderText?: string;
 
   /** A plain text button (sends its label as a message when pressed). */
-  text(label: string, hidden = false): this {
-    return this.add1({ text: label }, hidden);
+  text(label: string): this {
+    this.pushButton({ text: label });
+    return this;
   }
 
   /** Ask the user to share their phone number. */
-  requestContact(label: string, hidden = false): this {
-    return this.add1({ text: label, request_contact: true }, hidden);
+  requestContact(label: string): this {
+    this.pushButton({ text: label, request_contact: true });
+    return this;
   }
 
   /** Ask the user to share their location. */
-  requestLocation(label: string, hidden = false): this {
-    return this.add1({ text: label, request_location: true }, hidden);
+  requestLocation(label: string): this {
+    this.pushButton({ text: label, request_location: true });
+    return this;
   }
 
   /** Ask the user to create a poll — `type` restricts it to a quiz or regular poll. */
-  requestPoll(label: string, type?: PollType, hidden = false): this {
-    return this.add1({ text: label, request_poll: { type } }, hidden);
+  requestPoll(label: string, type?: PollType): this {
+    this.pushButton({ text: label, request_poll: { type } });
+    return this;
   }
 
   /** A Web App button: pressing it opens the Mini App at `url`. */
-  webApp(label: string, url: string, hidden = false): this {
-    return this.add1({ text: label, web_app: { url } }, hidden);
+  webApp(label: string, url: string): this {
+    this.pushButton({ text: label, web_app: { url } });
+    return this;
   }
 
   /** Ask the user to pick users (the request is identified by `request_id`). */
-  requestUsers(
-    label: string,
-    request: RawKeyboardButtonRequestUsers,
-    hidden = false,
-  ): this {
-    return this.add1({ text: label, request_users: request }, hidden);
+  requestUsers(label: string, request: RawKeyboardButtonRequestUsers): this {
+    this.pushButton({ text: label, request_users: request });
+    return this;
   }
 
   /** Ask the user to pick a chat (the request is identified by `request_id`). */
-  requestChat(
-    label: string,
-    request: RawKeyboardButtonRequestChat,
-    hidden = false,
-  ): this {
-    return this.add1({ text: label, request_chat: request }, hidden);
+  requestChat(label: string, request: RawKeyboardButtonRequestChat): this {
+    this.pushButton({ text: label, request_chat: request });
+    return this;
   }
 
   /** Fit the keyboard to its buttons (`resize_keyboard`). */
@@ -115,11 +114,5 @@ export class ReplyKeyboard extends KeyboardBuilder<RawKeyboardButton> {
         input_field_placeholder: this.placeholderText,
       }),
     };
-  }
-
-  /** Push one button through the column flow, honoring a trailing `hidden` flag. */
-  private add1(button: RawKeyboardButton, hidden: boolean): this {
-    this.push(button, hidden);
-    return this;
   }
 }

--- a/lib/keyboards/reply-keyboard.ts
+++ b/lib/keyboards/reply-keyboard.ts
@@ -1,44 +1,77 @@
-import { ButtonStyleValue } from './button-style';
+import type {
+  RawKeyboardButton,
+  RawKeyboardButtonRequestChat,
+  RawKeyboardButtonRequestUsers,
+  RawReplyKeyboardMarkup,
+} from '../events/raw-update.types';
 import { KeyboardBuilder } from './keyboard-builder';
 
-interface ReplyButton {
-  text: string;
-  request_contact?: boolean;
-  request_location?: boolean;
-  style?: ButtonStyleValue;
-}
-
-interface ReplyKeyboardMarkup {
-  keyboard: ReplyButton[][];
-  resize_keyboard?: boolean;
-  one_time_keyboard?: boolean;
-  input_field_placeholder?: string;
-  selective?: boolean;
-}
+/** The poll kind a `requestPoll` button asks for (any when omitted). */
+type PollType = 'quiz' | 'regular';
 
 /**
  * Fluent builder for a custom reply keyboard (buttons under the input field).
  *
  * Buttons go into the current row; `.row()` starts a new one, or `.columns(n)`
- * auto-wraps into a grid. A trailing `hidden` flag drops the button; a colour
- * modifier (`.primary()`/`.success()`/`.danger()`) styles the next button. Pass
- * the instance as `reply_markup` — `toJSON()` serializes to the Telegram
- * `{ keyboard, ... }` shape.
+ * auto-wraps into a grid. Beyond plain `.text()` buttons there is a method per
+ * Bot API kind — `.requestContact()`, `.requestLocation()`, `.requestPoll()`,
+ * `.webApp()`, `.requestUsers()`, `.requestChat()` — each with a trailing
+ * `hidden` flag. The flags (`.resize()`/`.oneTime()`/`.persistent()`/
+ * `.selective()`/`.placeholder()`) map to the Telegram markup options. Pass the
+ * instance as `reply_markup` — `toJSON()` serializes to `{ keyboard, ... }`.
  *
  * ```ts
- * new ReplyKeyboard().text('My orders').row().text('Help').resize().oneTime()
+ * new ReplyKeyboard().text('My orders').row().text('Help').resize().oneTime();
  * ```
  */
-export class ReplyKeyboard extends KeyboardBuilder<ReplyButton> {
+export class ReplyKeyboard extends KeyboardBuilder<RawKeyboardButton> {
   private resizeKeyboard = false;
   private oneTimeKeyboard = false;
+  private persistentKeyboard = false;
   private selectiveFlag = false;
   private placeholderText?: string;
 
   /** A plain text button (sends its label as a message when pressed). */
   text(label: string, hidden = false): this {
-    this.push({ text: label }, hidden);
-    return this;
+    return this.add1({ text: label }, hidden);
+  }
+
+  /** Ask the user to share their phone number. */
+  requestContact(label: string, hidden = false): this {
+    return this.add1({ text: label, request_contact: true }, hidden);
+  }
+
+  /** Ask the user to share their location. */
+  requestLocation(label: string, hidden = false): this {
+    return this.add1({ text: label, request_location: true }, hidden);
+  }
+
+  /** Ask the user to create a poll — `type` restricts it to a quiz or regular poll. */
+  requestPoll(label: string, type?: PollType, hidden = false): this {
+    return this.add1({ text: label, request_poll: { type } }, hidden);
+  }
+
+  /** A Web App button: pressing it opens the Mini App at `url`. */
+  webApp(label: string, url: string, hidden = false): this {
+    return this.add1({ text: label, web_app: { url } }, hidden);
+  }
+
+  /** Ask the user to pick users (the request is identified by `request_id`). */
+  requestUsers(
+    label: string,
+    request: RawKeyboardButtonRequestUsers,
+    hidden = false,
+  ): this {
+    return this.add1({ text: label, request_users: request }, hidden);
+  }
+
+  /** Ask the user to pick a chat (the request is identified by `request_id`). */
+  requestChat(
+    label: string,
+    request: RawKeyboardButtonRequestChat,
+    hidden = false,
+  ): this {
+    return this.add1({ text: label, request_chat: request }, hidden);
   }
 
   /** Fit the keyboard to its buttons (`resize_keyboard`). */
@@ -50,6 +83,12 @@ export class ReplyKeyboard extends KeyboardBuilder<ReplyButton> {
   /** Hide the keyboard after one use (`one_time_keyboard`). */
   oneTime(): this {
     this.oneTimeKeyboard = true;
+    return this;
+  }
+
+  /** Keep the keyboard open and always visible (`is_persistent`). */
+  persistent(): this {
+    this.persistentKeyboard = true;
     return this;
   }
 
@@ -65,15 +104,22 @@ export class ReplyKeyboard extends KeyboardBuilder<ReplyButton> {
     return this;
   }
 
-  toJSON(): ReplyKeyboardMarkup {
+  toJSON(): RawReplyKeyboardMarkup {
     return {
       keyboard: this.filledRows,
       ...(this.resizeKeyboard && { resize_keyboard: true }),
       ...(this.oneTimeKeyboard && { one_time_keyboard: true }),
+      ...(this.persistentKeyboard && { is_persistent: true }),
       ...(this.selectiveFlag && { selective: true }),
       ...(this.placeholderText && {
         input_field_placeholder: this.placeholderText,
       }),
     };
+  }
+
+  /** Push one button through the column flow, honoring a trailing `hidden` flag. */
+  private add1(button: RawKeyboardButton, hidden: boolean): this {
+    this.push(button, hidden);
+    return this;
   }
 }

--- a/lib/keyboards/route-params.types.ts
+++ b/lib/keyboards/route-params.types.ts
@@ -35,3 +35,17 @@ export type RouteParamArgs<Template extends string> = [
 ] extends [never]
   ? [hidden?: boolean]
   : [params: RouteParams<Template>, hidden?: boolean];
+
+/**
+ * The trailing arguments a `Button.text()` value takes, conditioned on the route
+ * template — like {@link RouteParamArgs} but without the `hidden` flag (a value
+ * is either created or not; a keyboard drops it via `.map(...)`/conditionals):
+ *
+ * - with `:params` — the values object is required;
+ * - without — nothing, so a plain or interpolated string needs no extra argument.
+ */
+export type RouteParamValues<Template extends string> = [
+  RouteParamName<Template>,
+] extends [never]
+  ? []
+  : [params: RouteParams<Template>];

--- a/lib/module/nestgram.module.spec.ts
+++ b/lib/module/nestgram.module.spec.ts
@@ -79,7 +79,8 @@ describe('NestgramModule (integration)', () => {
     });
 
     const table = app.get(RouteTable);
-    expect(table.size).toBe(1);
+    // 1 user route + the built-in no-op button route.
+    expect(table.size).toBe(2);
     expect(table.ofType('message')).toHaveLength(1);
 
     const dispatcher = app.get(UpdateDispatcher);
@@ -100,7 +101,7 @@ describe('NestgramModule (integration)', () => {
 
     // The only place GreetRouter is named is the providers array; forRoot got
     // no routers list, yet the route table still found it.
-    expect(app.get(RouteTable).size).toBe(1);
+    expect(app.get(RouteTable).size).toBe(2);
 
     await app.close();
   });
@@ -137,7 +138,7 @@ describe('NestgramModule.forRootAsync (integration)', () => {
     // Token resolved via the injected config factory reached the transport.
     expect(app.get(BotService).token).toBe('ASYNC_TOKEN');
     // Engine still wired: discovery built the route table.
-    expect(app.get(RouteTable).size).toBe(1);
+    expect(app.get(RouteTable).size).toBe(2);
 
     await app.close();
   });
@@ -211,9 +212,10 @@ describe('stacked listener decorators (integration)', () => {
     const dispatcher = app.get(UpdateDispatcher);
     const router = app.get(MultiRouter);
 
-    // Two routes for the one method: one per stacked decorator.
+    // Two routes for the one method: one per stacked decorator (the
+    // callback_query side also carries the built-in no-op route).
     expect(table.ofType('message')).toHaveLength(1);
-    expect(table.ofType('callback_query')).toHaveLength(1);
+    expect(table.ofType('callback_query')).toHaveLength(2);
 
     await dispatcher.dispatch(messageUpdate(1, 'hi'));
     expect(router.hits).toEqual(['hit']);

--- a/lib/module/nestgram.module.ts
+++ b/lib/module/nestgram.module.ts
@@ -37,6 +37,7 @@ import {
 import { AutoAnswerCallbackInterceptor } from '../builtins/auto-answer';
 import { ReplyExceptionFilter } from '../builtins/reply-exception';
 import { DeadButtonWarner } from '../builtins/unhandled';
+import { NoopButtonHandler } from '../builtins/noop';
 import { NestgramBootstrap } from './nestgram.bootstrap';
 import {
   NestgramModuleAsyncOptions,
@@ -163,6 +164,9 @@ export class NestgramModule {
     // `@Router` discovered like any other) — public and toggleable via
     // `warnUnhandledCallbacks`, so nothing here is privileged.
     DeadButtonWarner,
+    // Handles the reserved no-op route behind `Button.noop()`/`.else('label')`,
+    // so a dead-end button is answered (not warned). A plain `@Router`/`@Action`.
+    NoopButtonHandler,
   ];
 
   /**


### PR DESCRIPTION
Reworks the keyboard builders into a declarative, "reads-like-a-pipeline" API and makes a button a first-class value. Covers the full Bot API button surface, dynamic keyboards, editing an existing native keyboard, and dead-end buttons.

## Building

A button is a value (`Button`); the keyboard accumulates buttons and a layout method commits them.

- **`.split(n)`** cuts the accumulated buttons into rows of `n`, **`.spread()`** is one per row, **`.row(...buttons)`** commits a single row — so `.map(...).split(2)` reads the same as `.text().text().split(2)`.
- **`.map(items, fn)`** turns a collection into buttons; **`.add(...buttons)`** is the universal inlet (`.add(Button.pay('Pay'))`), reaching every Bot API kind.
- **`.group(build)`** appends an irregular block of rows.
- **`.if(cond)`** keeps the last unit — a button, row, `.split()` section or `.group()` — one verb for every scope. Inside `.map()`, `Button.if(cond).else(label|Button)` conditions a single button with an optional fallback.
- Colours are **postfix**: `.text('Delete', 'del').danger()`.

```ts
new InlineKeyboard()
  .map(items, (i) => Button.text(i.label, 'pick/:id', { id: i.id }))
  .split(3)
  .group((kb) => kb.text('Stats', 'stats').text('Ban', 'ban').split(2))
  .if(isAdmin);
```

## Editing

`InlineKeyboard.from(nativeMarkup)` adopts an incoming `reply_markup` (deep copy — the source is untouched). Address a button by **route** (`'toggle/3'` hits one, `'toggle/:id'` all that fit — the same `CallbackRoutePattern` that builds and routes it), by predicate, or by position (`.updateAt`/`.removeAt`). `.update`/`.setText`/`.replaceText`/`.remove` cover the edits, so a toggle/pagination is read-modify-send.

## Dead-end buttons

`Button.noop(label)` and `.else('label')` produce a button whose press does nothing: it carries a reserved `callback_data` handled by a built-in `@Router`/`@Action`, so the auto-answer interceptor stops the spinner and the dead-button warning never fires. Public and unprivileged, alongside `DeadButtonWarner`.

## Bot API coverage

`Button.*` and fluent shortcuts for every inline kind (text/url/webApp/loginUrl/switchInline(+Current)/copyText/pay), and a method per reply kind (requestContact/Location/Poll/webApp/requestUsers/requestChat) plus `.persistent()`.

## Removed (alpha)

`.columns(n)` (→ `.split(n)`), the trailing `hidden` boolean (→ `.if(cond)`), and prefix colours (→ postfix). These were strictly worse — `hidden` was a positional boolean, prefix colours needed one-shot/leak rules.

## Verify

`npm run build` · `npx eslint lib examples --max-warnings 0` · `npx jest` (776 passed) · `cd website && npm run build`. The no-op built-in adds one route to the table, so four route-count assertions were bumped (noted inline).
