### PR TITLE
Media DX — file inputs, send sugar, albums, in-place edit, caching

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -1,0 +1,229 @@
+---
+title: Sending media
+description: Send photos, videos, documents and albums with typed InputFile sources, edit media in place, and react to messages.
+sidebar:
+  label: Media
+  group: Events & replies
+  order: 35
+---
+
+Text is one reply; files are the other half. Nestgram sends every media kind
+through the same `message.answer*` / `reply*` sugar you already use for text.
+
+:::mental
+local file -> new InputFile() ; remote -> a string -> answer\* / MediaGroup
+:::
+
+## Files: a string or an `InputFile`
+
+A media field takes either:
+
+- **A remote file — just a string.** A URL or a `file_id` goes through as-is;
+  Telegram resolves it. No wrapper needed.
+- **A local file — `new InputFile(...)`.** Local bytes have to be read and
+  uploaded as `multipart/form-data`, so they're wrapped. The constructor takes a
+  path, a stream, or a buffer:
+
+| Source     | How                                           |
+| ---------- | --------------------------------------------- |
+| Remote URL | `'https://example.com/cat.jpg'`               |
+| `file_id`  | `'AgACAgIAAx…'`                               |
+| Local path | `new InputFile('./cat.jpg')`                  |
+| Buffer     | `new InputFile(bytes, { filename: 'c.jpg' })` |
+| Stream     | `new InputFile(createReadStream('./c.jpg'))`  |
+
+The file name and MIME type are inferred for an upload (override with
+`{ filename, contentType }`). To reuse a `file_id` after the first upload, use
+[`new CachedFile()`](#reusing-uploads-the-file-id-cache).
+
+:::note
+A buffer needs a `filename` — Telegram names the file from it (and derives the
+MIME type). It's required by the type, so the compiler reminds you.
+
+:::
+
+## Sending media
+
+Every media kind has an `answer*` (send to the same chat) and a `reply*` (quote
+the incoming message) method, mirroring `answer` / `reply` for text:
+`answerPhoto`, `answerVideo`, `answerAudio`, `answerDocument`, `answerVoice`,
+`answerAnimation`, `answerVideoNote`, `answerSticker`. Each takes the file as a
+`string | InputFile` plus the method's options:
+
+:::code[media.router.ts]
+
+```ts
+import { Router, Command, Message, InputFile, InlineKeyboard } from 'nestgram';
+
+@Router()
+export class MediaRouter {
+  @Command('photo')
+  photo(message: Message) {
+    return message.answerPhoto('https://picsum.photos/600/400', {
+      caption: 'A remote photo — tap Swap to edit it in place.',
+      reply_markup: new InlineKeyboard().text('Swap', 'swap'),
+    });
+  }
+
+  @Command('doc')
+  doc(message: Message) {
+    const notes = Buffer.from('Generated on the fly.\n', 'utf-8');
+    return message.answerDocument(
+      new InputFile(notes, { filename: 'notes.txt' }),
+    );
+  }
+}
+```
+
+:::
+
+The underlying command objects (`new SendPhoto(...)`, `new SendDocument(...)`)
+are the layer beneath — return one from a handler if you'd rather assemble the
+call yourself.
+
+## Reusing uploads: the file-id cache
+
+Re-sending the same static file re-uploads its bytes every time. The file-id
+cache fixes that: the first send uploads as usual, then later sends of the same
+source reuse the returned `file_id` — no bytes re-uploaded, no URL re-fetched.
+
+It's **opt-in per file**: send a `new CachedFile(path)` instead of a
+`new InputFile(path)` and it's cached (in a process-local store by default).
+There's no global switch to flip — a plain `InputFile` is never cached, so a
+user-uploaded photo can't land in the cache by accident:
+
+```ts
+// Cached after the first send — same bytes reused forever:
+message.answerPhoto(new CachedFile('./assets/logo.png'));
+
+// A plain upload → fresh every time (the safe default):
+message.answerPhoto(new InputFile(userUploadedPath));
+```
+
+That's all it takes. It's an ordinary outbound interceptor (no privileged core)
+sitting just before the throttler, so a cache hit still rate-limits. It caches
+the single primary file of a send (`answerPhoto`, `answerVideo`,
+`answerDocument`, …), keyed by the path and scoped per bot. `CachedFile` is
+path-only (a path is the one source with a stable identity), and album items and
+thumbnails are never cached.
+
+Pass `fileIdCache` only to swap the default store for Redis (any
+`KeyValueStore`), bound it with a `ttl`, or fold a content hash into the `key`:
+
+```ts
+NestgramModule.forRoot({
+  token: process.env.BOT_TOKEN ?? '',
+  polling: true,
+  fileIdCache: {
+    store: new MyRedisStore(redis), // any { get, set, delete }
+    ttl: 24 * 60 * 60 * 1000, // ms
+  },
+});
+```
+
+:::note
+Because the key is the path, a changed file at the same path keeps serving the
+old `file_id`. For a static asset that's the point; for something that may
+change, set a `ttl` or fold a content hash into the `key`. And only wrap
+**trusted** paths in `CachedFile` — caching a user-controlled one defeats the
+safe default.
+
+:::
+
+## Albums
+
+An album (Telegram's _media group_) is built with the fluent **`MediaGroup`**
+builder, the same shape as the keyboard builder: accumulate items, then hand it
+straight to `answerMediaGroup` / `replyMediaGroup`.
+
+:::code[album.router.ts]
+
+```ts
+import { Router, Command, Message, MediaGroup } from 'nestgram';
+
+@Router()
+export class AlbumRouter {
+  @Command('album')
+  album(message: Message) {
+    const album = new MediaGroup()
+      .photo('https://picsum.photos/seed/a/600/400', { caption: 'First' })
+      .photo('https://picsum.photos/seed/b/600/400')
+      .video('https://example.com/clip.mp4');
+
+    return message.answerMediaGroup(album);
+  }
+}
+```
+
+:::
+
+`.photo()` / `.video()` / `.audio()` / `.document()` each set the item type for
+you — no `type:` tag to write. Two more accumulators help with dynamic albums:
+
+- `.add(...items)` — append already-built items.
+- `.each(items, (group, item) => group.photo(item.url))` — one item per source
+  value, e.g. from a database row.
+
+`answerMediaGroup` also takes a plain item array, so `MediaGroup` is purely
+ergonomic. Telegram only allows mixing **photos and videos** in one album;
+audio-only and document-only albums are also valid.
+
+## Editing media in place
+
+`editMedia` swaps the media of an existing message — the counterpart to
+`editText` / `editReplyMarkup`:
+
+```ts
+await message.editMedia({ type: 'photo', media: nextPhotoUrl });
+```
+
+Inside a callback you can also **return** an untargeted `EditMessageMedia`: the
+engine fills `chat_id`/`message_id` from the callback message and edits it in
+place, exactly like a returned `EditMessageText` or a bare keyboard.
+
+:::code[media.router.ts]{mark="7-12"}
+
+```ts
+import { Router, Action, EditMessageMedia } from 'nestgram';
+
+@Router()
+export class MediaRouter {
+  @Action('swap')
+  swap() {
+    return new EditMessageMedia({
+      media: {
+        type: 'photo',
+        media: 'https://picsum.photos/id/20/600/400',
+      },
+    });
+  }
+}
+```
+
+:::
+
+:::note
+`editMessageMedia` only works when the target is already a media message —
+Telegram won't turn a text message into a photo. If the message is too old or
+deleted, the framework warns instead of throwing (it was the engine's
+auto-targeting, not your explicit call).
+
+:::
+
+## Reactions
+
+`message.react(emoji)` sets a single emoji reaction on the message (replacing
+any existing one), wrapping `setMessageReaction`:
+
+```ts
+@OnMessage()
+thumbsUp(message: Message) {
+  return message.react('👍');
+}
+```
+
+Pass `setMessageReaction` options as the second argument — for example
+`{ is_big: true }` for the large animation.
+
+See the full runnable tour in
+[`examples/media-gallery`](https://github.com/Degreet/nestgram/tree/main/examples/media-gallery).

--- a/examples/media-gallery/README.md
+++ b/examples/media-gallery/README.md
@@ -1,0 +1,29 @@
+# media-gallery
+
+A bot to play with Nestgram's media surface live — typed `InputFile` sources,
+per-kind send sugar, the album builder, editing media in place, and reactions.
+Every file is a remote URL Telegram fetches itself, so it runs with no local
+assets.
+
+| Command       | Shows                                                                        |
+| ------------- | ---------------------------------------------------------------------------- |
+| `/photo`      | `answerPhoto(url)` (remote = a string) with a caption and a **Swap** button. |
+| Swap (button) | An untargeted `EditMessageMedia` return — **edited in place** by the engine. |
+| `/album`      | A mixed photo + video album via the `MediaGroup` fluent builder.             |
+| `/doc`        | `answerDocument(new InputFile(bytes, …))` — raw bytes uploaded as a file.    |
+| _any text_    | A `👍` reaction via `message.react()`.                                       |
+
+## Run
+
+This folder imports from `nestgram` exactly as an outside app would — here it
+resolves to `lib/` via the repo's `tsconfig` path alias. Run it from the **repo
+root**:
+
+```bash
+BOT_TOKEN=123456789:your-token npx ts-node -r tsconfig-paths/register \
+  examples/media-gallery/main.ts
+```
+
+Get a token from [@BotFather](https://t.me/BotFather). Polling needs no HTTP
+server — the bot runs as a plain Nest application context, so `Ctrl-C` stops it
+cleanly.

--- a/examples/media-gallery/app.module.ts
+++ b/examples/media-gallery/app.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { NestgramModule } from 'nestgram';
+
+import { MediaRouter } from './media.router';
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      token: process.env.BOT_TOKEN ?? '',
+      polling: true,
+    }),
+  ],
+  providers: [MediaRouter],
+})
+export class AppModule {}

