### PR TITLE
chore(website): clear audit highs via lockfile bump

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1742,9 +1742,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.2.tgz",
-      "integrity": "sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==",
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+      "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
@@ -1761,7 +1761,7 @@
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
         "cookie": "^1.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
@@ -2761,9 +2761,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4845,9 +4855,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",


### PR DESCRIPTION
## Problem

The docs site (`website/`) carried dev-dependency audit advisories: 2 high
(astro XSS / Host-header SSRF; vite `launch-editor` / `fs.deny` bypass), 1
moderate (js-yaml merge-key DoS), 1 low (esbuild Windows dev-server file read).

## Change

Upstream shipped patches inside the existing semver ranges, so a plain
`npm audit fix` (no `--force`) resolves them by moving only `package-lock.json`
— `package.json` is untouched:

- astro 6.4.2 → 6.4.8 (clears the astro highs)
- vite → 7.3.5 (clears the vite highs)
- js-yaml 4.1.1 → 4.2.0 (clears the moderate)

## Verify

- `cd website && npm ci && npm run build` — exit 0, indexes the docs pages.
- `npm audit` — 4 (2 high, 1 moderate, 1 low) → 2 low.

The residual 2 low both trace to esbuild 0.27.7 (dev-server arbitrary file read
on Windows). The only `npm audit` remediation is `--force`, which downgrades
astro to 5.x (major breaking) — refused. Dev-only tooling, never shipped
(static `dist/`).
