### PR TITLE
feat(engine): edit the callback message in place from handler returns

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -62,6 +62,10 @@ From raw update to action, in order:
    unchanged.
 6. **Result handling.** A returned `string` becomes a reply; a returned
    command object (`new SendPhoto(...)`) is executed; `void` does nothing.
+   Inside a callback, this extends symmetrically to editing the message in
+   place: a returned `InlineKeyboard` edits its markup, and a returned edit
+   command (`new EditMessageText(...)`) has its `chat_id`/`message_id` filled
+   from the callback message — no manual target plumbing.
 
 ## Handlers and parameters
 

--- a/lib/engine/execution/extractors.spec.ts
+++ b/lib/engine/execution/extractors.spec.ts
@@ -9,6 +9,7 @@ import {
   extractArgs,
   extractCallbackData,
   extractChat,
+  extractEditTarget,
   extractPayload,
   extractSender,
 } from './extractors';
@@ -100,6 +101,62 @@ describe('extractors', () => {
         },
       });
       expect(extractCallbackData(ctx)).toBe('open_menu');
+    });
+  });
+
+  describe('extractEditTarget', () => {
+    it('targets the message a callback is attached to', () => {
+      const ctx = wrap({
+        update_id: 1,
+        callback_query: {
+          id: 'q',
+          from: { id: 1, is_bot: false, first_name: 'A' },
+          chat_instance: 'c',
+          data: 'toggle',
+          message: {
+            message_id: 555,
+            date: 1,
+            chat: { id: 99, type: 'private' },
+          },
+        },
+      });
+      expect(extractEditTarget(ctx)).toEqual({ chat_id: 99, message_id: 555 });
+    });
+
+    it('is undefined outside a callback context (nothing of the bot to edit)', () => {
+      expect(extractEditTarget(wrap(messageUpdate('hi')))).toBeUndefined();
+    });
+
+    it('is undefined for an inaccessible message (date 0 — too old/deleted)', () => {
+      const ctx = wrap({
+        update_id: 1,
+        callback_query: {
+          id: 'q',
+          from: { id: 1, is_bot: false, first_name: 'A' },
+          chat_instance: 'c',
+          data: 'toggle',
+          message: {
+            message_id: 555,
+            date: 0,
+            chat: { id: 99, type: 'private' },
+          },
+        },
+      });
+      expect(extractEditTarget(ctx)).toBeUndefined();
+    });
+
+    it('is undefined for an inline-only callback (no message)', () => {
+      const ctx = wrap({
+        update_id: 1,
+        callback_query: {
+          id: 'q',
+          from: { id: 1, is_bot: false, first_name: 'A' },
+          chat_instance: 'c',
+          data: 'toggle',
+          inline_message_id: 'inline-1',
+        },
+      });
+      expect(extractEditTarget(ctx)).toBeUndefined();
     });
   });
 });