--- a/examples/media-gallery/main.ts
+++ b/examples/media-gallery/main.ts
@@ -1,0 +1,16 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+
+import { AppModule } from './app.module';
+
+/**
+ * Run with: `BOT_TOKEN=123456:your-token npx ts-node -r tsconfig-paths/register
+ * examples/media-gallery/main.ts` from the repo root (see README).
+ * A polling bot needs no HTTP server — it's a plain application context.
+ */
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  app.enableShutdownHooks(); // lets polling stop cleanly on Ctrl-C
+}
+
+void bootstrap();

--- a/examples/media-gallery/media.router.ts
+++ b/examples/media-gallery/media.router.ts
@@ -1,0 +1,73 @@
+import {
+  Router,
+  Command,
+  Action,
+  OnMessage,
+  Message,
+  InputFile,
+  InlineKeyboard,
+  MediaGroup,
+  EditMessageMedia,
+} from 'nestgram';
+
+/**
+ * A tour of the media surface — typed `InputFile` sources, per-kind send sugar,
+ * an album builder, editing media in place, and message reactions.
+ *
+ * Every file here is a remote URL Telegram fetches itself, so the demo needs no
+ * local assets. Try `/photo`, `/album`, `/doc`, then send any plain text.
+ */
+@Router()
+export class MediaRouter {
+  private static readonly PHOTO_A =
+    'https://picsum.photos/seed/nestgram-a/600/400';
+  private static readonly PHOTO_B =
+    'https://picsum.photos/seed/nestgram-b/600/400';
+  private static readonly CLIP = 'https://www.w3schools.com/html/mov_bbb.mp4';
+
+  /** Send a photo by URL (remote = just a string) with a caption and a Swap button. */
+  @Command('photo')
+  photo(message: Message) {
+    return message.answerPhoto(MediaRouter.PHOTO_A, {
+      caption: 'A remote photo — tap Swap to edit it in place.',
+      reply_markup: new InlineKeyboard().text('Swap', 'swap'),
+    });
+  }
+
+  /**
+   * Swap returns an *untargeted* edit command: the framework fills
+   * chat_id/message_id from the callback message and edits it in place.
+   */
+  @Action('swap')
+  swap() {
+    return new EditMessageMedia({
+      media: { type: 'photo', media: MediaRouter.PHOTO_B },
+    });
+  }
+
+  /** A mixed photo + video album, assembled with the fluent builder. */
+  @Command('album')
+  album(message: Message) {
+    const album = new MediaGroup()
+      .photo(MediaRouter.PHOTO_A, { caption: 'First' })
+      .photo(MediaRouter.PHOTO_B)
+      .video(MediaRouter.CLIP);
+
+    return message.answerMediaGroup(album);
+  }
+
+  /** Upload raw bytes as a document — a Buffer needs an explicit filename. */
+  @Command('doc')
+  doc(message: Message) {
+    const notes = Buffer.from('Generated on the fly.\n', 'utf-8');
+    return message.answerDocument(
+      new InputFile(notes, { filename: 'notes.txt' }),
+    );
+  }
+
+  /** Any other text message gets a 👍 — the reaction sugar. */
+  @OnMessage()
+  thumbsUp(message: Message) {
+    return message.react('👍');
+  }
+}

--- a/lib/api/bot-options.ts
+++ b/lib/api/bot-options.ts
@@ -4,6 +4,7 @@ import type { ApiInterceptor } from './request';
 import type { ParseModeValue } from './parse-mode';
 import type { RichMessagesOptions } from '../builtins/rich-messages/rich-messages.types';
 import type { ThrottleOptions } from '../builtins/throttle/throttle.types';
