### PR TITLE
feat(streaming): live message streaming via native rich-message drafts

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,118 @@
+---
+title: Streaming
+description: Stream a reply live into a private chat — an async iterable of text deltas animates a native rich-message draft, then persists as a real message.
+sidebar:
+  group: Events & replies
+  order: 36
+---
+
+An LLM reply arrives token by token. Streaming pushes those tokens into
+Telegram's native rich-message draft (`sendRichMessageDraft`) — an ephemeral
+preview that **animates** as it grows — then persists the finished text as a
+real message with `sendRichMessage`. You hand the framework an async iterable of
+text deltas; it runs the draft loop, the throttling and the finalize.
+
+:::mental
+async iterable of deltas -> animated draft (coalesced) -> final sendRichMessage
+:::
+
+## The `*Stream` family
+
+Three doors, one engine — return a stream, or call a method:
+
+:::code[assistant.router.ts]
+
+```ts
+import { Router, Command, OnMessage, Message } from 'nestgram';
+
+@Router()
+export class AssistantRouter {
+  // Bare return: the framework detects the async iterable and streams it.
+  @Command('ask')
+  ask(message: Message) {
+    return llm(message.text ?? ''); // an AsyncIterable<string>
+  }
+
+  // Imperative: the same stream, but you hold the sent Message and pass options.
+  @OnMessage()
+  chat(message: Message) {
+    return message.answerStream(llm(message.text ?? ''), { format: 'html' });
+  }
+}
+```
+
+:::
+
+- `return <async-iterable>` — the return-value mirror of `return 'text'`. Zero
+  config, defaults applied.
+- `message.answerStream(source, options?)` / `message.replyStream(source, options?)`
+  — sugar that resolves the sent `Message`.
+- `bot.streamMessage(chat_id, source, options?)` — the hub the others funnel
+  through; reach for it from a service that injects `BotService`.
+
+## The source
+
+A `StreamSource` is an `AsyncIterable<string>` of **deltas** — each yield
+_appends_ to the growing message (not a replacement), the exact shape an LLM
+SDK's streaming response already has. An `async function*` works too:
+
+:::code[source.ts]
+
+```ts
+async function* llm(prompt: string): AsyncIterable<string> {
+  yield 'Once ';
+  yield 'upon ';
+  yield 'a time…';
+}
+```
+
+:::
+
+The framework accumulates the deltas, so the final message is the whole
+concatenation — regardless of how the animation was throttled along the way.
+
+## Options
+
+`StreamOptions` extends the `sendRichMessage` finalize options (reply target,
+keyboard, `token`/`signal`…), which apply to the **persisted** message rather
+than the draft frames, plus two streaming knobs:
+
+| Option       | Type                   | Default      | Meaning                                   |
+| ------------ | ---------------------- | ------------ | ----------------------------------------- |
+| `format`     | `'markdown' \| 'html'` | `'markdown'` | Dialect the deltas are written in         |
+| `throttleMs` | `number`               | `~1000`      | Minimum gap between animated draft frames |
+
+Streaming coalesces to the latest text and pushes at most one frame per
+`throttleMs`, so a fast token stream never floods — or queues behind — the send
+throttler. The `format` values are the same [rich-message](/rich-messages)
+dialects, since a draft frame _is_ a rich message.
+
+## Private chats only
+
+The native animated draft (`sendRichMessageDraft`) has no group equivalent, so
+streaming is **private-chat only**. The doors part ways on how they say so:
+
+| Door                                                 | In a group / channel                 | Catchable?                                            |
+| ---------------------------------------------------- | ------------------------------------ | ----------------------------------------------------- |
+| `bot.streamMessage` / `answerStream` / `replyStream` | rejects with a typed `NestgramError` | **yes** — `try/catch`, then fall back to `answer`     |
+| bare `return <async-iterable>`                       | warned and dropped                   | no — like any bare return, it runs after the pipeline |
+
+That mirror is the existing return contract: an awaited method throws so you can
+react, a bare return is best-effort sugar that warns when it can't be honored.
+Guest messages are refused the same way — a guest message's chat id can
+misdeliver, so answer a guest exchange with `message.answerGuest(result)`.
+
+:::note
+A returned value is detected as a stream structurally — anything carrying a
+`Symbol.asyncIterator`. A handler virtually never returns an async iterable for
+another reason; if yours does and you don't mean to stream it, send it
+imperatively (`await message.answerX(...)`) and return nothing.
+:::
+
+## No privileged core
+
+The engine calls only the public generated `sendRichMessageDraft` /
+`sendRichMessage`; `bot.streamMessage` is an ordinary hand-owned method you could
+have written, and the bare-return path is one more branch in the same result
+handler that turns `return 'text'` into a send. Nothing here is a privileged
+built-in — see [how Nestgram works](/how-nestgram-works).