--- a/lib/engine/execution/extractors.ts
+++ b/lib/engine/execution/extractors.ts
@@ -15,6 +15,12 @@ import {
  * never drift (DRY).
  */
 
+/**
+ * The `date` of an inaccessible message — the Bot API sets it to `0` so a bot
+ * can tell a real message from one it can no longer read (and so cannot edit).
+ */
+const INACCESSIBLE_MESSAGE_DATE = 0;
+
 /** The raw message carried by the update, if its kind has one. */
 function messageOf(ctx: TelegramExecutionContext): RawMessage | undefined {
   if (ctx.kind === UpdateKind.CallbackQuery) {
@@ -38,6 +44,34 @@ export function extractChat(
   ctx: TelegramExecutionContext,
 ): RawChat | undefined {
   return messageOf(ctx)?.chat;
+}
+
+/** Addresses the message an edit-in-place return value targets. */
+export interface EditTarget {
+  chat_id: number;
+  message_id: number;
+}
+
+/**
+ * The message a callback is attached to — what a bare-keyboard or edit-command
+ * return value edits in place. Defined only for a callback query over an
+ * accessible message; `undefined` everywhere else — a plain update has no
+ * message of the bot's own to edit, and an inaccessible one (too old/deleted)
+ * can't be edited — which is the signal to warn instead of making a doomed call.
+ */
+export function extractEditTarget(
+  ctx: TelegramExecutionContext,
+): EditTarget | undefined {
+  if (ctx.kind !== UpdateKind.CallbackQuery) {
+    return undefined;
+  }
+
+  const message = messageOf(ctx);
+  if (!message || message.date === INACCESSIBLE_MESSAGE_DATE) {
+    return undefined;
+  }
+
+  return { chat_id: message.chat.id, message_id: message.message_id };
 }
 
 /** The text the update carries (message text, or callback-query data). */

--- a/lib/engine/execution/result-handler.spec.ts
+++ b/lib/engine/execution/result-handler.spec.ts
@@ -1,12 +1,34 @@
+import { Logger } from '@nestjs/common';
+
 import { ResultHandler } from './result-handler';
 import { TelegramExecutionContext } from '../context';
 import { BotService } from '../../api';
-import { ApiMethod, GetMe } from '../../api/methods';
+import {
+  ApiMethod,
+  EditMessageReplyMarkup,
+  EditMessageText,
+  GetMe,
+} from '../../api/methods';
+import { InlineKeyboard } from '../../keyboards';
+import { ApiException } from '../../exceptions';
 
 // The handler reads the per-update bot off the context (ctx.bot), so the mock
 // bot is carried by the context, not injected into the handler.
 function ctxWith(event: unknown, bot: BotService): TelegramExecutionContext {
   return { kind: 'message', event, bot } as unknown as TelegramExecutionContext;
+}
+
+// A callback context whose attached message is the bot's own, editable one.
+function callbackCtx(bot: BotService): TelegramExecutionContext {
+  return {
+    kind: 'callback_query',
+    update: {
+      callback_query: {
+        message: { message_id: 555, chat: { id: 99, type: 'private' } },
+      },
+    },
+    bot,
+  } as unknown as TelegramExecutionContext;
 }
 
 describe('ResultHandler', () => {
@@ -60,5 +82,101 @@ describe('ResultHandler', () => {
       handler.handle({ message_id: 7 }, ctxWith({}, bot)),
     ).resolves.toBeUndefined();
     expect(called).toEqual([]);
+  });
+
+  describe('edit-in-place', () => {
+    it('edits the callback message markup when a bare keyboard is returned', async () => {
+      const keyboard = new InlineKeyboard().text('Done', 'done');
+
+      await handler.handle(keyboard, callbackCtx(bot));
+
+      expect(called).toHaveLength(1);
+      const command = called[0] as EditMessageReplyMarkup;
+      expect(command).toBeInstanceOf(EditMessageReplyMarkup);
+      expect(command.payload).toMatchObject({
+        chat_id: 99,
+        message_id: 555,
+        reply_markup: keyboard,
+      });
+    });
+
+    it('warns and does nothing when a keyboard is returned outside a callback', async () => {
+      const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      await handler.handle(
+        new InlineKeyboard().text('x', 'x'),
+        ctxWith({}, bot),
+      );
+
+      expect(called).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('no message to edit in place'),
+      );
+      warn.mockRestore();
+    });
+
+    it('fills chat_id/message_id on an untargeted edit command from the callback', async () => {
+      await handler.handle(
+        new EditMessageText({ text: 'updated' }),
+        callbackCtx(bot),
+      );
+
+      expect(called).toHaveLength(1);
+      const command = called[0] as EditMessageText;
+      expect(command).toBeInstanceOf(EditMessageText);
+      expect(command.payload).toMatchObject({
+        chat_id: 99,
+        message_id: 555,
+        text: 'updated',
+      });
+    });
+
+    it('leaves an explicitly-targeted edit command untouched', async () => {
+      const command = new EditMessageText({
+        chat_id: 5,
+        message_id: 9,
+        text: 'x',
+      });
+
+      await handler.handle(command, callbackCtx(bot));
+
+      // Passed straight through — same instance, no retargeting.
+      expect(called).toEqual([command]);
+    });
+
+    it('warns instead of throwing when the target message is not editable', async () => {
+      const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      bot = {
+        call: () =>
+          Promise.reject(
+            new ApiException(
+              {
+                ok: false,
+                error_code: 400,
+                description: "message can't be edited",
+              },
+              {},
+            ),
+          ),
+      } as unknown as BotService;
+
+      await expect(
+        handler.handle(new InlineKeyboard().text('x', 'x'), callbackCtx(bot)),
+      ).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Could not edit the message in place'),
+      );
+      warn.mockRestore();
+    });
+
+    it('rethrows a non-editability error from an auto-edit', async () => {
+      bot = {
+        call: () => Promise.reject(new Error('network down')),
+      } as unknown as BotService;
+
+      await expect(
+        handler.handle(new InlineKeyboard().text('x', 'x'), callbackCtx(bot)),
+      ).rejects.toThrow('network down');
+    });
   });
 });