+import type { FileIdCacheOptions } from '../builtins/file-id-cache/file-id-cache.types';
 
 export interface BotOptions {
   token: string;
@@ -26,6 +27,12 @@ export interface BotOptions {
   throttle?: boolean | ThrottleOptions;
   /** Replace the default throttler entirely (e.g. a distributed one). */
   throttler?: Type<ApiInterceptor>;
+  /**
+   * Configure the `file_id` cache — its store, TTL, or key strategy. Caching is
+   * opt-in per file (use `new CachedFile(path)`), so this option is only needed
+   * to swap the default in-memory store. See {@link FileIdCacheOptions}.
+   */
+  fileIdCache?: FileIdCacheOptions;
 }
 
 export interface BotAsyncOptions extends Pick<ModuleMetadata, 'imports'> {

--- a/lib/api/bot.module.spec.ts
+++ b/lib/api/bot.module.spec.ts
@@ -9,6 +9,7 @@ import { IgnoreNotModifiedInterceptor } from '../builtins/ignore-not-modified';
 import { RichMessagesInterceptor } from '../builtins/rich-messages';
 import { ThrottleInterceptor } from '../builtins/throttle';
 import { TokenValidationInterceptor } from '../builtins/token-validation';
+import { FileIdCacheInterceptor } from '../builtins/file-id-cache';
 
 @Module({ imports: [BotModule.forBot('default', { token: '1:T' })] })
 class DefaultApp {}
@@ -47,6 +48,9 @@ describe('BotModule interceptor wiring', () => {
     // parse_mode must not read as explicit formatting intent.
     expect(chain[2]).toBeInstanceOf(RichMessagesInterceptor);
     expect(chain[3]).toBeInstanceOf(DefaultParseModeInterceptor);
+    // The file-id cache sits last among the mutators — just before the throttler,
+    // so a hit that turns an upload into a file_id send still throttles.
+    expect(chain[chain.length - 2]).toBeInstanceOf(FileIdCacheInterceptor);
     expect(chain[chain.length - 1]).toBeInstanceOf(ThrottleInterceptor);
     await app.close();
   });

--- a/lib/api/bot.module.ts
+++ b/lib/api/bot.module.ts
@@ -19,6 +19,12 @@ import {
 } from '../builtins/rich-messages';
 import { ThrottleInterceptor, throttleProviders } from '../builtins/throttle';
 import { TokenValidationInterceptor } from '../builtins/token-validation';
+import {
+  FILE_ID_CACHE_SETTINGS,
+  FileIdCacheInterceptor,
+  FileIdCacheSettings,
+  resolveFileIdCacheSettings,
+} from '../builtins/file-id-cache';
 
 /**
  * Builds ONE bot — its own `BotService` reachable under `getBotToken(name)`, on
@@ -45,17 +51,22 @@ export class BotModule {
    * `throttler` replaces them.
    */
   private static pipelineProviders(
+    name: string,
     userInterceptors: Type<ApiInterceptor>[],
     throttler: Type<ApiInterceptor> | undefined,
   ): Provider[] {
     // One source of truth for the leading interceptors, reused for both the
-    // provider list and the factory's inject list so they can't drift.
+    // provider list and the factory's inject list so they can't drift. The
+    // file-id cache runs after the mutators (it reads the final payload) but
+    // before the throttler (a hit that turns an upload into a file_id still
+    // throttles).
     const leading: Type<ApiInterceptor>[] = [
       TokenValidationInterceptor,
       IgnoreNotModifiedInterceptor,
       RichMessagesInterceptor,
       DefaultParseModeInterceptor,
       ...userInterceptors,
+      FileIdCacheInterceptor,
     ];
     const throttleSlot = throttler ?? ThrottleInterceptor;
     return [
@@ -66,6 +77,16 @@ export class BotModule {
         provide: RICH_MESSAGES_SETTINGS,
         useFactory: (options: BotOptions): RichMessagesSettings | null =>
           resolveRichMessagesSettings(options.richMessages),
+        inject: [Providers.BOT_OPTIONS],
+      },
+      // Resolved from the `fileIdCache` option (defaults filled when omitted).
+      // Caching is gated per file by `CachedFile`, so the interceptor is always
+      // present but only acts on those sources. The bot name is baked in so a
+      // shared store stays scoped per bot.
+      {
+        provide: FILE_ID_CACHE_SETTINGS,
+        useFactory: (options: BotOptions): FileIdCacheSettings =>
+          resolveFileIdCacheSettings(options.fileIdCache, name),
         inject: [Providers.BOT_OPTIONS],
       },
       // The default throttler's providers are spliced (not imported) so they
@@ -100,6 +121,7 @@ export class BotModule {
       providers: [
         { provide: Providers.BOT_OPTIONS, useValue: options },
         ...this.pipelineProviders(
+          name,
           options.apiInterceptors ?? [],
           options.throttler,
         ),
@@ -124,6 +146,7 @@ export class BotModule {
       providers: [
         ...this.createAsyncProviders(options),
         ...this.pipelineProviders(
+          name,
           options.apiInterceptors ?? [],
           options.throttler,
         ),

--- a/lib/api/cached-file.ts
+++ b/lib/api/cached-file.ts
@@ -1,0 +1,26 @@
+import { InputFile, InputFileOptions } from './input-file';
+
+/**
+ * A local file whose Telegram `file_id` is reused after the first upload. Drop
+ * it in wherever an upload goes and the `fileIdCache` does the rest — the first
+ * send uploads the bytes, later sends of the same path go out as the cached
+ * `file_id`:
+ *
+ * ```ts
+ * message.answerPhoto(new CachedFile('./assets/logo.png'));
+ * ```
+ *
+ * Path-only: a path is the one upload source with a stable identity to key on
+ * (a stream is consumed once; a buffer's bytes have no durable name). Mark only
+ * **static** files — the key is the path, so a changed file at the same path
+ * keeps serving the old `file_id` until it expires.
+ */
+export class CachedFile extends InputFile {
+  constructor(private readonly path: string, options?: InputFileOptions) {
+    super(path, options);
+  }
+
+  get cacheKey(): string {
+    return this.path;
+  }
+}

--- a/lib/api/form-data.ts
+++ b/lib/api/form-data.ts
@@ -10,8 +10,9 @@ import { InputFile } from './input-file';
 /**
  * True if an `InputFile` is reachable anywhere in the payload. Mirrors the
  * recursive walk the serializers do, so a method's `hasMedia` is an exact "does
- * this call carry a file" check — no matter how deeply the file is nested, and
- * regardless of which field name holds it (`media`, `thumbnail`, `photo`, …).
+ * this call carry a file" check — no matter how deeply the file is nested, or
+ * which field name holds it (`media`, `thumbnail`, `photo`, …). Remote refs are
+ * bare strings, not `InputFile`s, so they never count.
  */
 export function hasInputFile(value: unknown): boolean {
   if (value instanceof InputFile) {
@@ -52,7 +53,7 @@ export async function createInlineData(
       continue;
     }
     if (value instanceof InputFile) {
-      formData.append(key, await value.toRaw());
+      formData.append(key, await value.toRaw(), value.filename);
     } else if (typeof value === 'object') {
       formData.append(key, JSON.stringify(value));
     } else {

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -5,4 +5,6 @@ export * from './api-response';
 export * from './bot-options';
 export * from './parse-mode';
 export * from './input-file';
+export * from './cached-file';
 export * from './input-media';
+export * from './media-group';

--- a/lib/api/input-file.spec.ts
+++ b/lib/api/input-file.spec.ts
@@ -1,0 +1,159 @@
+import { createReadStream } from 'fs';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { InputFile } from './input-file';
+import { CachedFile } from './cached-file';
+import {
+  createAttachedData,
+  createInlineData,
+  hasInputFile,
+} from './form-data';
+
+describe('InputFile', () => {
+  it('a path infers its filename and MIME', async () => {
+    const file = new InputFile('./pics/cat.png');
+    expect(file.filename).toBe('cat.png');
+    expect(file.cacheKey).toBeUndefined();
+  });
+
+  it('honors explicit filename/contentType overrides', () => {
+    const file = new InputFile('./cat.png', {
+      filename: 'kitty.png',
+      contentType: 'image/x-custom',
+    });
+    expect(file.filename).toBe('kitty.png');
+  });
+
+  it('a buffer produces a Blob with the inferred MIME', async () => {
+    const file = new InputFile(Buffer.from('hello'), { filename: 'a.png' });
+    expect(file.filename).toBe('a.png');
+    const blob = await file.toRaw();
+    expect(blob.type).toBe('image/png');
+    expect(await blob.text()).toBe('hello');
+  });
+
+  it('a buffer falls back to octet-stream for unknown extensions', async () => {
+    const file = new InputFile(Buffer.from('x'), { filename: 'data.xyz' });
+    expect((await file.toRaw()).type).toBe('application/octet-stream');
+  });
+
+  it('a buffer respects an explicit contentType', async () => {
+    const file = new InputFile(Buffer.from('x'), {
+      filename: 'data.bin',
+      contentType: 'application/pdf',
+    });
+    expect((await file.toRaw()).type).toBe('application/pdf');
+  });
+
+  it('a buffer without a filename throws', () => {
+    expect(
+      () => new InputFile(Buffer.from('x') as Buffer, {} as never),
+    ).toThrow(/filename/);
+  });
+
+  it('a stream infers the filename from the stream path and uploads its bytes', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'nestgram-inputfile-'));
+    const filePath = join(dir, 'note.txt');
+    try {
+      await writeFile(filePath, 'streamed');
+      const file = new InputFile(createReadStream(filePath));
+      expect(file.filename).toBe('note.txt');
+      const blob = await file.toRaw();
+      expect(await blob.text()).toBe('streamed');
+      expect(blob.type).toBe('text/plain');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('CachedFile', () => {
+  it('is an InputFile whose cacheKey is the path', () => {
+    const file = new CachedFile('/assets/logo.png');
+    expect(file).toBeInstanceOf(InputFile);
+    expect(file.cacheKey).toBe('/assets/logo.png');
+    expect(file.filename).toBe('logo.png');
+  });
+
+  it('uploads its bytes like any InputFile', async () => {
+    // (built from a real temp file so toRaw can read it)
+    const dir = await mkdtemp(join(tmpdir(), 'nestgram-cachedfile-'));
+    const filePath = join(dir, 'logo.png');
+    try {
+      await writeFile(filePath, 'PNGDATA');
+      const blob = await new CachedFile(filePath).toRaw();
+      expect(await blob.text()).toBe('PNGDATA');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('form-data', () => {
+  describe('hasInputFile (the multipart gate)', () => {
+    it('is true when an InputFile is present', () => {
+      expect(
+        hasInputFile({
+          photo: new InputFile(Buffer.from('x'), { filename: 'a.jpg' }),
+        }),
+      ).toBe(true);
+    });
+
+    it('is false for bare strings (remote refs)', () => {
+      expect(hasInputFile({ photo: 'https://x/c.jpg' })).toBe(false);
+      expect(hasInputFile({ photo: 'file_id' })).toBe(false);
+    });
+
+    it('finds a file nested in a media array', () => {
+      expect(
+        hasInputFile({
+          media: [
+            { type: 'photo', media: 'file_id' },
+            {
+              type: 'photo',
+              media: new InputFile(Buffer.from('x'), { filename: 'b.jpg' }),
+            },
+          ],
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('createInlineData (flat, single-file)', () => {
+    it('appends an uploaded blob with its filename', async () => {
+      const form = await createInlineData({
+        chat_id: 1,
+        photo: new InputFile(Buffer.from('bytes'), { filename: 'cat.jpg' }),
+      });
+      const photo = form.get('photo');
+      expect(typeof photo).not.toBe('string');
+      expect((photo as File).name).toBe('cat.jpg');
+    });
+
+    it('appends a bare remote string as-is', async () => {
+      const form = await createInlineData({
+        chat_id: 1,
+        photo: 'https://example.com/cat.jpg',
+      });
+      expect(form.get('photo')).toBe('https://example.com/cat.jpg');
+    });
+  });
+
+  describe('createAttachedData (nested media)', () => {
+    it('inlines remote strings and attach://-references uploads', async () => {
+      const form = await createAttachedData({
+        media: [
+          { type: 'photo', media: 'https://example.com/a.jpg' },
+          {
+            type: 'photo',
+            media: new InputFile(Buffer.from('x'), { filename: 'b.jpg' }),
+          },
+        ],
+      });
+      const media = JSON.parse(form.get('media') as string);
+      expect(media[0].media).toBe('https://example.com/a.jpg');
+      expect(media[1].media).toMatch(/^attach:\/\//);
+    });
+  });
+});

--- a/lib/api/input-file.ts
+++ b/lib/api/input-file.ts
@@ -1,34 +1,138 @@
 import { ReadStream } from 'fs';
-import { basename } from 'path';
+import { basename, extname } from 'path';
 import { readFile } from 'fs/promises';
 
+/** How an upload's bytes are sourced. */
+enum SourceKind {
+  Path = 'path',
+  Stream = 'stream',
+  Buffer = 'buffer',
+}
+
+/** The three local upload sources, discriminated by `kind`. */
+type InputSource =
+  | { kind: SourceKind.Path; path: string }
+  | { kind: SourceKind.Stream; stream: ReadStream }
+  | { kind: SourceKind.Buffer; data: Buffer | Uint8Array };
+
+/** Options for an upload. */
+export interface InputFileOptions {
+  /** Override the file name Telegram sees (inferred from the path/stream otherwise). */
+  filename?: string;
+  /** Override the MIME type (inferred from the file name otherwise). */
+  contentType?: string;
+}
+
+/** Options for a buffer upload — a `filename` is required so Telegram can name the file. */
+export interface BufferInputFileOptions extends InputFileOptions {
+  filename: string;
+}
+
 /**
- * A local file to upload to Telegram. Pass a path or a `ReadStream` as any
- * file field (`photo`, `document`, a media item's `media`, …) and the request
- * is sent as `multipart/form-data` automatically. Use a `file_id`/URL string
- * instead to reuse or link a remote file without uploading.
+ * A local file to upload to Telegram. Only **local** sources are wrapped — a
+ * remote URL or a `file_id` is just a string (Telegram resolves it), so you pass
+ * those bare:
  *
  * ```ts
- * message.answerPhoto(new InputFile('./cat.jpg'));
+ * message.answerPhoto(new InputFile('./cat.jpg'));            // upload a path
+ * message.answerPhoto(new InputFile(bytes, { filename: 'c.jpg' })); // a buffer
+ * message.answerPhoto(new InputFile(createReadStream('./c.jpg')));  // a stream
+ * message.answerPhoto('https://example.com/cat.jpg');          // remote URL
+ * message.answerPhoto('AgACAgIAAx...');                        // file_id
  * ```
+ *
+ * Uploads always go out as `multipart/form-data`, with the file name and MIME
+ * type inferred. To reuse a `file_id` after the first upload, use
+ * {@link CachedFile} instead.
  */
 export class InputFile {
-  constructor(readonly file: string | ReadStream, readonly filename?: string) {
-    if (!filename && typeof file === 'string') {
-      this.filename = basename(file);
+  private static readonly DEFAULT_MIME = 'application/octet-stream';
+
+  private static readonly MIME_BY_EXT: Readonly<Record<string, string>> = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.svg': 'image/svg+xml',
+    '.mp4': 'video/mp4',
+    '.mov': 'video/quicktime',
+    '.webm': 'video/webm',
+    '.mp3': 'audio/mpeg',
+    '.ogg': 'audio/ogg',
+    '.oga': 'audio/ogg',
+    '.m4a': 'audio/mp4',
+    '.wav': 'audio/wav',
+    '.pdf': 'application/pdf',
+    '.zip': 'application/zip',
+    '.txt': 'text/plain',
+  };
+
+  /** The file name Telegram sees. */
+  readonly filename?: string;
+  private readonly contentType?: string;
+  private readonly source: InputSource;
+
+  constructor(path: string, options?: InputFileOptions);
+  constructor(stream: ReadStream, options?: InputFileOptions);
+  constructor(data: Buffer | Uint8Array, options: BufferInputFileOptions);
+  constructor(
+    source: string | ReadStream | Buffer | Uint8Array,
+    options?: InputFileOptions,
+  ) {
+    if (typeof source === 'string') {
+      this.source = { kind: SourceKind.Path, path: source };
+      this.filename = options?.filename ?? basename(source);
+    } else if (source instanceof ReadStream) {
+      this.source = { kind: SourceKind.Stream, stream: source };
+      this.filename = options?.filename ?? InputFile.streamFilename(source);
+    } else {
+      if (!options?.filename) {
+        throw new Error(
+          'A buffer upload needs a filename so Telegram can name the file: new InputFile(bytes, { filename }).',
+        );
+      }
+      this.source = { kind: SourceKind.Buffer, data: source };
+      this.filename = options.filename;
+    }
+    this.contentType =
+      options?.contentType ??
+      (this.filename ? InputFile.mimeFor(this.filename) : undefined);
+  }
+
+  /**
+   * A stable identity for the file-id cache, or `undefined` when this file isn't
+   * cached. The base never caches; {@link CachedFile} overrides this.
+   */
+  get cacheKey(): string | undefined {
+    return undefined;
+  }
+
+  /** The uploadable bytes as a `Blob`. */
+  async toRaw(): Promise<Blob> {
+    const source = this.source;
+    const options = this.contentType ? { type: this.contentType } : undefined;
+    switch (source.kind) {
+      case SourceKind.Path:
+        return new Blob([await readFile(source.path)], options);
+      case SourceKind.Buffer:
+        return new Blob([source.data], options);
+      case SourceKind.Stream: {
+        const chunks: Buffer[] = [];
+        for await (const chunk of source.stream) {
+          chunks.push(chunk);
+        }
+        return new Blob([Buffer.concat(chunks)], options);
+      }
     }
   }
 
-  async toRaw() {
-    const file = this.file;
-    if (typeof file === 'string') {
-      return new Blob([await readFile(file)], { type: 'image/jpeg' });
-    }
-    const chunks: Buffer[] = [];
-    for await (const chunk of file) {
-      chunks.push(chunk);
-    }
-    const buffer = Buffer.concat(chunks);
-    return new Blob([buffer]);
+  private static mimeFor(filename: string): string {
+    const ext = extname(filename).toLowerCase();
+    return InputFile.MIME_BY_EXT[ext] ?? InputFile.DEFAULT_MIME;
+  }
+
+  private static streamFilename(stream: ReadStream): string | undefined {
+    return typeof stream.path === 'string' ? basename(stream.path) : undefined;
   }
 }

--- a/lib/api/media-group.spec.ts
+++ b/lib/api/media-group.spec.ts
@@ -1,0 +1,56 @@
+import { MediaGroup } from './media-group';
+import { InputFile } from './input-file';
+
+describe('MediaGroup builder', () => {
+  it('accumulates typed items with their tag and options', () => {
+    const group = new MediaGroup()
+      .photo('p_id', { caption: 'A' })
+      .video('v_id', { has_spoiler: true });
+
+    expect(group.size).toBe(2);
+    expect(group.toJSON()).toEqual([
+      { type: 'photo', media: 'p_id', caption: 'A' },
+      { type: 'video', media: 'v_id', has_spoiler: true },
+    ]);
+  });
+
+  it('supports audio and document items', () => {
+    const group = new MediaGroup()
+      .audio('a_id', { performer: 'X' })
+      .document('d_id');
+
+    expect(group.toJSON()).toEqual([
+      { type: 'audio', media: 'a_id', performer: 'X' },
+      { type: 'document', media: 'd_id' },
+    ]);
+  });
+
+  it('carries an InputFile through as the media source', () => {
+    const file = new InputFile('cat.jpg');
+    const group = new MediaGroup().photo(file);
+    expect(group.toJSON()[0].media).toBe(file);
+  });
+
+  it('add() appends pre-built items', () => {
+    const group = new MediaGroup()
+      .photo('p1')
+      .add({ type: 'photo', media: 'p2' }, { type: 'video', media: 'v1' });
+
+    expect(group.toJSON().map((i) => i.media)).toEqual(['p1', 'p2', 'v1']);
+  });
+
+  it('each() appends one item per source value', () => {
+    const urls = ['u1', 'u2', 'u3'];
+    const group = new MediaGroup().each(urls, (g, url) => g.photo(url));
+
+    expect(group.size).toBe(3);
+    expect(group.toJSON().map((i) => i.media)).toEqual(urls);
+  });
+
+  it('toJSON() returns a snapshot that does not alias the internal array', () => {
+    const group = new MediaGroup().photo('p1');
+    const snapshot = group.toJSON();
+    snapshot.push({ type: 'photo', media: 'rogue' });
+    expect(group.size).toBe(1);
+  });
+});

--- a/lib/api/media-group.ts
+++ b/lib/api/media-group.ts
@@ -1,0 +1,93 @@
+import { InputFile } from './input-file';
+import {
+  InputMediaAudio,
+  InputMediaDocument,
+  InputMediaPhoto,
+  InputMediaVideo,
+} from './input-media';
+
+/** A media item valid inside a Telegram album (`sendMediaGroup`). */
+export type AlbumItem =
+  | InputMediaAudio
+  | InputMediaDocument
+  | InputMediaPhoto
+  | InputMediaVideo;
+
+/** Per-item options — everything on an item except its `type` tag and `media` source. */
+type PhotoOptions = Omit<InputMediaPhoto, 'type' | 'media'>;
+type VideoOptions = Omit<InputMediaVideo, 'type' | 'media'>;
+type AudioOptions = Omit<InputMediaAudio, 'type' | 'media'>;
+type DocumentOptions = Omit<InputMediaDocument, 'type' | 'media'>;
+
+/**
+ * Fluent builder for a Telegram album (`sendMediaGroup`). Accumulate items with
+ * `.photo()/.video()/.audio()/.document()`, then hand the builder straight to
+ * `message.answerMediaGroup(...)` / `replyMediaGroup(...)`:
+ *
+ * ```ts
+ * const album = new MediaGroup()
+ *   .photo(new InputFile('a.jpg'), { caption: 'A' })
+ *   .video('https://example.com/v.mp4');
+ * message.answerMediaGroup(album);
+ * ```
+ *
+ * Telegram only allows mixing photos and videos in one album; audio-only and
+ * document-only albums are also valid. `JSON.stringify` and the multipart
+ * serializer both call `toJSON()`, so the builder is accepted anywhere the raw
+ * item array is.
+ */
+export class MediaGroup {
+  private static readonly TYPE = {
+    photo: 'photo',
+    video: 'video',
+    audio: 'audio',
+    document: 'document',
+  } as const;
+
+  private readonly items: AlbumItem[] = [];
+
+  photo(media: string | InputFile, options?: PhotoOptions): this {
+    this.items.push({ type: MediaGroup.TYPE.photo, media, ...options });
+    return this;
+  }
+
+  video(media: string | InputFile, options?: VideoOptions): this {
+    this.items.push({ type: MediaGroup.TYPE.video, media, ...options });
+    return this;
+  }
+
+  audio(media: string | InputFile, options?: AudioOptions): this {
+    this.items.push({ type: MediaGroup.TYPE.audio, media, ...options });
+    return this;
+  }
+
+  document(media: string | InputFile, options?: DocumentOptions): this {
+    this.items.push({ type: MediaGroup.TYPE.document, media, ...options });
+    return this;
+  }
+
+  /** Append already-built album items. */
+  add(...items: AlbumItem[]): this {
+    this.items.push(...items);
+    return this;
+  }
+
+  /** Append one item per source value via a builder callback (dynamic albums). */
+  each<T>(
+    items: readonly T[],
+    build: (group: this, item: T, index: number) => void,
+  ): this {
+    items.forEach((item, index) => build(this, item, index));
+    return this;
+  }
+
+  /** How many items have accumulated so far. */
+  get size(): number {
+    return this.items.length;
+  }
+
+  /** The raw item array — passable anywhere `sendMediaGroup`'s `media` is. */
+  toJSON(): AlbumItem[] {
+    return [...this.items];
+  }
+}

--- a/lib/api/methods/edit-message-media.ts
+++ b/lib/api/methods/edit-message-media.ts
@@ -1,4 +1,6 @@
 import { ApiMethod } from './api-method';
+import { Message } from '../../events';
+import type { BotService } from '../bot.service';
 import { hasInputFile } from '../form-data';
 import type {
   RawInlineKeyboardMarkup,
@@ -21,7 +23,7 @@ export interface EditMessageMediaOptions {
  */
 export class EditMessageMedia extends ApiMethod<
   EditMessageMediaOptions,
-  RawMessage | boolean
+  Message | true
 > {
   readonly method = 'editMessageMedia';
 
@@ -33,5 +35,11 @@ export class EditMessageMedia extends ApiMethod<
 
   get hasMedia(): boolean {
     return hasInputFile(this.payload);
+  }
+
+  wrap(raw: unknown, bot: BotService): Message | true {
+    return typeof raw === 'object' && raw !== null
+      ? new Message(bot, raw as Partial<RawMessage>)
+      : true;
   }
 }

--- a/lib/builtins/file-id-cache/file-id-cache.interceptor.spec.ts
+++ b/lib/builtins/file-id-cache/file-id-cache.interceptor.spec.ts
@@ -1,0 +1,180 @@
+import { lastValueFrom, of } from 'rxjs';
+
+import { FileIdCacheInterceptor } from './file-id-cache.interceptor';
+import {
+  defaultFileIdCacheKey,
+  FileIdCacheSettings,
+} from './file-id-cache.types';
+import { InputFile } from '../../api/input-file';
+import { CachedFile } from '../../api/cached-file';
+import { ApiExecutionContext } from '../../api/request';
+import { ApiMethod } from '../../api/methods';
+
+/** A store that records every write, for asserting cache hits/misses. */
+function fakeStore() {
+  const saved = new Map<string, string>();
+  const store = {
+    get: (key: string): string | undefined => saved.get(key),
+    set: (key: string, value: unknown): void => {
+      saved.set(key, value as string);
+    },
+    delete: (key: string): void => {
+      saved.delete(key);
+    },
+  };
+  return { store, saved };
+}
+
+function settingsWith(
+  store: FileIdCacheSettings['store'],
+): FileIdCacheSettings {
+  return { store, botName: 'bot', key: defaultFileIdCacheKey };
+}
+
+function context(
+  method: string,
+  payload: Record<string, unknown>,
+  isMedia = true,
+) {
+  const request = { method, payload, token: 'T' };
+  // Media method classes expose a `hasMedia` accessor; the interceptor gates on
+  // its presence, so the fake mirrors that.
+  const command = isMedia ? { method, hasMedia: false } : { method };
+  const ctx: ApiExecutionContext = {
+    getRequest: () => request,
+    getMethod: () => command as unknown as ApiMethod<unknown, unknown>,
+    getSignal: () => undefined,
+    getType: () => 'telegram:api',
+  };
+  return { ctx, request };
+}
+
+async function send(
+  interceptor: FileIdCacheInterceptor,
+  ctx: ApiExecutionContext,
+  result: unknown,
+): Promise<unknown> {
+  const observable = await interceptor.intercept(ctx, {
+    handle: () => of(result),
+  });
+  return lastValueFrom(observable);
+}
+
+describe('FileIdCacheInterceptor', () => {
+  it('leaves a plain (uncached) InputFile alone', async () => {
+    const { store, saved } = fakeStore();
+    const interceptor = new FileIdCacheInterceptor(settingsWith(store));
+    const { ctx, request } = context('sendDocument', {
+      chat_id: 1,
+      document: new InputFile('/x/report.pdf'), // not a CachedFile
+    });
+
+    await send(interceptor, ctx, { document: { file_id: 'DOC1' } });
+
+    expect(saved.size).toBe(0);
+    expect(request.payload.document).toBeInstanceOf(InputFile);
+  });
+
+  it('skips a non-media method without scanning the payload', async () => {
+    const { store, saved } = fakeStore();
+    const interceptor = new FileIdCacheInterceptor(settingsWith(store));
+    // sendMessage exposes no `hasMedia` accessor — the gate short-circuits.
+    const { ctx } = context('sendMessage', { chat_id: 1, text: 'hi' }, false);
+
+    const result = await send(interceptor, ctx, { message_id: 7 });
+
+    expect(result).toEqual({ message_id: 7 });
+    expect(saved.size).toBe(0);
+  });
+
+  describe('miss (a CachedFile)', () => {
+    it('uploads and caches the returned file_id under bot:method:source', async () => {
+      const { store, saved } = fakeStore();
+      const interceptor = new FileIdCacheInterceptor(settingsWith(store));
+      const { ctx, request } = context('sendDocument', {
+        chat_id: 1,
+        document: new CachedFile('/x/report.pdf'),
+      });
+
+      await send(interceptor, ctx, { document: { file_id: 'DOC1' } });
+
+      // The file stayed an upload (payload not rewritten).
+      expect(request.payload.document).toBeInstanceOf(InputFile);
+      expect(saved.get('nbot:sendDocument:/x/report.pdf')).toBe('DOC1');
+    });
+
+    it('picks the largest size for a photo (rich Photo wrapper)', async () => {
+      const { store, saved } = fakeStore();
+      const interceptor = new FileIdCacheInterceptor(settingsWith(store));
+      const { ctx } = context('sendPhoto', {
+        chat_id: 1,
+        photo: new CachedFile('/p.jpg'),
+      });
+
+      await send(interceptor, ctx, {
+        photo: {
+          sizes: [
+            { file_id: 'small', width: 1, height: 1 },
+            { file_id: 'big', width: 10, height: 10 },
+          ],
+        },
+      });
+
+      expect(saved.get('nbot:sendPhoto:/p.jpg')).toBe('big');
+    });
+
+    it('picks the largest size for a raw PhotoSize array', async () => {
+      const { store, saved } = fakeStore();
+      const interceptor = new FileIdCacheInterceptor(settingsWith(store));
+      const { ctx } = context('sendPhoto', {
+        chat_id: 1,
+        photo: new CachedFile('/p.jpg'),
+      });
+
+      await send(interceptor, ctx, {
+        photo: [
+          { file_id: 'a', width: 1, height: 1 },
+          { file_id: 'b', width: 5, height: 5 },
+        ],
+      });
+
+      expect(saved.get('nbot:sendPhoto:/p.jpg')).toBe('b');
+    });
+
+    it('caches only the primary file, never a thumbnail', async () => {
+      const { store, saved } = fakeStore();
+      const interceptor = new FileIdCacheInterceptor(settingsWith(store));
+      const { ctx } = context('sendVideo', {
+        chat_id: 1,
+        video: new CachedFile('/v.mp4'),
+        thumbnail: new CachedFile('/t.jpg'),
+      });
+
+      await send(interceptor, ctx, { video: { file_id: 'V' } });
+
+      expect(saved.get('nbot:sendVideo:/v.mp4')).toBe('V');
+      expect(saved.has('nbot:sendVideo:/t.jpg')).toBe(false);
+    });
+  });
+
+  describe('hit', () => {
+    it('rewrites the payload to the cached file_id string and does not re-upload', async () => {
+      const { store, saved } = fakeStore();
+      saved.set('nbot:sendPhoto:/logo.png', 'CACHED');
+      const interceptor = new FileIdCacheInterceptor(settingsWith(store));
+      const { ctx, request } = context('sendPhoto', {
+        chat_id: 1,
+        photo: new CachedFile('/logo.png'),
+      });
+
+      await send(interceptor, ctx, {
+        photo: { sizes: [{ file_id: 'NEW', width: 1, height: 1 }] },
+      });
+
+      // The upload is replaced by the bare file_id string.
+      expect(request.payload.photo).toBe('CACHED');
+      // The cache is not overwritten on a hit.
+      expect(saved.get('nbot:sendPhoto:/logo.png')).toBe('CACHED');
+    });
+  });
+});

--- a/lib/builtins/file-id-cache/file-id-cache.interceptor.ts
+++ b/lib/builtins/file-id-cache/file-id-cache.interceptor.ts
@@ -1,0 +1,181 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { type Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+import {
+  ApiCallHandler,
+  ApiExecutionContext,
+  ApiInterceptor,
+} from '../../api/request';
+import { InputFile } from '../../api/input-file';
+import { KeyValueStore } from '../../store';
+import {
+  FILE_ID_CACHE_SETTINGS,
+  FileIdCacheSettings,
+} from './file-id-cache.types';
+
+/**
+ * Reuses a Telegram `file_id` across sends of the same file. On the first send
+ * of a local/URL file the upload happens normally; the returned `file_id` is
+ * cached, and later sends of the same source go out as that `file_id` — no bytes
+ * re-uploaded, no URL re-fetched. A big win for static media (logos, repeated
+ * photos).
+ *
+ * An ordinary {@link ApiInterceptor} sitting just before the throttler (so a
+ * cache hit that turns an upload into a `file_id` send still throttles) — no
+ * privileged core. It only acts on a `new CachedFile(path)` source; every other
+ * send passes through, so the cache is opt-in per file with no global switch.
+ *
+ * Scope: a single primary media file per send (`sendPhoto`, `sendVideo`,
+ * `sendDocument`, …). Albums (`sendMediaGroup`) and secondary files
+ * (`thumbnail`/`cover`, whose `file_id` Telegram doesn't echo) are not cached.
+ */
+@Injectable()
+export class FileIdCacheInterceptor implements ApiInterceptor {
+  /** Secondary file fields whose `file_id` Telegram doesn't return — never cache these. */
+  private static readonly SECONDARY_FIELDS: ReadonlySet<string> = new Set([
+    'thumbnail',
+    'cover',
+  ]);
+
+  /**
+   * The accessor only media-capable method classes (`sendPhoto`, `sendVideo`, …)
+   * carry — the cheap O(1) gate that lets every non-media send (text, edits,
+   * callbacks) skip the payload scan. Checked with `in` so it never invokes the
+   * getter.
+   */
+  private static readonly MEDIA_METHOD_MARKER = 'hasMedia';
+
+  private readonly logger = new Logger(FileIdCacheInterceptor.name);
+
+  constructor(
+    @Inject(FILE_ID_CACHE_SETTINGS)
+    private readonly settings: FileIdCacheSettings,
+  ) {}
+
+  async intercept(
+    context: ApiExecutionContext,
+    next: ApiCallHandler,
+  ): Promise<Observable<unknown>> {
+    const method = context.getMethod();
+    // Only a media-capable method can carry a cacheable file — skip the payload
+    // scan for everything else (the common case pays nothing).
+    if (!(FileIdCacheInterceptor.MEDIA_METHOD_MARKER in method)) {
+      return next.handle();
+    }
+
+    const settings = this.settings;
+    const request = context.getRequest();
+    const slot = this.cacheableSlot(request.payload);
+    if (!slot || slot.file.cacheKey === undefined) {
+      return next.handle();
+    }
+
+    const key = settings.key({
+      botName: settings.botName,
+      method: method.method,
+      field: slot.field,
+      source: slot.file.cacheKey,
+    });
+    if (key === undefined) {
+      return next.handle();
+    }
+
+    const cached = await settings.store.get(key);
+    if (typeof cached === 'string') {
+      // Hit: swap the upload for the cached file_id (a bare string Telegram
+      // resolves), so the bytes are never read or re-uploaded.
+      request.payload[slot.field] = cached;
+      return next.handle();
+    }
+
+    // Miss: let it upload, then remember the returned file_id for next time.
+    return next.handle().pipe(
+      tap((result) => {
+        const fileId = this.extractFileId(result, slot.field);
+        if (fileId !== undefined) {
+          void this.persist(settings.store, key, fileId);
+        }
+      }),
+    );
+  }
+
+  /** The first top-level payload field carrying a cacheable file, if any. */
+  private cacheableSlot(
+    payload: Record<string, unknown>,
+  ): { field: string; file: InputFile } | undefined {
+    for (const [field, value] of Object.entries(payload)) {
+      if (FileIdCacheInterceptor.SECONDARY_FIELDS.has(field)) {
+        continue;
+      }
+      if (value instanceof InputFile && value.cacheKey !== undefined) {
+        return { field, file: value };
+      }
+    }
+    return undefined;
+  }
+
+  /** Pull the just-sent file's `file_id` out of the result message. */
+  private extractFileId(result: unknown, field: string): string | undefined {
+    if (result === null || typeof result !== 'object') {
+      return undefined;
+    }
+    const media = (result as Record<string, unknown>)[field];
+    if (media === null || typeof media !== 'object') {
+      return undefined;
+    }
+    // A photo is several sizes — a raw `PhotoSize[]` or the rich `Photo`
+    // wrapper's `sizes`. Cache the highest-resolution size's id.
+    const sizes = Array.isArray(media)
+      ? media
+      : (media as { sizes?: unknown }).sizes;
+    if (Array.isArray(sizes)) {
+      return this.largestFileId(sizes);
+    }
+    const fileId = (media as { file_id?: unknown }).file_id;
+    return typeof fileId === 'string' ? fileId : undefined;
+  }
+
+  private largestFileId(sizes: unknown[]): string | undefined {
+    let best:
+      | { file_id?: unknown; width?: number; height?: number }
+      | undefined;
+    for (const size of sizes) {
+      if (size === null || typeof size !== 'object') {
+        continue;
+      }
+      const candidate = size as {
+        file_id?: unknown;
+        width?: number;
+        height?: number;
+      };
+      if (best === undefined || this.area(candidate) > this.area(best)) {
+        best = candidate;
+      }
+    }
+    return best !== undefined && typeof best.file_id === 'string'
+      ? best.file_id
+      : undefined;
+  }
+
+  private area(size: { width?: number; height?: number }): number {
+    return (size.width ?? 0) * (size.height ?? 0);
+  }
+
+  /** Best-effort store write — a cache failure must never break the send. */
+  private async persist(
+    store: KeyValueStore,
+    key: string,
+    fileId: string,
+  ): Promise<void> {
+    try {
+      await store.set(key, fileId);
+    } catch (error) {
+      this.logger.warn(
+        `Could not cache a file_id — ${
+          error instanceof Error ? error.message : String(error)
+        }. The next send re-uploads instead.`,
+      );
+    }
+  }
+}

--- a/lib/builtins/file-id-cache/file-id-cache.types.spec.ts
+++ b/lib/builtins/file-id-cache/file-id-cache.types.spec.ts
@@ -1,0 +1,45 @@
+import { MemoryStore, KeyValueStore } from '../../store';
+import {
+  defaultFileIdCacheKey,
+  resolveFileIdCacheSettings,
+} from './file-id-cache.types';
+
+describe('resolveFileIdCacheSettings', () => {
+  it('fills defaults when no options are given (in-memory store, default key)', () => {
+    const settings = resolveFileIdCacheSettings(undefined, 'bot');
+    expect(settings.store).toBeInstanceOf(MemoryStore);
+    expect(settings.botName).toBe('bot');
+    expect(settings.key).toBe(defaultFileIdCacheKey);
+  });
+
+  it('uses a supplied store and key override', () => {
+    const store: KeyValueStore = new MemoryStore();
+    const key = (): string => 'custom';
+    const settings = resolveFileIdCacheSettings({ store, key }, 'bot');
+    expect(settings.store).toBe(store);
+    expect(settings.key).toBe(key);
+  });
+});
+
+describe('defaultFileIdCacheKey', () => {
+  it('is scoped by bot and method so ids never cross-contaminate', () => {
+    expect(
+      defaultFileIdCacheKey({
+        botName: 'bot',
+        method: 'sendPhoto',
+        field: 'photo',
+        source: '/logo.png',
+      }),
+    ).toBe('nbot:sendPhoto:/logo.png');
+
+    // Same file, different method → different key (photo id ≠ document id).
+    expect(
+      defaultFileIdCacheKey({
+        botName: 'bot',
+        method: 'sendDocument',
+        field: 'document',
+        source: '/logo.png',
+      }),
+    ).toBe('nbot:sendDocument:/logo.png');
+  });
+});

--- a/lib/builtins/file-id-cache/file-id-cache.types.ts
+++ b/lib/builtins/file-id-cache/file-id-cache.types.ts
@@ -1,0 +1,92 @@
+import { KeyValueStore, MemoryStore } from '../../store';
+
+/** The pieces a file-id cache key is built from. */
+export interface FileIdCacheKeyInput {
+  /** The bot's name — `file_id`s are bot-specific, so the key must scope by it. */
+  botName: string;
+  /**
+   * The Bot API method (e.g. `sendPhoto`). The same bytes sent as a photo vs a
+   * document get different, non-interchangeable `file_id`s, so the method scopes
+   * the key.
+   */
+  method: string;
+  /** The payload field holding the file (e.g. `photo`, `document`). */
+  field: string;
+  /** The file's stable source identity — its path or URL. */
+  source: string;
+}
+
+/**
+ * The `fileIdCache` option on `NestgramModule`/`BotModule` — purely the cache's
+ * backing config. Caching itself is opt-in per file (use `new CachedFile(path)`),
+ * so this is only needed to swap the default in-memory store.
+ *
+ * Cache only **trusted, low-cardinality** paths. A `new CachedFile()` over a
+ * user-controlled path on the unbounded in-memory store mints a permanent entry
+ * per distinct path and can grow without limit: set a `ttl` or supply a
+ * bounded/external `store` for those.
+ */
+export interface FileIdCacheOptions {
+  /** Where `file_id`s are stored. Defaults to a process-local in-memory store. */
+  store?: KeyValueStore;
+  /**
+   * TTL (ms) for the default in-memory store — also the guardrail against
+   * unbounded growth when sources are many. Ignored when a custom `store` is
+   * supplied (that store owns its own expiry).
+   */
+  ttl?: number;
+  /**
+   * Override the cache key — e.g. fold in a content hash to auto-invalidate when
+   * a file at a path changes. Return `undefined` to skip caching this call. Keep
+   * `method` in the key (the default does): a `file_id` minted for one method
+   * can be invalid for another (e.g. `setChatPhoto` rejects a `sendPhoto` id).
+   */
+  key?: (input: FileIdCacheKeyInput) => string | undefined;
+}
+
+/** {@link FileIdCacheOptions} with defaults resolved. */
+export interface FileIdCacheSettings {
+  store: KeyValueStore;
+  botName: string;
+  key: (input: FileIdCacheKeyInput) => string | undefined;
+}
+
+/**
+ * DI token for the resolved {@link FileIdCacheSettings}. Provided by `BotModule`
+ * from the `fileIdCache` option (or `null` when omitted); the interceptor in the
+ * pipeline injects it and stays a passthrough when it's `null`.
+ */
+export const FILE_ID_CACHE_SETTINGS = 'nestgram:file_id_cache_settings';
+
+const KEY_SEPARATOR = ':';
+const BOT_PREFIX = 'n';
+
+/**
+ * The default key: `n<botName>:<method>:<source>`. The bot name keeps a shared
+ * store safe across bots; the method keeps a photo's `file_id` from being reused
+ * as a document's (Telegram returns different ids per kind). `source` (a path or
+ * URL, which may itself contain `:`) stays the terminal segment so it can't
+ * collide with the fixed prefix — keep it last if you extend this.
+ */
+export function defaultFileIdCacheKey(input: FileIdCacheKeyInput): string {
+  return [`${BOT_PREFIX}${input.botName}`, input.method, input.source].join(
+    KEY_SEPARATOR,
+  );
+}
+
+/**
+ * Resolves the `fileIdCache` option into settings, filling the defaults (a
+ * process-local in-memory store, the default key). Always returns settings —
+ * the cache is gated per file by the `{ cache: true }` marker, not globally, so
+ * an unmarked send simply passes through.
+ */
+export function resolveFileIdCacheSettings(
+  options: FileIdCacheOptions | undefined,
+  botName: string,
+): FileIdCacheSettings {
+  return {
+    store: options?.store ?? new MemoryStore(options?.ttl),
+    botName,
+    key: options?.key ?? defaultFileIdCacheKey,
+  };
+}

--- a/lib/builtins/file-id-cache/index.ts
+++ b/lib/builtins/file-id-cache/index.ts
@@ -1,0 +1,2 @@
+export * from './file-id-cache.interceptor';
+export * from './file-id-cache.types';

--- a/lib/builtins/index.ts
+++ b/lib/builtins/index.ts
@@ -2,6 +2,7 @@ export * from './throttle';
 export * from './parse-mode';
 export * from './rich-messages';
 export * from './ignore-not-modified';
+export * from './file-id-cache';
 export * from './token-validation';
 export * from './auto-answer';
 export * from './reply-exception';

--- a/lib/engine/execution/result-handler.spec.ts
+++ b/lib/engine/execution/result-handler.spec.ts
@@ -5,6 +5,7 @@ import { TelegramExecutionContext } from '../context';
 import { BotService } from '../../api';
 import {
   ApiMethod,
+  EditMessageMedia,
   EditMessageReplyMarkup,
   EditMessageText,
   GetMe,
@@ -128,6 +129,22 @@ describe('ResultHandler', () => {
         chat_id: 99,
         message_id: 555,
         text: 'updated',
+      });
+    });
+
+    it('fills chat_id/message_id on an untargeted editMessageMedia from the callback', async () => {
+      await handler.handle(
+        new EditMessageMedia({ media: { type: 'photo', media: 'file_id' } }),
+        callbackCtx(bot),
+      );
+
+      expect(called).toHaveLength(1);
+      const command = called[0] as EditMessageMedia;
+      expect(command).toBeInstanceOf(EditMessageMedia);
+      expect(command.payload).toMatchObject({
+        chat_id: 99,
+        message_id: 555,
+        media: { type: 'photo', media: 'file_id' },
       });
     });
 

--- a/lib/engine/execution/result-handler.ts
+++ b/lib/engine/execution/result-handler.ts
@@ -4,6 +4,7 @@ import { TelegramExecutionContext } from '../context/telegram-execution-context'
 import { TelegramEvent } from '../context/event-factory';
 import {
   ApiMethod,
+  EditMessageMedia,
   EditMessageReplyMarkup,
   EditMessageText,
 } from '../../api/methods';
@@ -18,7 +19,10 @@ interface Answerable {
 }
 
 /** The edit-in-place commands that auto-target the current callback message. */
-type EditInPlaceMethod = EditMessageText | EditMessageReplyMarkup;
+type EditInPlaceMethod =
+  | EditMessageText
+  | EditMessageReplyMarkup
+  | EditMessageMedia;
 
 /**
  * Applies the return-value contract for handlers, after the invoker returns:
@@ -129,7 +133,8 @@ export class ResultHandler {
   ): method is EditInPlaceMethod {
     return (
       method instanceof EditMessageText ||
-      method instanceof EditMessageReplyMarkup
+      method instanceof EditMessageReplyMarkup ||
+      method instanceof EditMessageMedia
     );
   }
 

--- a/lib/events/events.spec.ts
+++ b/lib/events/events.spec.ts
@@ -2,7 +2,7 @@ import { Logger } from '@nestjs/common';
 
 import { Message } from './message';
 import { CallbackQuery } from './callback-query';
-import { BotService } from '../api';
+import { BotService, MediaGroup } from '../api';
 
 interface Call {
   method: string;
@@ -24,9 +24,19 @@ function fakeBot(): { bot: BotService; calls: Call[] } {
     answerCallbackQuery: record('answerCallbackQuery'),
     editMessageText: record('editMessageText'),
     editMessageReplyMarkup: record('editMessageReplyMarkup'),
+    editMessageMedia: record('editMessageMedia'),
     deleteMessage: record('deleteMessage'),
     forwardMessage: record('forwardMessage'),
     copyMessage: record('copyMessage'),
+    sendVideo: record('sendVideo'),
+    sendAudio: record('sendAudio'),
+    sendDocument: record('sendDocument'),
+    sendAnimation: record('sendAnimation'),
+    sendVoice: record('sendVoice'),
+    sendVideoNote: record('sendVideoNote'),
+    sendSticker: record('sendSticker'),
+    setMessageReaction: record('setMessageReaction'),
+    sendMediaGroup: record('sendMediaGroup'),
   } as unknown as BotService;
 
   return { bot, calls };
@@ -87,6 +97,16 @@ describe('Message actions', () => {
     });
   });
 
+  it('editMedia() edits this message media in place', () => {
+    const { bot, calls } = fakeBot();
+    const media = { type: 'photo' as const, media: 'file_id' };
+    message(bot).editMedia(media);
+    expect(calls[0]).toEqual({
+      method: 'editMessageMedia',
+      args: [1, 5, media, undefined],
+    });
+  });
+
   it('delete() removes this message', () => {
     const { bot, calls } = fakeBot();
     message(bot).delete();
@@ -111,6 +131,68 @@ describe('Message actions', () => {
     expect(calls[0]).toEqual({
       method: 'copyMessage',
       args: [99, 1, 5, undefined],
+    });
+  });
+
+  it('answerVideo() sends a video to the same chat', () => {
+    const { bot, calls } = fakeBot();
+    message(bot).answerVideo('file_id', { caption: 'hi' });
+    expect(calls[0]).toEqual({
+      method: 'sendVideo',
+      args: [1, 'file_id', { caption: 'hi' }],
+    });
+  });
+
+  it('answerSticker() sends a sticker to the same chat', () => {
+    const { bot, calls } = fakeBot();
+    message(bot).answerSticker('sticker_id');
+    expect(calls[0]).toEqual({
+      method: 'sendSticker',
+      args: [1, 'sticker_id', undefined],
+    });
+  });
+
+  it('replyDocument() quotes the original message', () => {
+    const { bot, calls } = fakeBot();
+    message(bot).replyDocument('doc_id');
+    expect(calls[0]).toEqual({
+      method: 'sendDocument',
+      args: [1, 'doc_id', { reply_parameters: { message_id: 5 } }],
+    });
+  });
+
+  it('react() sets a single emoji reaction on this message', () => {
+    const { bot, calls } = fakeBot();
+    message(bot).react('🔥');
+    expect(calls[0]).toEqual({
+      method: 'setMessageReaction',
+      args: [1, 5, { reaction: [{ type: 'emoji', emoji: '🔥' }] }],
+    });
+  });
+
+  it('answerMediaGroup() accepts a raw item array', () => {
+    const { bot, calls } = fakeBot();
+    const media = [{ type: 'photo' as const, media: 'p1' }];
+    message(bot).answerMediaGroup(media);
+    expect(calls[0]).toEqual({
+      method: 'sendMediaGroup',
+      args: [1, media, undefined],
+    });
+  });
+
+  it('answerMediaGroup() unwraps a MediaGroup builder to its items', () => {
+    const { bot, calls } = fakeBot();
+    message(bot).answerMediaGroup(new MediaGroup().photo('p1').video('v1'));
+    expect(calls[0]).toEqual({
+      method: 'sendMediaGroup',
+      args: [
+        1,
+        [
+          { type: 'photo', media: 'p1' },
+          { type: 'video', media: 'v1' },
+        ],
+        undefined,
+      ],
     });
   });
 });

--- a/lib/events/message.ts
+++ b/lib/events/message.ts
@@ -1,23 +1,26 @@
 import { TelegramObject } from './telegram-object';
-import { BotService, MethodOptions } from '../api';
+import { AlbumItem, BotService, MediaGroup, MethodOptions } from '../api';
 import {
   CopyMessageOptions,
   DeleteMessageOptions,
+  EditMessageMediaOptions,
   EditMessageReplyMarkupOptions,
   EditMessageTextOptions,
   ForwardMessageOptions,
+  SendAnimationOptions,
+  SendAudioOptions,
+  SendDocumentOptions,
   SendMediaGroupOptions,
   SendMessageOptions,
   SendPhotoOptions,
+  SendStickerOptions,
+  SendVideoNoteOptions,
+  SendVideoOptions,
+  SendVoiceOptions,
+  SetMessageReactionOptions,
 } from '../api/methods';
 import { UpdateType } from '../decorators';
 import { InputFile } from '../api/input-file';
-import {
-  InputMediaAudio,
-  InputMediaDocument,
-  InputMediaPhoto,
-  InputMediaVideo,
-} from '../api/input-media';
 import type { RawInputRichMessage, RawMessage } from './raw-update.types';
 import {
   Animation,
@@ -56,6 +59,14 @@ export interface Message extends Omit<RawMessage, WrappedMedia> {}
   'edited_business_message',
 )
 export class Message extends TelegramObject {
+  /** The `ReactionType` discriminant for a standard emoji reaction. */
+  private static readonly EMOJI_REACTION_TYPE = 'emoji' as const;
+
+  /** Unwrap a `MediaGroup` builder to its raw item array; pass an array through. */
+  private static albumItems(media: AlbumItem[] | MediaGroup): AlbumItem[] {
+    return media instanceof MediaGroup ? media.toJSON() : media;
+  }
+
   // Content (one is present per message). Downloadable media is wrapped into a
   // rich object with `.save(path)` / `.stream()`; non-file content stays raw.
   photo?: Photo;
@@ -101,12 +112,63 @@ export class Message extends TelegramObject {
   }
 
   answerMediaGroup(
-    media: Array<
-      InputMediaAudio | InputMediaDocument | InputMediaPhoto | InputMediaVideo
-    >,
+    media: AlbumItem[] | MediaGroup,
     options?: MethodOptions<SendMediaGroupOptions>,
   ) {
-    return this.botService.sendMediaGroup(this.chat.id, media, options);
+    return this.botService.sendMediaGroup(
+      this.chat.id,
+      Message.albumItems(media),
+      options,
+    );
+  }
+
+  answerVideo(
+    video: string | InputFile,
+    options?: MethodOptions<SendVideoOptions>,
+  ) {
+    return this.botService.sendVideo(this.chat.id, video, options);
+  }
+
+  answerAudio(
+    audio: string | InputFile,
+    options?: MethodOptions<SendAudioOptions>,
+  ) {
+    return this.botService.sendAudio(this.chat.id, audio, options);
+  }
+
+  answerDocument(
+    document: string | InputFile,
+    options?: MethodOptions<SendDocumentOptions>,
+  ) {
+    return this.botService.sendDocument(this.chat.id, document, options);
+  }
+
+  answerAnimation(
+    animation: string | InputFile,
+    options?: MethodOptions<SendAnimationOptions>,
+  ) {
+    return this.botService.sendAnimation(this.chat.id, animation, options);
+  }
+
+  answerVoice(
+    voice: string | InputFile,
+    options?: MethodOptions<SendVoiceOptions>,
+  ) {
+    return this.botService.sendVoice(this.chat.id, voice, options);
+  }
+
+  answerVideoNote(
+    video_note: string | InputFile,
+    options?: MethodOptions<SendVideoNoteOptions>,
+  ) {
+    return this.botService.sendVideoNote(this.chat.id, video_note, options);
+  }
+
+  answerSticker(
+    sticker: string | InputFile,
+    options?: MethodOptions<SendStickerOptions>,
+  ) {
+    return this.botService.sendSticker(this.chat.id, sticker, options);
   }
 
   reply(text: string, options?: MethodOptions<SendMessageOptions>) {
@@ -146,6 +208,20 @@ export class Message extends TelegramObject {
     );
   }
 
+  // Options omit `media`: the content slot already carries it; a second copy via
+  // options would send two media objects.
+  editMedia(
+    media: EditMessageMediaOptions['media'],
+    options?: MethodOptions<Omit<EditMessageMediaOptions, 'media'>>,
+  ) {
+    return this.botService.editMessageMedia(
+      this.chat.id,
+      this.message_id,
+      media,
+      options,
+    );
+  }
+
   replyPhoto(
     photo: string | InputFile,
     options?: MethodOptions<SendPhotoOptions>,
@@ -157,12 +233,84 @@ export class Message extends TelegramObject {
   }
 
   replyMediaGroup(
-    media: Array<
-      InputMediaAudio | InputMediaDocument | InputMediaPhoto | InputMediaVideo
-    >,
+    media: AlbumItem[] | MediaGroup,
     options?: MethodOptions<SendMediaGroupOptions>,
   ) {
-    return this.botService.sendMediaGroup(this.chat.id, media, {
+    return this.botService.sendMediaGroup(
+      this.chat.id,
+      Message.albumItems(media),
+      {
+        reply_parameters: { message_id: this.message_id },
+        ...options,
+      },
+    );
+  }
+
+  replyVideo(
+    video: string | InputFile,
+    options?: MethodOptions<SendVideoOptions>,
+  ) {
+    return this.botService.sendVideo(this.chat.id, video, {
+      reply_parameters: { message_id: this.message_id },
+      ...options,
+    });
+  }
+
+  replyAudio(
+    audio: string | InputFile,
+    options?: MethodOptions<SendAudioOptions>,
+  ) {
+    return this.botService.sendAudio(this.chat.id, audio, {
+      reply_parameters: { message_id: this.message_id },
+      ...options,
+    });
+  }
+
+  replyDocument(
+    document: string | InputFile,
+    options?: MethodOptions<SendDocumentOptions>,
+  ) {
+    return this.botService.sendDocument(this.chat.id, document, {
+      reply_parameters: { message_id: this.message_id },
+      ...options,
+    });
+  }
+
+  replyAnimation(
+    animation: string | InputFile,
+    options?: MethodOptions<SendAnimationOptions>,
+  ) {
+    return this.botService.sendAnimation(this.chat.id, animation, {
+      reply_parameters: { message_id: this.message_id },
+      ...options,
+    });
+  }
+
+  replyVoice(
+    voice: string | InputFile,
+    options?: MethodOptions<SendVoiceOptions>,
+  ) {
+    return this.botService.sendVoice(this.chat.id, voice, {
+      reply_parameters: { message_id: this.message_id },
+      ...options,
+    });
+  }
+
+  replyVideoNote(
+    video_note: string | InputFile,
+    options?: MethodOptions<SendVideoNoteOptions>,
+  ) {
+    return this.botService.sendVideoNote(this.chat.id, video_note, {
+      reply_parameters: { message_id: this.message_id },
+      ...options,
+    });
+  }
+
+  replySticker(
+    sticker: string | InputFile,
+    options?: MethodOptions<SendStickerOptions>,
+  ) {
+    return this.botService.sendSticker(this.chat.id, sticker, {
       reply_parameters: { message_id: this.message_id },
       ...options,
     });
@@ -175,6 +323,14 @@ export class Message extends TelegramObject {
       this.message_id,
       options,
     );
+  }
+
+  /** React to this message with a single emoji (replaces any existing reaction). */
+  react(emoji: string, options?: MethodOptions<SetMessageReactionOptions>) {
+    return this.botService.setMessageReaction(this.chat.id, this.message_id, {
+      reaction: [{ type: Message.EMOJI_REACTION_TYPE, emoji }],
+      ...options,
+    });
   }
 
   /** Forward this message to another chat (returns the forwarded `Message`). */

--- a/tools/codegen/manifest.ts
+++ b/tools/codegen/manifest.ts
@@ -230,6 +230,7 @@ const METHOD_OVERRIDES: Readonly<Record<string, MethodOverride>> = {
   sendMediaGroup: { returnType: 'Message[]', wrap: WRAP_ARRAY },
   editMessageText: { returnType: 'Message | true', wrap: WRAP_EDITABLE },
   editMessageReplyMarkup: { returnType: 'Message | true', wrap: WRAP_EDITABLE },
+  editMessageMedia: { returnType: 'Message | true', wrap: WRAP_EDITABLE },
 };
 
 export function getMethodOverride(


### PR DESCRIPTION
Adds the outbound media layer for v2 — sending files, albums, reactions,
in-place media edits, and a `file_id` cache. Closes ng-73, ng-59, ng-55, ng-74.

## File inputs

- `new InputFile(path | stream | buffer)` — overloaded by source type; uploads
  as `multipart/form-data` with the filename and MIME type inferred. A buffer
  requires a `filename` (enforced by the type).
- Remote files are **bare strings** — a URL or a `file_id` is passed as-is and
  Telegram resolves it, so no wrapper is needed.
- `new CachedFile(path)` — an `InputFile` whose `file_id` is reused after the
  first upload (see the cache below).

## Send sugar (Message event)

- `answer*` / `reply*` for every media kind: photo, video, audio, document,
  voice, animation, video_note, sticker.
- `message.react(emoji)` — wraps `setMessageReaction`.
- `message.editMedia(...)`.

## Albums

- `MediaGroup` fluent builder (`.photo/.video/.audio/.document/.add/.each`).
  `answerMediaGroup` / `replyMediaGroup` accept the builder or a raw item array.

## Editing media in place

- `editMessageMedia` is now a rich editable method (returns `Message | true`)
  and auto-targets the callback message when returned untargeted, matching
  `editMessageText` / a returned keyboard. Manifest `WRAP_EDITABLE` and the
  engine's `isEditInPlace` set are kept in sync.

## file_id cache (ng-74)

- Opt-in **per file** via `CachedFile` — there is no global switch, so a
  user-uploaded file is never cached by accident.
- Implemented as an ordinary `ApiInterceptor` just before the throttler (no
  privileged core). On a hit it sends the cached `file_id`, skipping the upload;
  on a miss it stores the returned id. Keyed `n<bot>:<method>:<source>` (the bot
  scopes a shared store; the method keeps a photo id from being served to a
  document). Non-media sends short-circuit via a `'hasMedia' in method` gate.
- Pluggable store (in-memory default, any `KeyValueStore`). The `fileIdCache`
  option only configures the store / TTL / key strategy.

## How to verify

- `npm run build && npm run lint && npm run generate -- --check && npx jest`
  — all green (115 suites, 892 tests).
- Runnable showcase: `examples/media-gallery` — `/photo` (+ Swap button),
  `/album`, `/doc`, and any text gets a 👍.
- Docs: `docs/media.md`.