--- a/examples/streaming-bot/README.md
+++ b/examples/streaming-bot/README.md
@@ -1,0 +1,30 @@
+# streaming-bot
+
+A Nestgram bot that streams its replies live. `/ask <text>` returns an async
+iterable and the framework streams it; any other message is answered with
+`message.answerStream(...)`. The reply animates in place via Telegram's native
+rich-message draft, then finalizes into a real message.
+
+The "LLM" here is a fake token generator (`fakeCompletion`) so the example runs
+with no API key — swap it for a real provider's streaming response, which is
+already an async iterable of text deltas.
+
+Streaming uses `sendRichMessageDraft`, which is **private-chat only** — DM the
+bot. In a group, `message.answerStream(...)` throws (catch it to fall back to a
+plain `answer`), and a bare `return <stream>` is warned and dropped.
+
+It imports from `nestgram` exactly as an app outside this repo would (resolved
+to `lib/` via a tsconfig path alias here).
+
+## Run
+
+This folder is reference code (type-checked here, not shipped in the package).
+To run it in your own project after `npm install nestgram@next`, point your usual
+Nest toolchain at `main.ts`, e.g.:
+
+```bash
+BOT_TOKEN=123456789:your-token npx ts-node main.ts
+```
+
+Get a token from [@BotFather](https://t.me/BotFather). Polling needs no HTTP
+server — the bot runs as a plain Nest application context.

--- a/examples/streaming-bot/app.module.ts
+++ b/examples/streaming-bot/app.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { NestgramModule } from 'nestgram';
+
+import { AssistantRouter } from './assistant.router';
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      token: process.env.BOT_TOKEN ?? '',
+      polling: true,
+    }),
+  ],
+  providers: [AssistantRouter],
+})
+export class AppModule {}

--- a/examples/streaming-bot/assistant.router.ts
+++ b/examples/streaming-bot/assistant.router.ts
@@ -1,0 +1,39 @@
+import { Router, Command, OnMessage, Message } from 'nestgram';
+
+/**
+ * Stands in for an LLM's streaming response: yields the reply a few tokens at a
+ * time with a small delay, so the draft visibly animates. A real provider's
+ * streaming API is already an `AsyncIterable<string>` of deltas — drop it in
+ * here unchanged.
+ */
+async function* fakeCompletion(prompt: string): AsyncIterable<string> {
+  const reply =
+    `You said: **${prompt}**\n\n` +
+    'Here is a streamed answer, arriving a few tokens at a time — the draft ' +
+    'animates in place until it finalizes into a real message.';
+  for (const token of reply.match(/\S+\s*/g) ?? []) {
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    yield token;
+  }
+}
+
+/**
+ * A tiny streaming assistant. `/ask <text>` returns the stream directly (the
+ * framework detects the async iterable and streams it); any other message is
+ * answered imperatively with `message.answerStream(...)`.
+ *
+ * Streaming is private-chat only — DM the bot. In a group `answerStream` throws
+ * (catch it to fall back to `answer`), and a bare `return <stream>` is dropped.
+ */
+@Router()
+export class AssistantRouter {
+  @Command('ask')
+  ask(message: Message) {
+    return fakeCompletion(message.text ?? '');
+  }
+
+  @OnMessage()
+  chat(message: Message) {
+    return message.answerStream(fakeCompletion(message.text ?? ''));
+  }
+}

--- a/examples/streaming-bot/assistant.router.ts
+++ b/examples/streaming-bot/assistant.router.ts
@@ -1,4 +1,4 @@
-import { Router, Command, OnMessage, Message } from 'nestgram';
+import { Router, Command, OnText, Message } from 'nestgram';
 
 /**
  * Stands in for an LLM's streaming response: yields the reply a few tokens at a
@@ -19,8 +19,8 @@ async function* fakeCompletion(prompt: string): AsyncIterable<string> {
 
 /**
  * A tiny streaming assistant. `/ask <text>` returns the stream directly (the
- * framework detects the async iterable and streams it); any other message is
- * answered imperatively with `message.answerStream(...)`.
+ * framework detects the async iterable and streams it); any other text message
+ * is answered imperatively with `message.answerStream(...)`.
  *
  * Streaming is private-chat only — DM the bot. In a group `answerStream` throws
  * (catch it to fall back to `answer`), and a bare `return <stream>` is dropped.
@@ -32,7 +32,7 @@ export class AssistantRouter {
     return fakeCompletion(message.text ?? '');
   }
 
-  @OnMessage()
+  @OnText()
   chat(message: Message) {
     return message.answerStream(fakeCompletion(message.text ?? ''));
   }

--- a/examples/streaming-bot/main.ts
+++ b/examples/streaming-bot/main.ts
@@ -1,0 +1,14 @@
+import { NestFactory } from '@nestjs/core';
+
+import { AppModule } from './app.module';
+
+/**
+ * Run with: `BOT_TOKEN=123456:your-token node dist/main.js`
+ * A polling bot needs no HTTP server — it's a plain application context.
+ */
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  app.enableShutdownHooks(); // lets polling stop cleanly on Ctrl-C
+}
+
+void bootstrap();

--- a/lib/api/bot.service.spec.ts
+++ b/lib/api/bot.service.spec.ts
@@ -422,3 +422,50 @@ describe('BotService message actions (delete/forward/copy + chaining)', () => {
     expect(typeof sent.delete).toBe('function');
   });
 });
