### PR TITLE
feat(matching): regex capture-group injection (@Matches + named @Param)

### DIFF
--- a/docs/match-predicates.md
+++ b/docs/match-predicates.md
@@ -84,6 +84,53 @@ refresh(query: CallbackQuery) {
 
 :::
 
+## Reading regex captures
+
+A regex `@Hears` or `@Action` can **capture** — read the groups instead of
+re-parsing the text yourself. `@Matches()` injects the whole `RegExpMatchArray`,
+so positional groups come back by index (`match[1]`, `match[2]`):
+
+:::code[calc.router.ts]
+
+```ts
+@Hears(/^add (\d+) (.+)$/)
+add(message: Message, @Matches() match: RegExpMatchArray) {
+  return `Added ${match[1]}: ${match[2]}`;
+}
+```
+
+:::
+
+Prefer a **named group** for a single value with a pipe — it flows into
+`@Param()` exactly like a `@Command('add :amount')` segment:
+
+:::code[calc.router.ts]
+
+```ts
+@Hears(/^add (?<amount>\d+)$/)
+add(message: Message, @Param('amount', ParseIntPipe) amount: number) {
+  return `Added ${amount}`;
+}
+```
+
+:::
+
+Because the `@Command` template and a regex named group feed the **same**
+`@Param`, one handler accepts either spelling — `/add 5` or `add 5` — through a
+single parameter:
+
+:::code[calc.router.ts]
+
+```ts
+@Command('add :amount')
+@Hears(/^add (?<amount>\d+)$/)
+add(message: Message, @Param('amount', ParseIntPipe) amount: number) {
+  return `Added ${amount}`;
+}
+```
+
+:::
+
 ## First match wins
 
 Within a router, Nestgram tries handlers in **declaration order** and runs the

--- a/lib/__target__/target-api.spec.ts
+++ b/lib/__target__/target-api.spec.ts
@@ -74,13 +74,14 @@ describe('Context by wrapping (no mutation)', () => {
 // command-args/command-routing.dispatch.spec.ts.
 
 describe('Not yet implemented (deferred)', () => {
-  it.todo('@Match() injects the RegExpMatchArray for a regex @Action / @Hears');
-  it.todo('message.react(emoji) reacts to the incoming message');
   it.todo('request-scoped providers resolve per update (contextId per update)');
   // Shipped since this checklist was written, now covered by their own specs:
   //   - @Session() backed by a store → sessions/session.integration.spec.ts
   //   - webhook transport → webhook-update-source.spec / webhook.controller.spec
   //   - typed callback-data factory → callback-data.factory.spec / acceptance.spec
+  //   - @Matches() RegExpMatchArray + named groups → @Param for a regex
+  //     @Hears/@Action → decorators/params/matches.decorator.integration.spec.ts
+  //   - message.react(emoji) → events.spec.ts (the media cluster)
   // Polling already dispatches a batch serially (bounded by construction); the
   // open work is webhook fire-and-forget's UNBOUNDED concurrency + per-chat
   // ordering — tracked as a backlog task, not a unit-test gap here.

--- a/lib/decorators/params/index.ts
+++ b/lib/decorators/params/index.ts
@@ -7,6 +7,7 @@ export * from './caption.decorator';
 export * from './payload.decorator';
 export * from './callback-data.decorator';
 export * from './param.decorator';
+export * from './matches.decorator';
 export * from './entity.decorator';
 export * from './session.decorator';
 export * from './locale.decorator';

--- a/lib/decorators/params/matches.decorator.integration.spec.ts
+++ b/lib/decorators/params/matches.decorator.integration.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Exercises `@Matches()` end to end through the real engine (discovery, matching,
+ * the Nest pipeline via ECC) — the whole `RegExpMatchArray` for positional
+ * groups, named groups flowing into `@Param` with a pipe, and the two surfaces
+ * sharing one `@Param` across a stacked `@Command` + regex `@Hears`.
+ */
+import { ParseIntPipe } from '@nestjs/common';
+
+import { Command } from '../listeners/command.decorator';
+import { Hears } from '../listeners/hears.decorator';
+import { Router } from '../injectable/router.decorator';
+import { Matches } from './matches.decorator';
+import { Param } from './param.decorator';
+import { Message } from '../../events/message';
+import { NestgramTestbed } from '../../testing/nestgram-testbed';
+import { updates } from '../../testing/update-factory';
+
+const captured: unknown[] = [];
+
+@Router()
+class CaptureRouter {
+  @Hears(/^add (\d+) (.+)$/)
+  add(_message: Message, @Matches() match: RegExpMatchArray): void {
+    captured.push([Number(match[1]), match[2]]);
+  }
+
+  @Hears(/^double (?<n>\d+)$/)
+  double(_message: Message, @Param('n', ParseIntPipe) n: number): void {
+    captured.push(n * 2);
+  }
+
+  @Hears('ping')
+  ping(
+    _message: Message,
+    @Matches() match: RegExpMatchArray | undefined,
+  ): void {
+    captured.push(match);
+  }
+}
+
+// One `@Param('amount')` serves both routes: `/add 5` (command segment) and
+// `add 5` (regex named group) land the same captured value through it.
+@Router()
+class StackedRouter {
+  @Command('add :amount')
+  @Hears(/^add (?<amount>\d+)$/)
+  add(_message: Message, @Param('amount', ParseIntPipe) amount: number): void {
+    captured.push(amount);
+  }
+}
+
+describe('@Matches', () => {
+  let bot: NestgramTestbed;
+
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  afterEach(async () => {
+    await bot.close();
+  });
+
+  it('injects the whole RegExpMatchArray for positional groups', async () => {
+    bot = await NestgramTestbed.create({ routers: [CaptureRouter] });
+
+    await bot.dispatch(updates.message('add 5 milk'));
+
+    expect(captured).toEqual([[5, 'milk']]);
+  });
+
+  it('routes a named group into @Param with a pipe', async () => {
+    bot = await NestgramTestbed.create({ routers: [CaptureRouter] });
+
+    await bot.dispatch(updates.message('double 7'));
+
+    expect(captured).toEqual([14]);
+  });
+
+  it('is undefined when the matched route is not a regex', async () => {
+    bot = await NestgramTestbed.create({ routers: [CaptureRouter] });
+
+    await bot.dispatch(updates.message('ping'));
+
+    expect(captured).toEqual([undefined]);
+  });
+
+  it('serves one @Param across a stacked @Command and regex @Hears', async () => {
+    bot = await NestgramTestbed.create({ routers: [StackedRouter] });
+
+    await bot.dispatch(updates.message('/add 5')); // command segment
+    await bot.dispatch(updates.message('add 9')); // regex named group
+
+    expect(captured).toEqual([5, 9]);
+  });
+});

--- a/lib/decorators/params/matches.decorator.ts
+++ b/lib/decorators/params/matches.decorator.ts
@@ -1,0 +1,52 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+import { TelegramExecutionContext } from '../../engine/context';
+import { isRegexMatchSource } from '../../engine/matching';
+import { ListenerOptions } from '../listener-options';
+import { Metadata } from '../metadata.enum';
+
+/**
+ * Injects the whole `RegExpMatchArray` captured by a regex `@Hears`/`@Action`,
+ * so positional groups are read by index:
+ *
+ * ```ts
+ * @Hears(/^add (\d+) (.+)$/)
+ * add(message: Message, @Matches() match: RegExpMatchArray) {
+ *   const amount = Number(match[1]);
+ *   const note = match[2];
+ * }
+ * ```
+ *
+ * `match[0]` is the whole match, `match[1..]` the positional groups,
+ * `match.groups` the named ones. For a NAMED group prefer `@Param('amount')` —
+ * it reads `match.groups.amount` and runs a per-parameter pipe, exactly like a
+ * `@Command('add :amount')` segment.
+ *
+ * Extraction runs against the regex of the handler that actually matched, so a
+ * sibling route the matcher only evaluated never bleeds in. `undefined` when the
+ * handler matched through a non-regex route (a string `@Hears`/`@Action`, a
+ * `@Command`, or a custom predicate) — there is no match to read there.
+ */
+export const Matches = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext) => {
+    const tgCtx = TelegramExecutionContext.of(ctx);
+    const listeners: ListenerOptions[] =
+      Reflect.getMetadata(Metadata.LISTENERS, ctx.getHandler()) ?? [];
+
+    // The first regex route that matched wins — a handler carries at most one
+    // capturing route predicate (extra predicates only narrow).
+    for (const listener of listeners) {
+      for (const predicate of listener.predicates ?? []) {
+        if (!isRegexMatchSource(predicate)) {
+          continue;
+        }
+        const match = predicate.extractMatch(tgCtx);
+        if (match !== null) {
+          return match;
+        }
+      }
+    }
+
+    return undefined;
+  },
+);

--- a/lib/engine/matching/action.predicate.spec.ts
+++ b/lib/engine/matching/action.predicate.spec.ts
@@ -38,4 +38,29 @@ describe('ActionPredicate', () => {
       false,
     );
   });
+
+  describe('captures', () => {
+    it('exposes the RegExpMatchArray of a regex pattern (for @Matches)', () => {
+      const buyId = new ActionPredicate(/^buy:(\d+)$/);
+
+      expect(buyId.extractMatch(callbackCtx('buy:42'))?.[1]).toBe('42');
+    });
+
+    it('exposes named groups to @Param via extractParams', () => {
+      const buyId = new ActionPredicate(/^buy:(?<id>\d+)$/);
+
+      expect(buyId.extractParams(callbackCtx('buy:42'))).toEqual({ id: '42' });
+    });
+
+    it('has no captures for any/string data, a non-match, or missing data', () => {
+      expect(new ActionPredicate().extractMatch(callbackCtx('x'))).toBeNull();
+      expect(
+        new ActionPredicate('buy').extractMatch(callbackCtx('buy')),
+      ).toBeNull();
+
+      const buyId = new ActionPredicate(/^buy:(\d+)$/);
+      expect(buyId.extractMatch(callbackCtx('sell'))).toBeNull();
+      expect(buyId.extractMatch(callbackCtx(undefined))).toBeNull();
+    });
+  });
 });

