### PR TITLE
feat(api): expose cached bot identity via bot.me / bot.id

### DIFF
--- a/lib/api/bot.service.spec.ts
+++ b/lib/api/bot.service.spec.ts
@@ -238,9 +238,26 @@ describe('BotService identity & deepLink', () => {
     expect(b.username).toBe('mybot');
   });
 
+  it('exposes the bot id and full identity from the cached getMe', async () => {
+    const b = bot({ token: '1:T' });
+    await b.getMe(); // the launch health check warms the identity
+
+    expect(b.id).toBe(1);
+    expect(b.me).toEqual({
+      id: 1,
+      is_bot: true,
+      first_name: 'Bot',
+      username: 'mybot',
+    });
+    expect(getMeCalls).toBe(1); // the sync accessors read the cache, no new request
+  });
+
   it('throws a clear error if the identity is not loaded yet', () => {
     const b = bot({ token: '1:T' });
     expect(() => b.deepLink({ start: 'x' })).toThrow(NestgramError);
+    expect(() => b.id).toThrow(NestgramError);
+    expect(() => b.me).toThrow(NestgramError);
+    expect(() => b.username).toThrow(NestgramError);
   });
 });
 

--- a/lib/api/bot.service.ts
+++ b/lib/api/bot.service.ts
@@ -137,8 +137,9 @@ export class BotService extends GeneratedBotMethods {
 
   /**
    * The bot account. Its own identity (called without a custom token) is cached
-   * after the first call — it is effectively static and backs {@link username}
-   * and {@link deepLink}. Pass a `token` to query a different bot, always live.
+   * after the first call — it is effectively static and backs {@link me},
+   * {@link id}, {@link username} and {@link deepLink}. Pass a `token` to query a
+   * different bot, always live.
    */
   async getMe(options?: MethodOptions): Promise<User> {
     const { token, signal } = options ?? {};
@@ -154,16 +155,36 @@ export class BotService extends GeneratedBotMethods {
   }
 
   /**
-   * The bot's own `@username`, cached from `getMe`. Available once the bot has
-   * started (the launch health check loads it) or after any `getMe()` call.
+   * The bot's own identity — the full {@link User} from `getMe`, cached at
+   * startup. Synchronous, unlike {@link getMe}: it never makes a request, and
+   * throws if the identity has not loaded yet. Backs {@link id},
+   * {@link username} and {@link deepLink}; reach for it when you need a field
+   * those don't expose (e.g. `first_name`, `can_join_groups`).
    */
-  get username(): string {
-    const username = this.cachedMe?.username;
-    if (!username) {
+  get me(): Readonly<User> {
+    if (!this.cachedMe) {
       throw new NestgramError(
-        "The bot's username is not loaded yet — it is available after startup " +
+        "The bot's identity is not loaded yet — it is available after startup " +
           '(the getMe health check) or once getMe() has been called.',
       );
+    }
+    return this.cachedMe;
+  }
+
+  /** The bot's own numeric id, cached from `getMe` (see {@link me}). */
+  get id(): number {
+    return this.me.id;
+  }
+
+  /**
+   * The bot's own `@username`, cached from `getMe` (see {@link me}). A bot always
+   * has one in practice; the guard only satisfies the optional `User.username`
+   * type and shouldn't fire.
+   */
+  get username(): string {
+    const { username } = this.me;
+    if (username === undefined) {
+      throw new NestgramError('The bot account has no username.');
     }
     return username;
   }


### PR DESCRIPTION
## What

Two synchronous accessors for the bot's own identity on `BotService`, beside the existing async `getMe()`:

- **`bot.me`** — the full cached `User`, returned `Readonly`. The single place that guards "identity not loaded yet".
- **`bot.id`** — the bot's numeric id.

`bot.username` is refactored to delegate to `me`, so the not-loaded guard lives in one place instead of being copied into each accessor.

## Why

The bot's identity is already fetched at boot (the `getMe` health check) and cached in `cachedMe`. Only `username` was exposed, so reading the bot's own `id` — e.g. to detect self-authored messages or filter membership updates — forced an `await bot.getMe()` for data already in memory.

`me` / `id` are sync, cache-only reads; `getMe()` stays the async, token-aware fetch (query another bot, always live). `me` returns `Readonly<User>` so a caller can't mutate the shared cached identity that also backs `deepLink()` and `username`.

## Verify

```
npm run build       # typechecks
npx jest lib/api/bot.service.spec.ts
npm run lint
```

Tests cover both paths: the cached read makes no second `getMe` request, and `me` / `id` / `username` all throw `NestgramError` before the identity is loaded.