+
+describe('BotService streaming', () => {
+  let calls: FetchCall[];
+
+  beforeEach(() => {
+    calls = mockFetch();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  async function* gen(deltas: string[]): AsyncGenerator<string> {
+    for (const delta of deltas) {
+      yield delta;
+    }
+  }
+
+  it('animates rich drafts then persists the final message in a private chat', async () => {
+    const sent = await bot({ token: '1:T' }).streamMessage(
+      7,
+      gen(['Hel', 'lo']),
+      { throttleMs: 0 },
+    );
+
+    const methods = calls.map((c) =>
+      c.url.replace('https://api.telegram.org/bot1:T/', ''),
+    );
+    expect(methods).toEqual([
+      'sendRichMessageDraft',
+      'sendRichMessageDraft',
+      'sendRichMessage',
+    ]);
+    expect(calls[calls.length - 1].body).toMatchObject({
+      chat_id: 7,
+      rich_message: { markdown: 'Hello' },
+    });
+    expect(sent).toBeInstanceOf(Message);
+  });
+
+  it('rejects for a non-private chat before sending anything', async () => {
+    await expect(
+      bot({ token: '1:T' }).streamMessage(-100, gen(['hi'])),
+    ).rejects.toBeInstanceOf(NestgramError);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/lib/api/bot.service.ts
+++ b/lib/api/bot.service.ts
@@ -11,6 +11,9 @@ import { DEFAULT_BOT_NAME, Providers } from '../providers';
 import { ApiException, NestgramError } from '../exceptions';
 import { deepLink as createDeepLink, DeepLinkParams } from '../deep-links';
 import type { User } from '../events/user';
+import type { Message } from '../events';
+import { MessageStream } from '../streaming/message-stream';
+import type { StreamOptions, StreamSource } from '../streaming';
 
 import { ApiError, ApiResponse } from './api-response';
 import { createAttachedData, createInlineData } from './form-data';
@@ -260,6 +263,42 @@ export class BotService extends GeneratedBotMethods {
       await rm(destinationPath, { force: true });
       throw error;
     }
+  }
+
+  /**
+   * Stream a message live into a private chat: consume an async iterable of text
+   * deltas, animate a native `sendRichMessageDraft` preview, then persist the
+   * final text with `sendRichMessage`. Resolves the sent {@link Message}, or
+   * `undefined` when the stream produced no text.
+   *
+   * Private-chat only — the native animated draft has no group equivalent. Any
+   * other chat throws a {@link NestgramError}; catch it to fall back to a plain
+   * `sendMessage`. `message.answerStream(...)` / `replyStream(...)` and a bare
+   * `return <async-iterable>` from a handler are the sugar over this.
+   */
+  async streamMessage(
+    chat_id: number,
+    source: StreamSource,
+    options?: StreamOptions,
+  ): Promise<Message | undefined> {
+    if (!BotService.isPrivateChatId(chat_id)) {
+      throw new NestgramError(
+        `streamMessage needs a private chat, but chat_id ${chat_id} is not one ` +
+          '(the native sendRichMessageDraft animation is private-chat-only). ' +
+          'Catch this to fall back to a plain sendMessage.',
+      );
+    }
+    return new MessageStream(this, chat_id, source, options).run();
+  }
+
+  /**
+   * Whether a chat id addresses a private (one-to-one) chat. Telegram gives
+   * users and private chats positive ids; groups, supergroups and channels are
+   * negative. Streaming's native draft is private-only, so this gates
+   * {@link streamMessage}.
+   */
+  private static isPrivateChatId(id: number): boolean {
+    return id > 0;
   }
 
   private async fetchFile(

--- a/lib/api/bot.service.ts
+++ b/lib/api/bot.service.ts
@@ -276,29 +276,12 @@ export class BotService extends GeneratedBotMethods {
    * `sendMessage`. `message.answerStream(...)` / `replyStream(...)` and a bare
    * `return <async-iterable>` from a handler are the sugar over this.
    */
-  async streamMessage(
+  streamMessage(
     chat_id: number,
     source: StreamSource,
     options?: StreamOptions,
   ): Promise<Message | undefined> {
-    if (!BotService.isPrivateChatId(chat_id)) {
-      throw new NestgramError(
-        `streamMessage needs a private chat, but chat_id ${chat_id} is not one ` +
-          '(the native sendRichMessageDraft animation is private-chat-only). ' +
-          'Catch this to fall back to a plain sendMessage.',
-      );
-    }
     return new MessageStream(this, chat_id, source, options).run();
-  }
-
-  /**
-   * Whether a chat id addresses a private (one-to-one) chat. Telegram gives
-   * users and private chats positive ids; groups, supergroups and channels are
-   * negative. Streaming's native draft is private-only, so this gates
-   * {@link streamMessage}.
-   */
-  private static isPrivateChatId(id: number): boolean {
-    return id > 0;
   }
 
   private async fetchFile(

--- a/lib/engine/execution/result-handler.spec.ts
+++ b/lib/engine/execution/result-handler.spec.ts
@@ -34,15 +34,21 @@ function callbackCtx(bot: BotService): TelegramExecutionContext {
 
 describe('ResultHandler', () => {
   let called: ApiMethod<unknown, unknown>[];
+  let streamed: { chatId: number; source: unknown }[];
   let handler: ResultHandler;
   let bot: BotService;
 
   beforeEach(() => {
     called = [];
+    streamed = [];
     bot = {
       call: (method: ApiMethod<unknown, unknown>) => {
         called.push(method);
         return Promise.resolve();
+      },
+      streamMessage: (chatId: number, source: unknown) => {
+        streamed.push({ chatId, source });
+        return Promise.resolve(undefined);
       },
     } as unknown as BotService;
     handler = new ResultHandler();
@@ -194,6 +200,71 @@ describe('ResultHandler', () => {
       await expect(
         handler.handle(new InlineKeyboard().text('x', 'x'), callbackCtx(bot)),
       ).rejects.toThrow('network down');
+    });
+  });
+
+  describe('streaming (returned async-iterable)', () => {
+    async function* gen(): AsyncGenerator<string> {
+      yield 'hi';
+    }
+
+    function chatCtx(
+      chat: { id: number; type: string } | undefined,
+    ): TelegramExecutionContext {
+      return {
+        kind: 'message',
+        event: {},
+        bot,
+        chat,
+        update: {},
+      } as unknown as TelegramExecutionContext;
+    }
+
+    it('streams a returned async-iterable to a private chat', async () => {
+      const source = gen();
+
+      await handler.handle(source, chatCtx({ id: 7, type: 'private' }));
+
+      expect(streamed).toEqual([{ chatId: 7, source }]);
+    });
+
+    it('warns and drops a stream returned in a non-private chat', async () => {
+      const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      await handler.handle(gen(), chatCtx({ id: -100, type: 'supergroup' }));
+
+      expect(streamed).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('private chat'),
+      );
+      warn.mockRestore();
+    });
+
+    it('warns and drops a stream when the update has no chat', async () => {
+      const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      await handler.handle(gen(), chatCtx(undefined));
+
+      expect(streamed).toEqual([]);
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('warns and drops a stream returned for a guest message', async () => {
+      const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      // A guest message's chat looks private, so the guest guard must fire first.
+      await handler.handle(gen(), {
+        kind: 'guest_message',
+        event: {},
+        bot,
+        chat: { id: 7, type: 'private' },
+        update: { guest_message: { guest_query_id: 'gq_1' } },
+      } as unknown as TelegramExecutionContext);
+
+      expect(streamed).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('guest'));
+      warn.mockRestore();
     });
   });
 });

--- a/lib/engine/execution/result-handler.ts
+++ b/lib/engine/execution/result-handler.ts
@@ -32,6 +32,7 @@ type EditInPlaceMethod =
  *                        are filled from the callback message when omitted
  *   - command object  -> execute it (the pure-data `new SendMessage(...)` layer
  *                        beneath `message.answer(...)` sugar)
+ *   - async-iterable  -> stream it to the same chat (private only; else warn+drop)
  *   - anything else   -> noop
  *
  * Editing in place is symmetric to `answer()`: just as a returned string replies
@@ -80,6 +81,12 @@ export class ResultHandler {
       // The bot that received this update — not a global default — so a returned
       // command object (new SendMessage(...)) goes out through the right bot.
       await ctx.bot.call(result);
+      return;
+    }
+
+    if (ResultHandler.isStream(result)) {
+      await this.streamInPlace(result, ctx);
+      return;
     }
   }
 
@@ -181,6 +188,55 @@ export class ResultHandler {
       }
       throw error;
     }
+  }
+
+  /**
+   * A returned async-iterable streams to the same chat — the return-value mirror
+   * of `message.answerStream(...)`. Streaming's native draft is private-chat
+   * only, so a group (or an update with no chat) warns and drops, exactly as a
+   * bare string return to a non-answerable event does — the method doors throw
+   * for a caller that wants to catch and fall back.
+   */
+  private async streamInPlace(
+    source: AsyncIterable<string>,
+    ctx: TelegramExecutionContext,
+  ): Promise<void> {
+    // A guest message's chat id can misdeliver (see Message.answer) and a guest
+    // exchange has no streaming reply, so a returned stream can't be honored —
+    // drop it, mirroring the throw `answerStream` gives an imperative caller.
+    if (ctx.update.guest_message) {
+      this.logger.warn(
+        `Handler for "${ctx.kind}" returned a stream for a guest message, which ` +
+          "can't be answered by streaming (its chat id may misdeliver). Reply " +
+          'with message.answerGuest(result) instead.',
+      );
+      return;
+    }
+    const chat = ctx.chat;
+    if (chat?.type !== 'private') {
+      this.logger.warn(
+        `Handler for "${ctx.kind}" returned a stream, but streaming needs a ` +
+          'private chat (the native draft is private-chat-only). Use ' +
+          'message.answerStream(...) to handle non-private chats explicitly.',
+      );
+      return;
+    }
+    await ctx.bot.streamMessage(chat.id, source);
+  }
+
+  /**
+   * Whether a handler return value is an async-iterable to stream (an LLM token
+   * stream, an `async function*`). Structural, like the `typeof === 'string'`
+   * check: strings carry `Symbol.iterator`, not `Symbol.asyncIterator`, so they
+   * never match here (and are handled by the earlier branch regardless).
+   */
+  private static isStream(result: unknown): result is AsyncIterable<string> {
+    return (
+      typeof result === 'object' &&
+      result !== null &&
+      typeof (result as AsyncIterable<string>)[Symbol.asyncIterator] ===
+        'function'
+    );
   }
 
   private isAnswerable(

--- a/lib/events/events.spec.ts
+++ b/lib/events/events.spec.ts
@@ -40,6 +40,7 @@ function fakeBot(): { bot: BotService; calls: Call[] } {
     sendSticker: record('sendSticker'),
     setMessageReaction: record('setMessageReaction'),
     sendMediaGroup: record('sendMediaGroup'),
+    streamMessage: record('streamMessage'),
   } as unknown as BotService;
 
   return { bot, calls };
@@ -110,6 +111,39 @@ describe('Message actions', () => {
       method: 'sendMessage',
       args: [1, 'hello', { reply_parameters: { message_id: 5 } }],
     });
+  });
+
+  it('answerStream() streams to the same chat', () => {
+    const { bot, calls } = fakeBot();
+    const source = (async function* () {
+      yield 'x';
+    })();
+    message(bot).answerStream(source, { format: 'html' });
+    expect(calls[0]).toEqual({
+      method: 'streamMessage',
+      args: [1, source, { format: 'html' }],
+    });
+  });
+
+  it('replyStream() quotes the original message', () => {
+    const { bot, calls } = fakeBot();
+    const source = (async function* () {
+      yield 'x';
+    })();
+    message(bot).replyStream(source);
+    expect(calls[0]).toEqual({
+      method: 'streamMessage',
+      args: [1, source, { reply_parameters: { message_id: 5 } }],
+    });
+  });
+
+  it('answerStream() refuses a guest message', () => {
+    const { bot, calls } = fakeBot();
+    const source = (async function* () {
+      yield 'x';
+    })();
+    expect(() => guestMessage(bot).answerStream(source)).toThrow(NestgramError);
+    expect(calls).toHaveLength(0);
   });
 
   it('editText() edits this message', () => {

--- a/lib/events/message.ts
+++ b/lib/events/message.ts
@@ -23,6 +23,7 @@ import {
 import { UpdateType } from '../decorators';
 import { InputFile } from '../api/input-file';
 import { NestgramError } from '../exceptions';
+import type { StreamOptions, StreamSource } from '../streaming';
 import type {
   RawInlineQueryResult,
   RawInputRichMessage,
@@ -107,19 +108,37 @@ export class Message extends TelegramObject {
     if (raw.sticker) this.sticker = new Sticker(botService, raw.sticker);
   }
 
-  answer(text: string, options?: MethodOptions<SendMessageOptions>) {
-    // A guest message's chat id can, per the spec, resolve to a DIFFERENT real
-    // chat (the `guest_query_id`-scoped identifier only coincides with the guest
-    // exchange). Replying to `this.chat.id` here risks delivering to the wrong
-    // user, so refuse — a guest exchange is answered via `answerGuest`.
+  /**
+   * Refuse an action that would reply to `this.chat.id` when this is a guest
+   * message: a guest message's chat id can resolve to a DIFFERENT real chat (per
+   * the spec), so a same-chat reply risks misdelivery. A guest exchange is
+   * answered via {@link answerGuest} instead.
+   */
+  private assertNotGuest(action: string): void {
     if (this.guest_query_id) {
       throw new NestgramError(
-        "message.answer() can't reply to a guest message — its chat id may " +
+        `message.${action}() can't reply to a guest message — its chat id may ` +
           'resolve to a different real chat (per the spec). Use ' +
           'message.answerGuest(result) (or bot.answerGuestQuery).',
       );
     }
+  }
+
+  answer(text: string, options?: MethodOptions<SendMessageOptions>) {
+    this.assertNotGuest('answer');
     return this.botService.sendMessage(this.chat.id, text, options);
+  }
+
+  /**
+   * Stream a reply into this chat live — consume an async iterable of text
+   * deltas (an LLM token stream, an `async function*`) and animate it via the
+   * native rich-message draft, persisting the final text when the stream ends.
+   * Resolves the sent {@link Message}, or `undefined` for an empty stream.
+   * Private-chat only — throws in a group (see {@link BotService.streamMessage}).
+   */
+  answerStream(source: StreamSource, options?: StreamOptions) {
+    this.assertNotGuest('answerStream');
+    return this.botService.streamMessage(this.chat.id, source, options);
   }
 
   /**
@@ -216,6 +235,15 @@ export class Message extends TelegramObject {
 
   reply(text: string, options?: MethodOptions<SendMessageOptions>) {
     return this.botService.sendMessage(this.chat.id, text, {
+      reply_parameters: { message_id: this.message_id },
+      ...options,
+    });
+  }
+
+  /** {@link answerStream} that quotes this message on the persisted reply. */
+  replyStream(source: StreamSource, options?: StreamOptions) {
+    this.assertNotGuest('replyStream');
+    return this.botService.streamMessage(this.chat.id, source, {
       reply_parameters: { message_id: this.message_id },
       ...options,
     });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,6 +18,7 @@ export * from './i18n';
 export * from './fsm';
 export * from './scenes';
 export * from './rate-limit';
+export * from './streaming';
 
 // Engine public surface (the update -> dispatch pipeline).
 export * from './engine/matching';

--- a/lib/streaming/index.ts
+++ b/lib/streaming/index.ts
@@ -1,0 +1,4 @@
+// The engine (MessageStream) is internal — reached only through
+// `bot.streamMessage(...)`, which guards the private-chat invariant. The public
+// surface is the option/source types a handler annotates with.
+export * from './stream.types';

--- a/lib/streaming/message-stream.spec.ts
+++ b/lib/streaming/message-stream.spec.ts
@@ -1,4 +1,5 @@
 import { MessageStream } from './message-stream';
+import { NestgramError } from '../exceptions';
 import type { BotService } from '../api';
 import type { Message } from '../events';
 
@@ -151,6 +152,17 @@ describe('MessageStream', () => {
       }).run(),
     ).rejects.toThrow('boom');
 
+    expect(finals).toHaveLength(0);
+  });
+
+  it('refuses a non-private chat (self-enforced, not just at the hub)', async () => {
+    const { bot, drafts, finals } = fakeBot();
+
+    await expect(
+      new MessageStream(bot, -100, gen(['hi']), { throttleMs: 0 }).run(),
+    ).rejects.toBeInstanceOf(NestgramError);
+
+    expect(drafts).toHaveLength(0);
     expect(finals).toHaveLength(0);
   });
 

--- a/lib/streaming/message-stream.spec.ts
+++ b/lib/streaming/message-stream.spec.ts
@@ -1,0 +1,185 @@
+import { MessageStream } from './message-stream';
+import type { BotService } from '../api';
+import type { Message } from '../events';
+
+interface DraftCall {
+  chat_id: number;
+  draft_id: number;
+  rich_message: unknown;
+  options: unknown;
+}
+
+interface FinalCall {
+  chat_id: number;
+  rich_message: unknown;
+  options: unknown;
+}
+
+/** A fake bot recording the two rich-message calls the engine makes. */
+function fakeBot() {
+  const drafts: DraftCall[] = [];
+  const finals: FinalCall[] = [];
+  const sent = { message_id: 1 } as unknown as Message;
+  const bot = {
+    sendRichMessageDraft: (
+      chat_id: number,
+      draft_id: number,
+      rich_message: unknown,
+      options: unknown,
+    ) => {
+      drafts.push({ chat_id, draft_id, rich_message, options });
+      return Promise.resolve(true);
+    },
+    sendRichMessage: (
+      chat_id: number,
+      rich_message: unknown,
+      options: unknown,
+    ) => {
+      finals.push({ chat_id, rich_message, options });
+      return Promise.resolve(sent);
+    },
+  } as unknown as BotService;
+  return { bot, drafts, finals, sent };
+}
+
+async function* gen(deltas: string[]): AsyncGenerator<string> {
+  for (const delta of deltas) {
+    yield delta;
+  }
+}
+
+async function* throwingGen(deltas: string[]): AsyncGenerator<string> {
+  for (const delta of deltas) {
+    yield delta;
+  }
+  throw new Error('boom');
+}
+
+// A private chat id — the hub (`bot.streamMessage`) guards this; the engine
+// itself assumes it and just streams.
+const CHAT = 111;
+
+describe('MessageStream', () => {
+  it('accumulates deltas and persists the full text', async () => {
+    const { bot, drafts, finals, sent } = fakeBot();
+
+    const result = await new MessageStream(
+      bot,
+      CHAT,
+      gen(['Hel', 'lo ', 'world']),
+      { throttleMs: 0 },
+    ).run();
+
+    expect(drafts.map((d) => d.rich_message)).toEqual([
+      { markdown: 'Hel' },
+      { markdown: 'Hello ' },
+      { markdown: 'Hello world' },
+    ]);
+    expect(finals).toHaveLength(1);
+    expect(finals[0]).toMatchObject({
+      chat_id: CHAT,
+      rich_message: { markdown: 'Hello world' },
+    });
+    expect(result).toBe(sent);
+  });
+
+  it('coalesces to the latest text within a throttle window', async () => {
+    const { bot, drafts, finals } = fakeBot();
+
+    await new MessageStream(bot, CHAT, gen(['a', 'b', 'c']), {
+      throttleMs: 100_000,
+    }).run();
+
+    // Only the first frame pushes; the rest fold into the finalize — the final
+    // message still carries the whole text.
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].rich_message).toEqual({ markdown: 'a' });
+    expect(finals[0].rich_message).toEqual({ markdown: 'abc' });
+  });
+
+  it('animates the first real delta even after a leading empty chunk', async () => {
+    const { bot, drafts, finals } = fakeBot();
+
+    // LLM streams often open with an empty content delta; it must not spend the
+    // throttle window and swallow the first visible frame.
+    await new MessageStream(bot, CHAT, gen(['', 'hi']), {
+      throttleMs: 100_000,
+    }).run();
+
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].rich_message).toEqual({ markdown: 'hi' });
+    expect(finals[0].rich_message).toEqual({ markdown: 'hi' });
+  });
+
+  it('animates every frame under a single draft id', async () => {
+    const { bot, drafts } = fakeBot();
+
+    await new MessageStream(bot, CHAT, gen(['a', 'b']), {
+      throttleMs: 0,
+    }).run();
+
+    expect(new Set(drafts.map((d) => d.draft_id)).size).toBe(1);
+  });
+
+  it('gives each stream its own draft id', async () => {
+    const { bot, drafts } = fakeBot();
+
+    await new MessageStream(bot, CHAT, gen(['a']), { throttleMs: 0 }).run();
+    await new MessageStream(bot, CHAT, gen(['b']), { throttleMs: 0 }).run();
+
+    expect(drafts[0].draft_id).not.toBe(drafts[1].draft_id);
+  });
+
+  it('sends nothing and resolves undefined for an empty stream', async () => {
+    const { bot, drafts, finals } = fakeBot();
+
+    const result = await new MessageStream(bot, CHAT, gen([]), {
+      throttleMs: 0,
+    }).run();
+
+    expect(drafts).toHaveLength(0);
+    expect(finals).toHaveLength(0);
+    expect(result).toBeUndefined();
+  });
+
+  it('aborts on a source error and persists nothing', async () => {
+    const { bot, finals } = fakeBot();
+
+    await expect(
+      new MessageStream(bot, CHAT, throwingGen(['partial']), {
+        throttleMs: 0,
+      }).run(),
+    ).rejects.toThrow('boom');
+
+    expect(finals).toHaveLength(0);
+  });
+
+  it('writes the html dialect when asked', async () => {
+    const { bot, drafts, finals } = fakeBot();
+
+    await new MessageStream(bot, CHAT, gen(['<b>hi</b>']), {
+      throttleMs: 0,
+      format: 'html',
+    }).run();
+
+    expect(drafts[0].rich_message).toEqual({ html: '<b>hi</b>' });
+    expect(finals[0].rich_message).toEqual({ html: '<b>hi</b>' });
+  });
+
+  it('applies finalize options to the persisted message only, not the drafts', async () => {
+    const { bot, drafts, finals } = fakeBot();
+    const reply_markup = { inline_keyboard: [] };
+
+    await new MessageStream(bot, CHAT, gen(['x']), {
+      throttleMs: 0,
+      reply_markup,
+    }).run();
+
+    expect(
+      (drafts[0].options as { reply_markup?: unknown }).reply_markup,
+    ).toBeUndefined();
+    expect((finals[0].options as { reply_markup?: unknown }).reply_markup).toBe(
+      reply_markup,
+    );
+  });
+});

--- a/lib/streaming/message-stream.ts
+++ b/lib/streaming/message-stream.ts
@@ -1,0 +1,124 @@
+import { Logger } from '@nestjs/common';
+
+import type { BotService, CallOptions } from '../api';
+import type { SendRichMessageOptions } from '../api/methods';
+import type { Message } from '../events';
+import type { RawInputRichMessage } from '../events/raw-update.types';
+import type { RichMessageDialect } from '../builtins/rich-messages/rich-messages.types';
+import type { StreamOptions, StreamSource } from './stream.types';
+
+/** The `sendRichMessage` payload minus what the engine fills itself. */
+type FinalizeOptions = Partial<
+  Omit<SendRichMessageOptions, 'chat_id' | 'rich_message'>
+>;
+
+/**
+ * Drives one live streamed message: consume a {@link StreamSource} of text
+ * deltas, animate a native `sendRichMessageDraft` preview (coalescing to the
+ * latest text so rapid tokens never fight the send throttler), then persist the
+ * final text with `sendRichMessage`.
+ *
+ * A per-stream value object — it holds the growing text, its own draft id and
+ * the last-pushed snapshot, so it is `new`ed per stream by `bot.streamMessage`,
+ * never a DI singleton (which couldn't hold per-stream state). Same shape as the
+ * rich events, which hold a `BotService` and are `new`ed per update.
+ *
+ * Private-chat only: `bot.streamMessage` guards that before constructing this —
+ * `sendRichMessageDraft` has no group equivalent.
+ */
+export class MessageStream {
+  private static readonly logger = new Logger(MessageStream.name);
+
+  /**
+   * Default minimum gap between animated draft pushes. Matches the send
+   * throttler's per-chat cadence, so coalesced pushes arrive as it frees up
+   * rather than queuing behind one another.
+   */
+  private static readonly DEFAULT_THROTTLE_MS = 1000;
+
+  /** The dialect a stream is written in when the caller doesn't pick one. */
+  private static readonly DEFAULT_FORMAT: RichMessageDialect = 'markdown';
+
+  /** Draft-id source — each stream animates its own draft (must be non-zero). */
+  private static nextDraftId = 1;
+
+  private readonly draftId = MessageStream.nextDraftId++;
+  private readonly format: RichMessageDialect;
+  private readonly throttleMs: number;
+  private readonly finalizeOptions: FinalizeOptions;
+  private readonly callOptions: CallOptions;
+
+  /** The text accumulated so far — every delta appends. */
+  private text = '';
+  /** The text of the last draft actually pushed — skip a push when unchanged. */
+  private pushed = '';
+
+  constructor(
+    private readonly bot: BotService,
+    private readonly chatId: number,
+    private readonly source: StreamSource,
+    options: StreamOptions = {},
+  ) {
+    const { format, throttleMs, token, signal, ...finalizeOptions } = options;
+    this.format = format ?? MessageStream.DEFAULT_FORMAT;
+    this.throttleMs = throttleMs ?? MessageStream.DEFAULT_THROTTLE_MS;
+    this.finalizeOptions = finalizeOptions;
+    this.callOptions = { token, signal };
+  }
+
+  /**
+   * Run the stream to completion. Resolves the persisted {@link Message}, or
+   * `undefined` when the stream produced no text (nothing to send). A source
+   * error — or a failed draft push — aborts: the ephemeral draft expires and the
+   * error propagates, so nothing is persisted.
+   */
+  async run(): Promise<Message | undefined> {
+    let lastPushAt = 0;
+    for await (const delta of this.source) {
+      this.text += delta;
+      // Gate on real new content so a leading empty / duplicate chunk (LLM
+      // streams often open with an empty delta) doesn't spend the throttle
+      // window and suppress the first visible frame.
+      if (
+        this.text !== this.pushed &&
+        Date.now() - lastPushAt >= this.throttleMs
+      ) {
+        await this.pushDraft();
+        lastPushAt = Date.now();
+      }
+    }
+    return this.finalize();
+  }
+
+  /**
+   * Push the latest accumulated text as an animated draft frame. The caller
+   * (`run`) gates this on real new content, so it always has a frame to send.
+   */
+  private async pushDraft(): Promise<void> {
+    const snapshot = this.text;
+    await this.bot.sendRichMessageDraft(
+      this.chatId,
+      this.draftId,
+      this.fmt(snapshot),
+      this.callOptions,
+    );
+    this.pushed = snapshot;
+  }
+
+  /** Persist the full text as a real message — or nothing for an empty stream. */
+  private async finalize(): Promise<Message | undefined> {
+    if (this.text === '') {
+      MessageStream.logger.debug('Stream produced no text — nothing sent.');
+      return undefined;
+    }
+    return this.bot.sendRichMessage(this.chatId, this.fmt(this.text), {
+      ...this.finalizeOptions,
+      ...this.callOptions,
+    });
+  }
+
+  /** Wrap the accumulated text as the dialect's `InputRichMessage` field. */
+  private fmt(text: string): RawInputRichMessage {
+    return this.format === 'html' ? { html: text } : { markdown: text };
+  }
+}

--- a/lib/streaming/message-stream.ts
+++ b/lib/streaming/message-stream.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@nestjs/common';
 
+import { NestgramError } from '../exceptions';
 import type { BotService, CallOptions } from '../api';
 import type { SendRichMessageOptions } from '../api/methods';
 import type { Message } from '../events';
@@ -23,8 +24,8 @@ type FinalizeOptions = Partial<
  * never a DI singleton (which couldn't hold per-stream state). Same shape as the
  * rich events, which hold a `BotService` and are `new`ed per update.
  *
- * Private-chat only: `bot.streamMessage` guards that before constructing this —
- * `sendRichMessageDraft` has no group equivalent.
+ * Private-chat only — `run()` refuses a non-private chat (Telegram gives private
+ * chats positive ids); `sendRichMessageDraft` has no group equivalent.
  */
 export class MessageStream {
   private static readonly logger = new Logger(MessageStream.name);
@@ -73,6 +74,13 @@ export class MessageStream {
    * error propagates, so nothing is persisted.
    */
   async run(): Promise<Message | undefined> {
+    if (!MessageStream.isPrivateChatId(this.chatId)) {
+      throw new NestgramError(
+        `streamMessage needs a private chat, but chat_id ${this.chatId} is not ` +
+          'one — the native sendRichMessageDraft animation is private-chat-only. ' +
+          'Catch this to fall back to a plain send.',
+      );
+    }
     let lastPushAt = 0;
     for await (const delta of this.source) {
       this.text += delta;
@@ -120,5 +128,14 @@ export class MessageStream {
   /** Wrap the accumulated text as the dialect's `InputRichMessage` field. */
   private fmt(text: string): RawInputRichMessage {
     return this.format === 'html' ? { html: text } : { markdown: text };
+  }
+
+  /**
+   * Whether a chat id addresses a private (one-to-one) chat. Telegram gives
+   * users and private chats positive ids; groups, supergroups and channels are
+   * negative. The native draft is private-only, so `run()` gates on this.
+   */
+  private static isPrivateChatId(id: number): boolean {
+    return id > 0;
   }
 }

--- a/lib/streaming/stream.types.ts
+++ b/lib/streaming/stream.types.ts
@@ -1,0 +1,31 @@
+import type { MethodOptions } from '../api';
+import type { SendRichMessageOptions } from '../api/methods';
+import type { RichMessageDialect } from '../builtins/rich-messages/rich-messages.types';
+
+/**
+ * The text a stream consumes: an async iterable of *deltas* that concatenate
+ * into the growing message — an LLM token stream, an `async function*`, anything
+ * `for await`-able. Each yield appends (it is not a full replacement), so the
+ * engine accumulates them and the final message is the whole concatenation.
+ */
+export type StreamSource = AsyncIterable<string>;
+
+/**
+ * Options for a streamed message: the `sendRichMessage` finalize options (reply
+ * target, keyboard, notification, `token`/`signal`…) plus the two streaming
+ * knobs. The finalize options apply to the persisted message, not the animated
+ * draft frames.
+ */
+export interface StreamOptions
+  extends MethodOptions<
+    Omit<SendRichMessageOptions, 'chat_id' | 'rich_message'>
+  > {
+  /** Rich dialect the streamed text is written in. Defaults to `'markdown'`. */
+  format?: RichMessageDialect;
+  /**
+   * Minimum milliseconds between animated draft pushes. The engine coalesces
+   * deltas and pushes at most this often, so rapid tokens never flood — or queue
+   * behind — the send throttler. Defaults to ~1s.
+   */
+  throttleMs?: number;
+}


### PR DESCRIPTION
## What

Live message streaming — a dedicated `*Stream` family that streams a reply into
Telegram's native rich-message draft (`sendRichMessageDraft`, an ephemeral
animated preview), then persists the final text with `sendRichMessage`.

Three entry points, all funnelling through one hub:

- `bot.streamMessage(chat_id, source, options?)` — the hub.
- `message.answerStream(source, options?)` / `replyStream(source, options?)` — sugar on the event.
- a bare `return <async-iterable>` from a handler — the return-value mirror of `return 'text'`.

The source is an `AsyncIterable<string>` of text deltas, so a provider's
streaming response drops in unchanged.

```ts
@Router()
export class AssistantRouter {
  @Command('ask')
  ask(message: Message) {
    return llm(message.text ?? ''); // an AsyncIterable<string> — streamed
  }
}
```

## Design

- **Dedicated family, not an overload of `answer`/`sendMessage`.** A command
  object (`ApiMethod`) is a one-method / one-`call()` value; a stream is a
  multi-push loop whose orchestration lives above the transport, so it earns its
  own hub + engine (`MessageStream`) rather than widening existing send
  signatures.
- **Per-door error contract** (mirrors the existing return model): the method
  doors throw a typed `NestgramError` in a non-private chat (catchable — fall
  back to a plain send); a bare return warns and drops, like a bare
  `return 'string'` to a non-answerable event.
- **Private-chat only** — `sendRichMessageDraft` has no group equivalent.
  Self-enforced in `MessageStream.run()`. Guest messages are refused (their chat
  id can misdeliver — answer via `answerGuest`).
- **Throttler-friendly** — the engine coalesces to the latest text and pushes at
  most one draft frame per `throttleMs` (~1s default), so a fast token stream
  never floods, or queues behind, the send throttler. No builtin changes.
- **No privileged core** — the engine calls only public generated methods, and
  the bare-return path is one more branch in the same result handler that turns
  `return 'text'` into a send.

## Verify

- `npm run build && npm run lint && npx jest` — green (929 tests).
- `npm run typecheck` — covers `examples/streaming-bot`.
- `cd website && npm run build` — renders `docs/streaming.md`.
- End to end: `examples/streaming-bot` streams a fake token generator; DM the bot.

## Deferred (fast-follows)

- Group animation via `editMessageText` coalescing (a second transport).
- Exempting `sendRichMessageDraft` from the throttler for sub-second animation.
- `ReadableStream` / full-replacement sources (v1 is `AsyncIterable<string>` deltas).