--- a/lib/engine/execution/result-handler.ts
+++ b/lib/engine/execution/result-handler.ts
@@ -2,7 +2,14 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { TelegramExecutionContext } from '../context/telegram-execution-context';
 import { TelegramEvent } from '../context/event-factory';
-import { ApiMethod } from '../../api/methods';
+import {
+  ApiMethod,
+  EditMessageReplyMarkup,
+  EditMessageText,
+} from '../../api/methods';
+import { InlineKeyboard } from '../../keyboards';
+import { ApiException } from '../../exceptions';
+import { extractEditTarget, EditTarget } from './extractors';
 import type { ReplyOptions } from '../../api';
 
 /** An event that can reply to itself with optional reply options (e.g. `Message.answer`). */
@@ -10,12 +17,22 @@ interface Answerable {
   answer(text: string, options?: ReplyOptions): Promise<unknown>;
 }
 
+/** The edit-in-place commands that auto-target the current callback message. */
+type EditInPlaceMethod = EditMessageText | EditMessageReplyMarkup;
+
 /**
  * Applies the return-value contract for handlers, after the invoker returns:
- *   - `string`       -> reply that string to the same chat
- *   - command object -> execute it (the pure-data `new SendMessage(...)` layer
- *                       beneath `message.answer(...)` sugar)
- *   - anything else  -> noop
+ *   - `string`        -> reply that string to the same chat
+ *   - `InlineKeyboard`-> edit the current message's markup in place (callback only)
+ *   - edit command    -> `new EditMessageText(...)` etc.; its `chat_id`/`message_id`
+ *                        are filled from the callback message when omitted
+ *   - command object  -> execute it (the pure-data `new SendMessage(...)` layer
+ *                        beneath `message.answer(...)` sugar)
+ *   - anything else   -> noop
+ *
+ * Editing in place is symmetric to `answer()`: just as a returned string replies
+ * to the same chat, a returned keyboard or untargeted edit command acts on the
+ * message the callback is attached to — no manual `chat_id`/`message_id` plumbing.
  *
  * Non-string, non-command results are ignored silently — `return message.answer(...)`
  * is idiomatic (especially in arrow handlers) and has already sent the message,
@@ -46,10 +63,118 @@ export class ResultHandler {
       return;
     }
 
+    if (result instanceof InlineKeyboard) {
+      await this.editMarkupInPlace(result, ctx);
+      return;
+    }
+
     if (result instanceof ApiMethod) {
+      if (this.isEditInPlace(result) && !this.hasTarget(result)) {
+        await this.editCommandInPlace(result, ctx);
+        return;
+      }
       // The bot that received this update — not a global default — so a returned
       // command object (new SendMessage(...)) goes out through the right bot.
       await ctx.bot.call(result);
+    }
+  }
+
+  /** A bare keyboard return edits only the current message's reply markup. */
+  private async editMarkupInPlace(
+    keyboard: InlineKeyboard,
+    ctx: TelegramExecutionContext,
+  ): Promise<void> {
+    const target = extractEditTarget(ctx);
+    if (target === undefined) {
+      this.logger.warn(
+        'Handler returned a keyboard with no message to edit in place — not a ' +
+          'callback over an accessible message (a plain update, an old/deleted ' +
+          'message, or an inline-message callback). Attach it to a message you ' +
+          'send instead, e.g. `message.answer(text, { reply_markup })`.',
+      );
+      return;
+    }
+
+    await this.callEditable(
+      new EditMessageReplyMarkup({ ...target, reply_markup: keyboard }),
+      ctx,
+    );
+  }
+
+  /** An untargeted edit command (`new EditMessageText(...)`) targets the callback message. */
+  private async editCommandInPlace(
+    command: EditInPlaceMethod,
+    ctx: TelegramExecutionContext,
+  ): Promise<void> {
+    const target = extractEditTarget(ctx);
+    if (target === undefined) {
+      this.logger.warn(
+        `Handler returned ${command.method} without a target and there is no ` +
+          'editable callback message to fill it from (a plain update, an ' +
+          'old/deleted message, or an inline-message callback). Set chat_id/' +
+          'message_id — or inline_message_id — on the command explicitly.',
+      );
+      return;
+    }
+
+    await this.callEditable(this.retarget(command, target), ctx);
+  }
+
+  // The edit-in-place set must mirror the methods tagged `WRAP_EDITABLE` in
+  // tools/codegen/manifest.ts (the ones that edit a message and return
+  // `Message | true`). Keep the two in sync: a new editable method added there
+  // and meant to auto-target a callback message belongs here too.
+  private isEditInPlace(
+    method: ApiMethod<unknown, unknown>,
+  ): method is EditInPlaceMethod {
+    return (
+      method instanceof EditMessageText ||
+      method instanceof EditMessageReplyMarkup
+    );
+  }
+
+  /** Whether the command already addresses a message — an explicit target wins. */
+  private hasTarget(method: EditInPlaceMethod): boolean {
+    const payload = method.payload as
+      | { chat_id?: unknown; inline_message_id?: unknown }
+      | undefined;
+    return (
+      payload?.chat_id !== undefined || payload?.inline_message_id !== undefined
+    );
+  }
+
+  /** A copy of the command addressed at `target` (commands stay immutable). */
+  private retarget(
+    command: EditInPlaceMethod,
+    target: EditTarget,
+  ): EditInPlaceMethod {
+    const Ctor = command.constructor as new (
+      payload: object,
+    ) => EditInPlaceMethod;
+    return new Ctor({ ...command.payload, ...target });
+  }
+
+  /**
+   * Runs a framework-targeted edit. A stale target (`message can't be edited` /
+   * `to edit not found`) is the bot's own message having aged out or been
+   * deleted — we warn rather than throw, since the call was our auto-targeting,
+   * not an explicit user request. Every other failure propagates unchanged.
+   */
+  private async callEditable(
+    command: ApiMethod<unknown, unknown>,
+    ctx: TelegramExecutionContext,
+  ): Promise<void> {
+    try {
+      await ctx.bot.call(command);
+    } catch (error) {
+      if (ApiException.isNotEditable(error)) {
+        this.logger.warn(
+          `Could not edit the message in place — ${error.description}. The ` +
+            "message may be too old, deleted, or not the bot's own.",
+        );
+        return;
+      }
+      throw error;
     }
   }
 