--- a/lib/engine/matching/action.predicate.ts
+++ b/lib/engine/matching/action.predicate.ts
@@ -1,6 +1,10 @@
 import type { TelegramExecutionContext } from '../context/telegram-execution-context';
-import { RoutePredicate } from './route-predicate';
-import { matchesPattern, toStatelessPattern } from './pattern';
+import {
+  RegexMatchSource,
+  RouteParamSource,
+  RoutePredicate,
+} from './route-predicate';
+import { execPattern, matchesPattern, toStatelessPattern } from './pattern';
 
 /**
  * Matches a callback query by its `data` (the `@Action` predicate):
@@ -8,10 +12,15 @@ import { matchesPattern, toStatelessPattern } from './pattern';
  *   - string   -> exact match
  *   - RegExp   -> `pattern.test(data)`
  *
+ * A regex pattern also exposes its captures: the whole `RegExpMatchArray` to
+ * `@Matches()` and any named groups to `@Param()`.
+ *
  * Reads the raw `callback_query.data` off the update, so it needs no rich-event
  * import (which would pull `events` -> `decorators` into a cycle).
  */
-export class ActionPredicate implements RoutePredicate {
+export class ActionPredicate
+  implements RoutePredicate, RegexMatchSource, RouteParamSource
+{
   private readonly data?: string | RegExp;
 
   constructor(data?: string | RegExp) {
@@ -29,5 +38,19 @@ export class ActionPredicate implements RoutePredicate {
     }
 
     return matchesPattern(this.data, data);
+  }
+
+  /** The `RegExpMatchArray` a regex pattern captured from the data, for `@Matches()`. */
+  extractMatch(ctx: TelegramExecutionContext): RegExpMatchArray | null {
+    const data = ctx.update.callback_query?.data;
+    if (this.data === undefined || data === undefined) {
+      return null;
+    }
+    return execPattern(this.data, data);
+  }
+
+  /** Named regex groups exposed to `@Param()`, mirroring `@Action('done/:id')`. */
+  extractParams(ctx: TelegramExecutionContext): Record<string, string> | null {
+    return this.extractMatch(ctx)?.groups ?? null;
   }
 }

--- a/lib/engine/matching/hears.predicate.spec.ts
+++ b/lib/engine/matching/hears.predicate.spec.ts
@@ -31,4 +31,32 @@ describe('HearsPredicate', () => {
   it('does not match when there is no text', () => {
     expect(new HearsPredicate('hi').matches(messageCtx(undefined))).toBe(false);
   });
+
+  describe('captures', () => {
+    it('exposes the RegExpMatchArray of a regex pattern (for @Matches)', () => {
+      const add = new HearsPredicate(/^add (\d+) (.+)$/);
+      const match = add.extractMatch(messageCtx('add 5 milk'));
+
+      expect(match?.[1]).toBe('5');
+      expect(match?.[2]).toBe('milk');
+    });
+
+    it('exposes named groups to @Param via extractParams', () => {
+      const add = new HearsPredicate(/^add (?<amount>\d+)$/);
+
+      expect(add.extractParams(messageCtx('add 5'))).toEqual({ amount: '5' });
+    });
+
+    it('has no captures for a string pattern, a non-match, or missing text', () => {
+      expect(
+        new HearsPredicate('hi').extractMatch(messageCtx('hi')),
+      ).toBeNull();
+
+      const add = new HearsPredicate(/^add (\d+)$/);
+      expect(add.extractMatch(messageCtx('nope'))).toBeNull();
+      expect(add.extractMatch(messageCtx(undefined))).toBeNull();
+      // A positional-only match has no named groups, so @Param sees nothing.
+      expect(add.extractParams(messageCtx('add 5'))).toBeNull();
+    });
+  });
 });

--- a/lib/engine/matching/hears.predicate.ts
+++ b/lib/engine/matching/hears.predicate.ts
@@ -1,12 +1,21 @@
 import type { TelegramExecutionContext } from '../context/telegram-execution-context';
-import { RoutePredicate } from './route-predicate';
-import { matchesPattern, toStatelessPattern } from './pattern';
+import {
+  RegexMatchSource,
+  RouteParamSource,
+  RoutePredicate,
+} from './route-predicate';
+import { execPattern, matchesPattern, toStatelessPattern } from './pattern';
 
 /**
  * Matches message text (the `@Hears` predicate): a string matches exactly, a
  * RegExp is tested against the text (`@Hears('hi')`, `@Hears(/^\d+$/)`).
+ *
+ * A regex pattern also exposes its captures: the whole `RegExpMatchArray` to
+ * `@Matches()` and any named groups to `@Param()`.
  */
-export class HearsPredicate implements RoutePredicate {
+export class HearsPredicate
+  implements RoutePredicate, RegexMatchSource, RouteParamSource
+{
   private readonly pattern: string | RegExp;
 
   constructor(pattern: string | RegExp) {
@@ -20,5 +29,16 @@ export class HearsPredicate implements RoutePredicate {
     }
 
     return matchesPattern(this.pattern, text);
+  }
+
+  /** The `RegExpMatchArray` a regex pattern captured from the text, for `@Matches()`. */
+  extractMatch(ctx: TelegramExecutionContext): RegExpMatchArray | null {
+    const text = ctx.update.message?.text;
+    return text === undefined ? null : execPattern(this.pattern, text);
+  }
+
+  /** Named regex groups exposed to `@Param()`, mirroring `@Command('add :amount')`. */
+  extractParams(ctx: TelegramExecutionContext): Record<string, string> | null {
+    return this.extractMatch(ctx)?.groups ?? null;
   }
 }

--- a/lib/engine/matching/pattern.ts
+++ b/lib/engine/matching/pattern.ts
@@ -20,3 +20,22 @@ export function matchesPattern(
 ): boolean {
   return typeof pattern === 'string' ? value === pattern : pattern.test(value);
 }
+
+/**
+ * Run a pattern for its capture groups: `null` for a string pattern (exact
+ * match — nothing to capture) or a RegExp that doesn't match, otherwise the
+ * `RegExpMatchArray` (`[0]` the whole match, `[1..]` positional groups,
+ * `.groups` the named ones).
+ *
+ * Separate from {@link matchesPattern} so the hot routing path stays a cheap
+ * boolean `.test()` and this allocating `.match()` runs only when a param
+ * (`@Matches()` / a named-group `@Param()`) actually reads the captures. Assumes
+ * a stateless pattern (callers strip `g`/`y` via {@link toStatelessPattern}), so
+ * a non-global `.match()` returns the first match with its groups intact.
+ */
+export function execPattern(
+  pattern: string | RegExp,
+  value: string,
+): RegExpMatchArray | null {
+  return typeof pattern === 'string' ? null : value.match(pattern);
+}

--- a/lib/engine/matching/route-predicate.ts
+++ b/lib/engine/matching/route-predicate.ts
@@ -56,3 +56,21 @@ export const isRouteParamSource = (
   predicate: RoutePredicate,
 ): predicate is RoutePredicate & RouteParamSource =>
   typeof (predicate as Partial<RouteParamSource>).extractParams === 'function';
+
+/**
+ * A predicate that captured a `RegExpMatchArray` from the update it matched — a
+ * regex `@Hears(/add (\d+)/)` or `@Action(/buy:(\d+)/)`. `@Matches()` asks the
+ * matched handler's predicates for it and injects the whole array, so a handler
+ * reads positional groups by index (`m[1]`). Named groups `(?<id>…)`
+ * additionally surface through `@Param('id')` via {@link RouteParamSource}, just
+ * like a `@Command('add :amount')` segment.
+ */
+export interface RegexMatchSource {
+  extractMatch(ctx: TelegramExecutionContext): RegExpMatchArray | null;
+}
+
+/** Whether a predicate captured a regex match (see {@link RegexMatchSource}). */
+export const isRegexMatchSource = (
+  predicate: RoutePredicate,
+): predicate is RoutePredicate & RegexMatchSource =>
+  typeof (predicate as Partial<RegexMatchSource>).extractMatch === 'function';


### PR DESCRIPTION
## Problem

A regex `@Hears(/.../)` / `@Action(/.../)` matched via `.test()` (boolean), so
capture groups were discarded — a handler could not read `(\d+)` from
`@Hears(/add (\d+)/)`.

## Change

Regex predicates now expose their captures, reusing the existing
`RouteParamSource` / `@Param` seam:

- New `@Matches()` param decorator injects the whole `RegExpMatchArray`
  (positional groups by index: `m[1]`, `m[2]`).
- Named groups `(?<amount>\d+)` flow into the existing `@Param('amount')` —
  pipe-friendly, identical to a `@Command('add :amount')` segment. One `@Param`
  serves both a `@Command` template and a regex named group on the same handler.
- New public `RegexMatchSource` interface (mirrors `RouteParamSource`);
  `HearsPredicate` / `ActionPredicate` implement it.
- `.match()` runs lazily at param-resolution only; the hot routing path stays a
  boolean `.test()`.

## Verify

- `npm run build`, `npm run lint`, `npx jest` — 116 suites, 902 passed.
- Unit specs for both predicates' capture/extract; an end-to-end `@Matches`
  integration spec (positional, named-group pipe, non-regex → undefined, and a
  stacked `@Command` + regex `@Hears` sharing one `@Param`).