--- a/lib/exceptions/api.exception.spec.ts
+++ b/lib/exceptions/api.exception.spec.ts
@@ -87,5 +87,24 @@ describe('ApiException predicates', () => {
         ApiException.isChatNotFound(apiException(403, 'chat not found')),
       ).toBe(false);
     });
+
+    it('isNotEditable', () => {
+      expect(
+        ApiException.isNotEditable(
+          apiException(400, "Bad Request: message can't be edited"),
+        ),
+      ).toBe(true);
+      expect(
+        ApiException.isNotEditable(
+          apiException(400, 'Bad Request: message to edit not found'),
+        ),
+      ).toBe(true);
+      // A content no-op is `isNotModified`, not `isNotEditable`.
+      expect(
+        ApiException.isNotEditable(
+          apiException(400, 'Bad Request: message is not modified'),
+        ),
+      ).toBe(false);
+    });
   });
 });

--- a/lib/exceptions/api.exception.ts
+++ b/lib/exceptions/api.exception.ts
@@ -68,4 +68,13 @@ export class ApiException extends NestgramError {
   static isChatNotFound(error: unknown): error is ApiException {
     return ApiException.matches(error, KnownApiError.chatNotFound);
   }
+
+  /**
+   * The message can no longer be edited — too old, deleted, or not the bot's
+   * own (`400 message can't be edited` / `message to edit not found`). Distinct
+   * from {@link isNotModified}, which is a content no-op.
+   */
+  static isNotEditable(error: unknown): error is ApiException {
+    return ApiException.matches(error, KnownApiError.notEditable);
+  }
 }

--- a/lib/exceptions/error-catalog.ts
+++ b/lib/exceptions/error-catalog.ts
@@ -33,4 +33,13 @@ export const KnownApiError = {
   blockedByUser: { code: 403, description: /bot was blocked by the user/i },
   /** The target chat does not exist (wrong id, or the bot was never there). */
   chatNotFound: { code: 400, description: /chat not found/i },
+  /**
+   * The message can no longer be edited — too old, already deleted, or not the
+   * bot's own message. Distinct from {@link notModified} (a content no-op): here
+   * the edit is genuinely impossible.
+   */
+  notEditable: {
+    code: 400,
+    description: /message can't be edited|message to edit not found/i,
+  },
 } as const satisfies Record<string, ApiErrorMatcher>;

--- a/tools/codegen/manifest.ts
+++ b/tools/codegen/manifest.ts
@@ -200,6 +200,10 @@ const WRAP_ARRAY = `wrap(raw: unknown, bot: BotService): Message[] {
   );
 }`;
 
+// Methods that edit a message in place and so return `Message | true`. The
+// engine's result-handler mirrors this set (see `isEditInPlace` in
+// lib/engine/execution/result-handler.ts) to auto-target a returned edit command
+// at the callback message — keep the two in sync when adding an editable method.
 const WRAP_EDITABLE = `wrap(raw: unknown, bot: BotService): Message | true {
   return typeof raw === 'object' && raw !== null
     ? new Message(bot, raw as Partial<RawMessage>)


### PR DESCRIPTION
## Problem

Editing the message a callback is attached to meant manually threading
`chat_id`/`message_id` into an edit command in every handler. The return-value
contract (string → reply, command object → execute) didn't yet cover the common
"toggle / paginate this message" case.

## Change

Extends the return-value contract so a callback handler can edit its message in
place — symmetric to how a returned string replies to the same chat:

- Returning a bare `InlineKeyboard` edits the current message's reply markup.
- Returning an untargeted edit command (`new EditMessageText({ text })`) has its
  `chat_id`/`message_id` filled from the callback message.
- Warns instead of crashing on the honest cases: no editable message to target
  (a plain update, an old/deleted message, or an inline-message callback), or a
  message that can no longer be edited (new `ApiException.isNotEditable` —
  swallowed for the framework's own auto-edit, rethrown for anything else).

Edit-in-place commands are recognized via `instanceof` of the two methods the
codegen manifest tags `WRAP_EDITABLE`; targeting builds a fresh command instance
(returned commands are never mutated).

## Verify

- `npm run build`, `npm run lint`
- `npx jest` — 787 pass; new coverage in `result-handler`, `extractors`, and
  `api.exception` specs (keyboard edit, auto-target fill, both warn paths,
  not-editable swallow vs rethrow, inaccessible/inline targets).
