### PR TITLE
Rich message entities + typed context event accessors

### DIFF
--- a/docs/custom-predicates.md
+++ b/docs/custom-predicates.md
@@ -40,21 +40,24 @@ predicates are instantiated once when `DiscoveryService` builds the boot-time
 route table, then reused for every update — so a predicate instance is shared,
 keep it stateless.
 
-The context hands you three views of the same update:
+The context hands you several views of the same update:
 
-| Accessor      | What you get                                             |
-| ------------- | -------------------------------------------------------- |
-| `ctx.update`  | the raw `Update` Telegram sent, `Readonly`               |
-| `ctx.kind`    | the resolved `UpdateKind` (`resolveKind`'s whitelist)    |
-| `ctx.event`   | the rich typed event (`Message`, `CallbackQuery`, …)     |
-| `ctx.message` | the rich `Message` on a message update, else `undefined` |
-| `ctx.chat`    | the `Chat` the update happened in, if any                |
-| `ctx.from`    | the `User` who triggered it, if any                      |
+| Accessor            | What you get                                                    |
+| ------------------- | --------------------------------------------------------------- |
+| `ctx.update`        | the raw `Update` Telegram sent, `Readonly`                      |
+| `ctx.kind`          | the resolved `UpdateKind` (`resolveKind`'s whitelist)           |
+| `ctx.event`         | the rich typed event (`Message`, `CallbackQuery`, …)            |
+| `ctx.message`       | the rich `Message` on a message update, else `undefined`        |
+| `ctx.callbackQuery` | the rich `CallbackQuery` on a callback update, else `undefined` |
+| `ctx.chat`          | the `Chat` the update happened in, if any                       |
+| `ctx.from`          | the `User` who triggered it, if any                             |
 
 `ctx.event` is built lazily and cached; reach for `ctx.update` when you only need
-a raw field and want to skip building the rich event. `ctx.message` is that
-cached event narrowed to a `Message` — the rich way to read message content in a
-predicate (`ctx.message?.hasEntity('mention')`), no raw `update.message` needed.
+a raw field and want to skip building the rich event. `ctx.message` and
+`ctx.callbackQuery` are that cached event narrowed to a concrete type — the rich
+way to read content in a predicate (`ctx.message?.hasEntity('mention')`), no raw
+`update.message` needed. For a less common kind, `ctx.eventOf(InlineQuery)` gives
+the same narrowing for any event class.
 
 ## Writing one
 

--- a/docs/custom-predicates.md
+++ b/docs/custom-predicates.md
@@ -42,16 +42,19 @@ keep it stateless.
 
 The context hands you three views of the same update:
 
-| Accessor     | What you get                                         |
-| ------------ | ---------------------------------------------------- |
-| `ctx.update` | the raw `Update` Telegram sent, `Readonly`           |
-| `ctx.kind`   | the resolved `UpdateKind` (`resolveKind`'s whitelist)|
-| `ctx.event`  | the rich typed event (`Message`, `CallbackQuery`, …) |
-| `ctx.chat`   | the `Chat` the update happened in, if any            |
-| `ctx.from`   | the `User` who triggered it, if any                  |
+| Accessor      | What you get                                             |
+| ------------- | -------------------------------------------------------- |
+| `ctx.update`  | the raw `Update` Telegram sent, `Readonly`               |
+| `ctx.kind`    | the resolved `UpdateKind` (`resolveKind`'s whitelist)    |
+| `ctx.event`   | the rich typed event (`Message`, `CallbackQuery`, …)     |
+| `ctx.message` | the rich `Message` on a message update, else `undefined` |
+| `ctx.chat`    | the `Chat` the update happened in, if any                |
+| `ctx.from`    | the `User` who triggered it, if any                      |
 
 `ctx.event` is built lazily and cached; reach for `ctx.update` when you only need
-a raw field and want to skip building the rich event.
+a raw field and want to skip building the rich event. `ctx.message` is that
+cached event narrowed to a `Message` — the rich way to read message content in a
+predicate (`ctx.message?.hasEntity('mention')`), no raw `update.message` needed.
 
 ## Writing one
 
@@ -126,9 +129,7 @@ import {
 } from 'nestgram';
 
 // Matches a message like `en:reset` and exposes the `lang` segment to @Param.
-export class LocalePrefixPredicate
-  implements RoutePredicate, RouteParamSource
-{
+export class LocalePrefixPredicate implements RoutePredicate, RouteParamSource {
   private static readonly PATTERN = /^(?<lang>[a-z]{2}):reset$/;
 
   matches(ctx: TelegramExecutionContext): boolean {

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -1,0 +1,172 @@
+---
+title: Message entities
+description: Route on, inject, and read the mentions, hashtags, URLs, emails and commands Telegram marks up in a message — with @OnMention, @Mention, and message.hasEntity.
+sidebar:
+  label: Entities
+  group: Routing
+  order: 25
+---
+
+Telegram doesn't just hand you the text of a message — it also tells you which
+_spans_ of that text are special: an `@mention`, a `#hashtag`, a `$cashtag`, a
+`url`, an `email`, a `/command`, a `text_link`. Each is a **message entity**: a
+`{ type, offset, length }` triple that points into the text (or a media
+`caption`), rather than the substring itself. Nestgram gives you three ways to
+work with them, cheapest first.
+
+:::mental
+route on an entity (`@OnMention`) → inject its text (`@Mention`) → read it off the event (`message.hasEntity`)
+:::
+
+## Route on an entity
+
+The `@On*` family picks the handler by the _kind_ of entity present — the
+message-type layer, same as [`@OnMessage`](/docs/update-types). `@OnEntity(type)` is
+the generic form; the named aliases cover the common types.
+
+```ts
+import { OnMention, OnEntity, Router } from 'nestgram';
+import type { Message } from 'nestgram';
+
+@Router()
+export class LinksRouter {
+  // Fires for any message whose text OR caption contains a URL entity.
+  @OnEntity('url')
+  onLink(message: Message) {
+    return 'nice link';
+  }
+
+  @OnMention()
+  onMention(message: Message) {
+    return 'you rang?';
+  }
+}
+```
+
+`@OnEmail`, `@OnUrl`, `@OnMention`, `@OnHashtag`, `@OnCashtag` and `@OnPhone` are
+the built-in aliases; `@OnEntity('bot_command')` matches _any_ command (a
+specific one is [`@Command('start')`](/docs/commands-and-parameters)).
+
+## Inject the entity text
+
+Inside a handler, the entity **param decorators** pull the resolved text straight
+into an argument — no offsets, no slicing. Singular gives the first match;
+plural gives every match, from the text and the caption both.
+
+```ts
+import { Router, OnMention, Mention, Mentions, Entities } from 'nestgram';
+import type { Message } from 'nestgram';
+
+@Router()
+export class MentionRouter {
+  @OnMention()
+  onMention(
+    message: Message,
+    @Mention() first: string | undefined, // '@alice'
+    @Mentions() all: string[], // ['@alice', '@bob']
+    @Entities('url') urls: string[], // any URLs in the same message
+  ) {
+    return `first mention: ${first ?? 'none'}`;
+  }
+}
+```
+
+`@Email`/`@Emails`, `@Url`/`@Urls`, `@Hashtag`/`@Hashtags`, `@Cashtag`/`@Cashtags`
+and `@Phone`/`@Phones` follow the same singular/plural pair. `@Entity(type)` and
+`@Entities(type)` are the generic forms for any entity type.
+
+## Read entities off the message
+
+When the entity is _incidental_ to why the handler ran — you took the message
+for another reason and now want to check it — read it off the rich
+[`Message`](/docs/update-types) event directly.
+
+```ts
+// Does this message carry a mention at all?
+message.hasEntity('mention'); // boolean
+
+// Does it mention THIS bot specifically? (exact entity-text match)
+message.hasEntity({ type: 'mention', text: '@my_bot' }); // boolean
+
+// Every URL in the message, each with its text sliced out.
+message.entitiesOf('url'); // MessageEntity[]  → [{ type: 'url', offset, length, text }]
+
+// Every entity, any type.
+message.entitiesOf();
+```
+
+`entitiesOf()` returns each entity with its `text` resolved — the object form of
+`@Entities()`, useful when you also need an entity's `url` (`text_link`) or
+`user` (`text_mention`) field, not just the span. Both methods draw from the
+message text and a media caption, so `message.hasEntity('hashtag')` is `true`
+whether the `#tag` sat in the text or under a photo.
+
+:::note
+Entity `offset`/`length` are **UTF-16 code units** — which is exactly how
+JavaScript indexes strings, so nestgram slices them for you and you never touch
+the offsets. Hand-rolling `text.slice(offset, offset + length)` yourself is the
+one thing you don't need to do.
+:::
+
+## Entities in a custom predicate
+
+The richest payoff is a [custom predicate](/docs/custom-predicates). A predicate
+runs during route selection — before the handler — so it can't take a `Message`
+argument. Instead it reads the update off the execution context. Reach for
+**`ctx.message`**: the same rich `Message` a handler would get (entity sugar and
+all), not the raw payload.
+
+A common group-bot need — route a message to a handler only when it's addressed
+to the bot (any DM, or in a group an `@mention` of the bot or a reply to it):
+
+```ts
+import type { RoutePredicate, TelegramExecutionContext } from 'nestgram';
+
+export class AddressedToBotPredicate implements RoutePredicate {
+  async matches(ctx: TelegramExecutionContext): Promise<boolean> {
+    const message = ctx.message;
+    if (!message?.from || message.from.is_bot) {
+      return false;
+    }
+    if (message.chat.type === 'private') {
+      return true;
+    }
+
+    const me = await ctx.bot.getMe();
+    return (
+      message.reply_to_message?.from?.id === me.id ||
+      message.hasEntity({ type: 'mention', text: `@${me.username}` })
+    );
+  }
+}
+```
+
+```ts
+@OnMessage(new AddressedToBotPredicate())
+chat(message: Message) {
+  /* only runs when the message is aimed at the bot */
+}
+```
+
+No `update.message` raw access, no `RawMessageEntity`, no offset math — the
+predicate works with the rich event exactly as a handler does. `ctx.message` is
+`undefined` for non-message updates (a callback query, a poll), so the optional
+chain is the whole guard you need.
+
+## Entity types
+
+| Type           | Example              | Alias decorators             |
+| -------------- | -------------------- | ---------------------------- |
+| `mention`      | `@username`          | `@OnMention` · `@Mention(s)` |
+| `hashtag`      | `#topic`             | `@OnHashtag` · `@Hashtag(s)` |
+| `cashtag`      | `$USD`               | `@OnCashtag` · `@Cashtag(s)` |
+| `bot_command`  | `/start`             | `@OnEntity('bot_command')`   |
+| `url`          | `https://t.me`       | `@OnUrl` · `@Url(s)`         |
+| `email`        | `hi@t.me`            | `@OnEmail` · `@Email(s)`     |
+| `phone_number` | `+1-212-555-0123`    | `@OnPhone` · `@Phone(s)`     |
+| `text_link`    | a clickable label    | `@OnEntity('text_link')`     |
+| `text_mention` | a user without a `@` | `@OnEntity('text_mention')`  |
+| `custom_emoji` | an inline emoji      | `@OnEntity('custom_emoji')`  |
+
+Formatting entities (`bold`, `italic`, `code`, `spoiler`, …) ride in the same
+list — reach them with `@OnEntity('code')` or `message.entitiesOf('spoiler')`.

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -85,8 +85,8 @@ for another reason and now want to check it — read it off the rich
 // Does this message carry a mention at all?
 message.hasEntity('mention'); // boolean
 
-// Does it mention THIS bot specifically? (exact entity-text match)
-message.hasEntity({ type: 'mention', text: '@my_bot' }); // boolean
+// Does it @mention this bot? (case-insensitive, @ optional — see below)
+message.mentions('my_bot'); // boolean
 
 // Every URL in the message, each with its text sliced out.
 message.entitiesOf('url'); // MessageEntity[]  → [{ type: 'url', offset, length, text }]
@@ -100,6 +100,34 @@ message.entitiesOf();
 `user` (`text_mention`) field, not just the span. Both methods draw from the
 message text and a media caption, so `message.hasEntity('hashtag')` is `true`
 whether the `#tag` sat in the text or under a photo.
+
+Prefer `message.mentions(username)` over `hasEntity({ type: 'mention', text })`
+for mentions: Telegram usernames are **case-insensitive**, so `@My_Bot` and
+`@my_bot` are the same handle — but `hasEntity` matches the entity text exactly.
+`mentions()` normalizes case and makes the leading `@` optional, so it's the
+correct test. (It matches `@handle` mentions only, not the `text_mention` of a
+user without a username.)
+
+## Reconstruct the formatting
+
+An incoming message arrives as plain `text` plus an `entities` array — the
+**bold**, _italic_, `code`, links and spoilers are described positionally, not in
+the string. `message.html` and `message.markdown` render that back into formatted
+source, the inverse of sending with a `parse_mode`. A bot that quotes, echoes or
+logs a user's message keeps its formatting instead of flattening it.
+
+```ts
+// message.text = 'hello world', one bold entity over 'world'
+message.html; // 'hello <b>world</b>'
+message.markdown; // 'hello *world*'  (MarkdownV2)
+
+// Quote it straight back, formatting intact:
+message.reply(message.html, { parse_mode: 'HTML' });
+```
+
+Both read from the caption for a media message, and are `''` when there's no
+text or caption. Overlapping entities that can't be expressed as nested markup
+are dropped to plain text rather than producing broken output.
 
 :::note
 Entity `offset`/`length` are **UTF-16 code units** — which is exactly how

--- a/docs/guards-and-pipeline.md
+++ b/docs/guards-and-pipeline.md
@@ -12,12 +12,12 @@ handler is invoked through Nest's own `ExternalContextCreator` — the same
 machinery behind your HTTP controllers — so the primitives you already
 know wrap a router method exactly as they wrap a route:
 
-| Primitive            | Apply with               | Runs                          |
-| -------------------- | ------------------------ | ----------------------------- |
-| Guard                | `@UseGuards()`           | before the handler; `false` blocks it |
-| Interceptor          | `@UseInterceptors()`     | around the handler, both sides |
-| Pipe                 | `@UsePipes()`            | on params, before the handler |
-| Exception filter     | `@Catch()` + `@UseFilters()` | when the handler (or pipeline) throws |
+| Primitive        | Apply with                   | Runs                                  |
+| ---------------- | ---------------------------- | ------------------------------------- |
+| Guard            | `@UseGuards()`               | before the handler; `false` blocks it |
+| Interceptor      | `@UseInterceptors()`         | around the handler, both sides        |
+| Pipe             | `@UsePipes()`                | on params, before the handler         |
+| Exception filter | `@Catch()` + `@UseFilters()` | when the handler (or pipeline) throws |
 
 There is no Nestgram middleware system to learn. The `bot.use(...)` chain you'd
 reach for in telegraf maps onto whichever of these four does the job.
@@ -33,14 +33,15 @@ event. `TelegramExecutionContext.of(context)` unwraps it — the engine invokes
 handlers as `invoker(event, ctx)`, so the wrapper sits at argument index 1, and
 `.of()` reads it back.
 
-| Accessor       | Is                                                  |
-| -------------- | --------------------------------------------------- |
-| `ctx.event`    | the rich typed event (`Message`, `CallbackQuery`, …) |
-| `ctx.from`     | the `User` who triggered the update, or `undefined`  |
-| `ctx.chat`     | the chat the update happened in, or `undefined`      |
-| `ctx.kind`     | the resolved `UpdateKind`                             |
-| `ctx.update`   | the raw, read-only update payload                    |
-| `ctx.state`    | a per-update `Map` you can read and write            |
+| Accessor      | Is                                                     |
+| ------------- | ------------------------------------------------------ |
+| `ctx.event`   | the rich typed event (`Message`, `CallbackQuery`, …)   |
+| `ctx.message` | the rich `Message` on a message update, or `undefined` |
+| `ctx.from`    | the `User` who triggered the update, or `undefined`    |
+| `ctx.chat`    | the chat the update happened in, or `undefined`        |
+| `ctx.kind`    | the resolved `UpdateKind`                              |
+| `ctx.update`  | the raw, read-only update payload                      |
+| `ctx.state`   | a per-update `Map` you can read and write              |
 
 ## An admin-only guard
 
@@ -122,7 +123,8 @@ export class AdminGuard implements CanActivate {
     const userId =
       context.getType<'http' | 'telegram'>() === 'telegram'
         ? TelegramExecutionContext.of(context).from?.id
-        : context.switchToHttp().getRequest<{ user?: { id: number } }>().user?.id;
+        : context.switchToHttp().getRequest<{ user?: { id: number } }>().user
+            ?.id;
 
     return userId !== undefined && ADMIN_IDS.has(userId);
   }
@@ -166,7 +168,9 @@ export class LoggingInterceptor implements NestInterceptor {
     this.logger.log(`${ctx.kind} from ${who}`);
     return next
       .handle()
-      .pipe(tap(() => this.logger.log(`handled in ${Date.now() - startedAt}ms`)));
+      .pipe(
+        tap(() => this.logger.log(`handled in ${Date.now() - startedAt}ms`)),
+      );
   }
 }
 ```

--- a/docs/guards-and-pipeline.md
+++ b/docs/guards-and-pipeline.md
@@ -33,15 +33,16 @@ event. `TelegramExecutionContext.of(context)` unwraps it — the engine invokes
 handlers as `invoker(event, ctx)`, so the wrapper sits at argument index 1, and
 `.of()` reads it back.
 
-| Accessor      | Is                                                     |
-| ------------- | ------------------------------------------------------ |
-| `ctx.event`   | the rich typed event (`Message`, `CallbackQuery`, …)   |
-| `ctx.message` | the rich `Message` on a message update, or `undefined` |
-| `ctx.from`    | the `User` who triggered the update, or `undefined`    |
-| `ctx.chat`    | the chat the update happened in, or `undefined`        |
-| `ctx.kind`    | the resolved `UpdateKind`                              |
-| `ctx.update`  | the raw, read-only update payload                      |
-| `ctx.state`   | a per-update `Map` you can read and write              |
+| Accessor            | Is                                                     |
+| ------------------- | ------------------------------------------------------ |
+| `ctx.event`         | the rich typed event (`Message`, `CallbackQuery`, …)   |
+| `ctx.message`       | the rich `Message` on a message update, or `undefined` |
+| `ctx.callbackQuery` | the rich `CallbackQuery` on a callback, or `undefined` |
+| `ctx.from`          | the `User` who triggered the update, or `undefined`    |
+| `ctx.chat`          | the chat the update happened in, or `undefined`        |
+| `ctx.kind`          | the resolved `UpdateKind`                              |
+| `ctx.update`        | the raw, read-only update payload                      |
+| `ctx.state`         | a per-update `Map` you can read and write              |
 
 ## An admin-only guard
 

--- a/docs/guards-and-pipeline.md
+++ b/docs/guards-and-pipeline.md
@@ -289,5 +289,6 @@ Cross-cutting concerns — auth, rate limits, logging, i18n, error mapping — l
 in guards, interceptors, pipes and filters, never copied into every handler.
 That is the whole payoff of running on `ExternalContextCreator`: the pipeline
 you reason about for an HTTP route is the pipeline that runs here. From this
-base, [Handling errors](/docs/handling-errors) goes deep on the filter side and
-[Rate limiting](/docs/rate-limiting) on the throttle interceptor.
+base, [Handling errors](/docs/handling-errors) goes deep on the filter side,
+[Send throttling](/docs/throttling) on the outbound throttle interceptor, and
+[Rate limiting](/docs/rate-limiting) on capping inbound updates.

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,203 +1,189 @@
 ---
-title: Send throttling (flood control)
-description: The built-in send throttler — a global token bucket, a per-chat minimum interval, and a scope-aware 429 handler that honors retry_after. On by default; tune it with throttle, or replace it with throttler.
+title: Rate limiting
+description: Cap how often a user or chat can trigger your handlers — an inbound flood guard via RateLimitModule, @RateLimit and @SkipRateLimit, with a silent drop or an onLimit reply.
 sidebar:
   label: Rate limiting
   group: The Nest pipeline
-  order: 62
+  order: 61
 ---
 
-Telegram rate-limits what your bot _sends_, not just what it receives. Exceed
-roughly 30 messages a second globally, or send to the same chat faster than
-about once a second, and you start collecting `429 Too Many Requests` with a
-`retry_after`. The **send throttler** paces your outbound calls so you stay
-under those limits, and absorbs the 429s you do hit — on by default, no wiring.
+[Send throttling](/docs/throttling) paces what your bot **sends**. Rate limiting
+is the opposite end of the pipe: it caps what your bot **accepts** — how often a
+single user or chat can trigger a handler. Someone hammering a command, a script
+spamming a group: rate limiting drops the excess updates before they reach your
+code, so an expensive handler (an LLM call, a DB write) runs at most `limit`
+times per rolling window.
 
 :::mental
-your send -> per-chat gate -> global bucket -> Telegram (429? back off, retry)
+update in → rate-limit gate (per user/chat) → within limit? handler runs : dropped
 :::
 
-This is the **outbound** side: it shapes the bot's calls to the Bot API. Don't
-conflate it with the **inbound** [update queue](/docs/how-nestgram-works), which
-serializes _incoming_ updates per chat. They sit at opposite ends of the request
-— one paces what you send, the other paces what you process — and both run by
-default.
+It's off unless you import it — one module alongside `NestgramModule`.
 
-## How it gates a send
+## Turning it on
 
-The throttler is the innermost interceptor in the [outbound API
-pipeline](/docs/guards-and-pipeline) — `ThrottleInterceptor`, the last onion
-layer before the call leaves for Telegram. Every send passes through two gates,
-in order:
-
-1. **The per-chat gate.** A `chat_id` send first acquires a per-chat slot — a
-   minimum-interval limiter (default 1s between sends to one chat). Groups and
-   channels additionally pass a `20 / 60s` token bucket. Acquired _before_ the
-   global token, so a chat that's still cooling down doesn't burn a global token
-   it can't yet use.
-2. **The global token bucket.** One bucket shared across the whole bot
-   (`30 / 1s` by default), refilling continuously so short bursts are allowed
-   while the average rate holds.
-
-Only then does the call go out. Both gates serialize their waiters in FIFO
-order, so a chat's messages keep their send order even when several are queued
-behind the limiter.
-
-:::note
-The throttler reads `chat_id` from the final payload, _after_ the mutating
-interceptors (parse-mode, rich-messages, the file-id cache) have run. A send
-without a `chat_id` skips the per-chat gate and only takes a global token.
-:::
-
-## Read calls pass through
-
-Reads don't count against Telegram's send limits, so the throttler waves them
-past untouched — they neither spend a global token nor stall behind a send-side
-backoff. The pass-through is decided by the method name:
-
-| Method group                                    | Throttled? |
-| ----------------------------------------------- | ---------- |
-| Anything starting with `get*` (incl. `getUpdates`, `getMe`, `getFile`) | no — passes through |
-| `setWebhook`, `deleteWebhook`, `logOut`, `close` | no — webhook/session admin |
-| Everything else (`sendMessage`, `sendPhoto`, `editMessageText`, `answerCallbackQuery`, …) | yes |
-
-This matters most for long polling: `getUpdates` runs through the same outbound
-pipeline, and routing it through the throttler would burn your send budget and
-couple the poll loop to a send-side 429 backoff. The policy lives on the
-throttler itself — not as a flag on every method class — so it travels with the
-component you can swap out.
-
-## On a 429: scope-aware backoff
-
-When a send comes back `429`, the throttler doesn't just bubble the error — it
-reads the `retry_after` Telegram returned and waits it out, then retries the
-same call, up to `maxRetries` times. The wait is `retry_after` plus a small
-`retryBufferMs` cushion; a 429 that omits `retry_after` falls back to
-`fallbackRetrySeconds`.
-
-The clever part is _what_ it pauses, keyed on the 429's `scope`:
-
-| 429 `scope`        | What backs off                                              |
-| ------------------ | ---------------------------------------------------------- |
-| `global`           | the global bucket — the whole bot pauses for the window    |
-| per-chat / absent  | only that chat's limiter — other chats keep flowing        |
-
-So a global flood-wait stalls everything until it clears, while a per-chat
-flood-wait quarantines just the offending chat. Every send already queued behind
-the paused limiter inherits the backoff, instead of each rediscovering the 429
-on its own.
-
-If retries are exhausted — or you set `retry: false` — the `ApiException`
-surfaces unchanged, so a handler-side [`@Catch` filter](/docs/handling-errors)
-can react to it (`ApiException.is(error, 429)`, `error.parameters?.retry_after`)
-like any other API failure.
-
-## Tuning it
-
-Pass an object to `throttle` to override any default. Telegram's limits are
-unofficial and shift, so every knob is open:
+`RateLimitModule.forRoot` with a `default` rule applies to every route: at most
+`limit` updates per rolling `windowMs`, scoped per user-per-chat.
 
 :::code[app.module.ts]
 
 ```ts
 import { Module } from '@nestjs/common';
-import { NestgramModule } from 'nestgram';
-import { EchoRouter } from './echo.router';
+import { NestgramModule, RateLimitModule } from 'nestgram';
+import { ChatRouter } from './chat.router';
 
 @Module({
   imports: [
     NestgramModule.forRoot({
       token: process.env.BOT_TOKEN ?? '',
       polling: true,
-      throttle: {
-        globalRate: 30,
-        globalIntervalMs: 1000,
-        perChatIntervalMs: 1000,
-        maxRetries: 5,
-      },
+    }),
+    RateLimitModule.forRoot({
+      default: { limit: 5, windowMs: 10_000 }, // 5 updates / 10s per user
     }),
   ],
-  providers: [EchoRouter],
+  providers: [ChatRouter],
 })
 export class AppModule {}
 ```
 
 :::
 
-The full knob set, with defaults:
+Omit `default` to limit **only** the routes you decorate explicitly — the module
+then does nothing until a `@RateLimit` opts a route in.
 
-| Knob                   | Default | Effect                                                                    |
-| ---------------------- | ------- | ------------------------------------------------------------------------- |
-| `globalRate`           | `30`    | Global allowance: sends per `globalIntervalMs`.                           |
-| `globalIntervalMs`     | `1000`  | The window the global bucket refills over.                               |
-| `perChatIntervalMs`    | `1000`  | Minimum gap between two sends to the same chat.                          |
-| `groupRate`            | `20`    | Group/channel allowance: sends per `groupIntervalMs`.                    |
-| `groupIntervalMs`      | `60000` | The window the per-group bucket refills over.                           |
-| `maxRetries`           | `3`     | How many times a 429 is retried before the `ApiException` surfaces.      |
-| `retry`                | `true`  | Retry 429s at all; `false` surfaces them immediately.                   |
-| `retryBufferMs`        | `250`   | Extra wait added on top of `retry_after` before retrying.               |
-| `fallbackRetrySeconds` | `5`     | Wait used when a 429 omits `retry_after`.                               |
-| `idleTtlMs`            | `300000`| Evict a per-chat limiter idle at least this long.                       |
-| `maxKeys`              | `10000` | Hard cap on tracked chats; LRU-evict past it.                           |
-| `sweepIntervalMs`      | `60000` | How often the idle sweeper runs.                                        |
+## Per-route rules
 
-:::note
-The last three knobs bound memory, not rate. Per-chat limiters are created
-lazily and an unref'd sweeper evicts the idle ones, so the chat map can't grow
-without bound as new chats message a long-running bot.
+`@RateLimit(rule)` overrides the default for one handler, or for a whole
+`@Router()` class. `@SkipRateLimit()` exempts a route entirely — it always wins.
+
+:::code[chat.router.ts]
+
+```ts
+import { Router, Command, RateLimit, SkipRateLimit } from 'nestgram';
+import type { Message } from 'nestgram';
+
+@Router()
+export class ChatRouter {
+  // Expensive: tighten it well below the module default.
+  @Command('ask')
+  @RateLimit({ limit: 3, windowMs: 60_000 })
+  ask(message: Message) {
+    return 'thinking…';
+  }
+
+  // Cheap and always welcome — never limited.
+  @Command('help')
+  @SkipRateLimit()
+  help(message: Message) {
+    return 'here to help';
+  }
+}
+```
+
 :::
 
-## Turning it off
+Resolution is nearest-wins: `@SkipRateLimit` first, then a handler `@RateLimit`,
+then a class `@RateLimit`, then the module `default`. No rule anywhere → the
+update passes through uncounted.
 
-`throttle: false` makes the interceptor a pure passthrough — it stays in the
-pipeline but every call goes straight through. Reach for this only when
-something upstream already paces your sends (your own queue, a gateway), since
-without it nothing stands between your bot and a 429 storm.
+## What happens at the limit
+
+Over the limit, the handler **never runs**. By default the update is dropped
+silently — the flooder simply gets no response. Pass `onLimit` to answer instead:
+whatever it returns flows through the normal [reply path](/docs/handling-errors),
+so a `string` (or a `SendMessage`) becomes a "slow down" message. Return nothing
+to stay silent for that call.
 
 :::code[app.module.ts]
 
 ```ts
-import { NestgramModule } from 'nestgram';
-
-NestgramModule.forRoot({
-  token: process.env.BOT_TOKEN ?? '',
-  polling: true,
-  throttle: false, // no pacing — you own send rate
+RateLimitModule.forRoot({
+  default: {
+    limit: 5,
+    windowMs: 10_000,
+    onLimit: () => '⏳ Too fast — give it a few seconds.',
+  },
 });
 ```
 
 :::
+
+:::note
+Rate limiting is an **interceptor**, not a guard, on purpose. A guard returning
+`false` makes Nest throw `ForbiddenException`, which hits your exception filters —
+not a silent drop. The interceptor short-circuits cleanly: within limit it calls
+the handler, over limit it emits the `onLimit` value or nothing at all.
+:::
+
+## What the counter is keyed on
+
+Each rule counts against a **key**. The default is the conversation scope — bot ·
+chat · user · forum topic · business connection — so one user flooding a group
+doesn't limit everyone else, and the same user in two chats gets two budgets.
+
+Override `key` to change the scope. Return `undefined` to skip an update (nothing
+to scope it to):
+
+:::code[app.module.ts]
+
+```ts
+RateLimitModule.forRoot({
+  // One shared budget for the whole chat, regardless of who sends.
+  default: {
+    limit: 20,
+    windowMs: 60_000,
+    key: (ctx) => (ctx.chat ? `chat:${ctx.chat.id}` : undefined),
+  },
+});
+```
+
+:::
+
+## Scaling out
+
+The counters live in a process-local store by default. That's correct for a
+single instance; bound its memory with `idleTtlMs` (evict a key idle at least
+that long — set it **≥ your largest window**). Run more than one instance and the
+per-process counters diverge, so give it a shared store — the same
+[`KeyValueStore`](/docs/sessions) seam sessions use, backed by Redis. Resolve it
+from config with `forRootAsync`:
+
+:::code[app.module.ts]
+
+```ts
+import { RateLimitModule } from 'nestgram';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
+RateLimitModule.forRootAsync({
+  imports: [ConfigModule],
+  inject: [ConfigService],
+  useFactory: (config: ConfigService) => ({
+    default: { limit: 5, windowMs: 10_000 },
+    store: new RedisRateLimitStore(config.get('REDIS_URL')),
+  }),
+});
+```
+
+:::
+
+## Options
+
+| Option      | Applies to    | Effect                                                                     |
+| ----------- | ------------- | -------------------------------------------------------------------------- |
+| `default`   | module        | Fallback `{ limit, windowMs, key?, onLimit? }` for undecorated routes.     |
+| `store`     | module        | Counter persistence. Default: in-memory; supply Redis to scale out.        |
+| `idleTtlMs` | module        | Evict an idle in-memory key after this long. Must be ≥ the largest window. |
+| `key`       | module / rule | Scope function. Default: the conversation key; `undefined` skips.          |
+| `onLimit`   | module / rule | Called when an update is dropped; a returned value becomes the reply.      |
+| `limit`     | rule          | Max updates allowed within the window.                                     |
+| `windowMs`  | rule          | Rolling window length, in milliseconds.                                    |
+
+`key` and `onLimit` set on a `@RateLimit` rule beat the module-level ones, which
+beat the built-in defaults.
 
 ## Not a privileged core
 
-The throttler is one public `ApiInterceptor`, the same contract your own
-outbound interceptors implement — nothing the framework reserves for itself. Set
-`throttler` to a class of your own and it takes the innermost slot instead of
-the built-in:
-
-:::code[app.module.ts]
-
-```ts
-import { NestgramModule } from 'nestgram';
-import { DistributedThrottleInterceptor } from './distributed-throttle.interceptor';
-
-NestgramModule.forRoot({
-  token: process.env.BOT_TOKEN ?? '',
-  polling: true,
-  throttler: DistributedThrottleInterceptor, // your interceptor, innermost slot
-});
-```
-
-:::
-
-This is the seam for the throttler's one real limitation: its buckets live **in
-process**, so each replica paces against its own budget and `N` replicas can
-collectively still exceed Telegram's limits. A Redis-backed `throttler` sharing
-state across the fleet swaps in through exactly this interface — same `intercept`
-contract, replacing the default rather than wrapping it.
-
-:::tip
-`throttle` tunes the built-in throttler; `throttler` _replaces_ it. Set
-`throttler` and the `throttle` knobs no longer apply — your interceptor owns the
-policy end to end.
-:::
+`RateLimitModule` registers one public `APP_INTERCEPTOR` — the same kind of
+interceptor you could write by hand, holding no reserved framework powers. Leave
+the module out and rate limiting is simply absent; there is nothing to turn off.

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -1,0 +1,203 @@
+---
+title: Send throttling (flood control)
+description: The built-in send throttler — a global token bucket, a per-chat minimum interval, and a scope-aware 429 handler that honors retry_after. On by default; tune it with throttle, or replace it with throttler.
+sidebar:
+  label: Send throttling
+  group: The Nest pipeline
+  order: 62
+---
+
+Telegram rate-limits what your bot _sends_, not just what it receives. Exceed
+roughly 30 messages a second globally, or send to the same chat faster than
+about once a second, and you start collecting `429 Too Many Requests` with a
+`retry_after`. The **send throttler** paces your outbound calls so you stay
+under those limits, and absorbs the 429s you do hit — on by default, no wiring.
+
+:::mental
+your send -> per-chat gate -> global bucket -> Telegram (429? back off, retry)
+:::
+
+This is the **outbound** side: it shapes the bot's calls to the Bot API. Don't
+conflate it with the **inbound** [update queue](/docs/how-nestgram-works), which
+serializes _incoming_ updates per chat. They sit at opposite ends of the request
+— one paces what you send, the other paces what you process — and both run by
+default.
+
+## How it gates a send
+
+The throttler is the innermost interceptor in the [outbound API
+pipeline](/docs/guards-and-pipeline) — `ThrottleInterceptor`, the last onion
+layer before the call leaves for Telegram. Every send passes through two gates,
+in order:
+
+1. **The per-chat gate.** A `chat_id` send first acquires a per-chat slot — a
+   minimum-interval limiter (default 1s between sends to one chat). Groups and
+   channels additionally pass a `20 / 60s` token bucket. Acquired _before_ the
+   global token, so a chat that's still cooling down doesn't burn a global token
+   it can't yet use.
+2. **The global token bucket.** One bucket shared across the whole bot
+   (`30 / 1s` by default), refilling continuously so short bursts are allowed
+   while the average rate holds.
+
+Only then does the call go out. Both gates serialize their waiters in FIFO
+order, so a chat's messages keep their send order even when several are queued
+behind the limiter.
+
+:::note
+The throttler reads `chat_id` from the final payload, _after_ the mutating
+interceptors (parse-mode, rich-messages, the file-id cache) have run. A send
+without a `chat_id` skips the per-chat gate and only takes a global token.
+:::
+
+## Read calls pass through
+
+Reads don't count against Telegram's send limits, so the throttler waves them
+past untouched — they neither spend a global token nor stall behind a send-side
+backoff. The pass-through is decided by the method name:
+
+| Method group                                                                              | Throttled?                 |
+| ----------------------------------------------------------------------------------------- | -------------------------- |
+| Anything starting with `get*` (incl. `getUpdates`, `getMe`, `getFile`)                    | no — passes through        |
+| `setWebhook`, `deleteWebhook`, `logOut`, `close`                                          | no — webhook/session admin |
+| Everything else (`sendMessage`, `sendPhoto`, `editMessageText`, `answerCallbackQuery`, …) | yes                        |
+
+This matters most for long polling: `getUpdates` runs through the same outbound
+pipeline, and routing it through the throttler would burn your send budget and
+couple the poll loop to a send-side 429 backoff. The policy lives on the
+throttler itself — not as a flag on every method class — so it travels with the
+component you can swap out.
+
+## On a 429: scope-aware backoff
+
+When a send comes back `429`, the throttler doesn't just bubble the error — it
+reads the `retry_after` Telegram returned and waits it out, then retries the
+same call, up to `maxRetries` times. The wait is `retry_after` plus a small
+`retryBufferMs` cushion; a 429 that omits `retry_after` falls back to
+`fallbackRetrySeconds`.
+
+The clever part is _what_ it pauses, keyed on the 429's `scope`:
+
+| 429 `scope`       | What backs off                                          |
+| ----------------- | ------------------------------------------------------- |
+| `global`          | the global bucket — the whole bot pauses for the window |
+| per-chat / absent | only that chat's limiter — other chats keep flowing     |
+
+So a global flood-wait stalls everything until it clears, while a per-chat
+flood-wait quarantines just the offending chat. Every send already queued behind
+the paused limiter inherits the backoff, instead of each rediscovering the 429
+on its own.
+
+If retries are exhausted — or you set `retry: false` — the `ApiException`
+surfaces unchanged, so a handler-side [`@Catch` filter](/docs/handling-errors)
+can react to it (`ApiException.is(error, 429)`, `error.parameters?.retry_after`)
+like any other API failure.
+
+## Tuning it
+
+Pass an object to `throttle` to override any default. Telegram's limits are
+unofficial and shift, so every knob is open:
+
+:::code[app.module.ts]
+
+```ts
+import { Module } from '@nestjs/common';
+import { NestgramModule } from 'nestgram';
+import { EchoRouter } from './echo.router';
+
+@Module({
+  imports: [
+    NestgramModule.forRoot({
+      token: process.env.BOT_TOKEN ?? '',
+      polling: true,
+      throttle: {
+        globalRate: 30,
+        globalIntervalMs: 1000,
+        perChatIntervalMs: 1000,
+        maxRetries: 5,
+      },
+    }),
+  ],
+  providers: [EchoRouter],
+})
+export class AppModule {}
+```
+
+:::
+
+The full knob set, with defaults:
+
+| Knob                   | Default  | Effect                                                              |
+| ---------------------- | -------- | ------------------------------------------------------------------- |
+| `globalRate`           | `30`     | Global allowance: sends per `globalIntervalMs`.                     |
+| `globalIntervalMs`     | `1000`   | The window the global bucket refills over.                          |
+| `perChatIntervalMs`    | `1000`   | Minimum gap between two sends to the same chat.                     |
+| `groupRate`            | `20`     | Group/channel allowance: sends per `groupIntervalMs`.               |
+| `groupIntervalMs`      | `60000`  | The window the per-group bucket refills over.                       |
+| `maxRetries`           | `3`      | How many times a 429 is retried before the `ApiException` surfaces. |
+| `retry`                | `true`   | Retry 429s at all; `false` surfaces them immediately.               |
+| `retryBufferMs`        | `250`    | Extra wait added on top of `retry_after` before retrying.           |
+| `fallbackRetrySeconds` | `5`      | Wait used when a 429 omits `retry_after`.                           |
+| `idleTtlMs`            | `300000` | Evict a per-chat limiter idle at least this long.                   |
+| `maxKeys`              | `10000`  | Hard cap on tracked chats; LRU-evict past it.                       |
+| `sweepIntervalMs`      | `60000`  | How often the idle sweeper runs.                                    |
+
+:::note
+The last three knobs bound memory, not rate. Per-chat limiters are created
+lazily and an unref'd sweeper evicts the idle ones, so the chat map can't grow
+without bound as new chats message a long-running bot.
+:::
+
+## Turning it off
+
+`throttle: false` makes the interceptor a pure passthrough — it stays in the
+pipeline but every call goes straight through. Reach for this only when
+something upstream already paces your sends (your own queue, a gateway), since
+without it nothing stands between your bot and a 429 storm.
+
+:::code[app.module.ts]
+
+```ts
+import { NestgramModule } from 'nestgram';
+
+NestgramModule.forRoot({
+  token: process.env.BOT_TOKEN ?? '',
+  polling: true,
+  throttle: false, // no pacing — you own send rate
+});
+```
+
+:::
+
+## Not a privileged core
+
+The throttler is one public `ApiInterceptor`, the same contract your own
+outbound interceptors implement — nothing the framework reserves for itself. Set
+`throttler` to a class of your own and it takes the innermost slot instead of
+the built-in:
+
+:::code[app.module.ts]
+
+```ts
+import { NestgramModule } from 'nestgram';
+import { DistributedThrottleInterceptor } from './distributed-throttle.interceptor';
+
+NestgramModule.forRoot({
+  token: process.env.BOT_TOKEN ?? '',
+  polling: true,
+  throttler: DistributedThrottleInterceptor, // your interceptor, innermost slot
+});
+```
+
+:::
+
+This is the seam for the throttler's one real limitation: its buckets live **in
+process**, so each replica paces against its own budget and `N` replicas can
+collectively still exceed Telegram's limits. A Redis-backed `throttler` sharing
+state across the fleet swaps in through exactly this interface — same `intercept`
+contract, replacing the default rather than wrapping it.
+
+:::tip
+`throttle` tunes the built-in throttler; `throttler` _replaces_ it. Set
+`throttler` and the `throttle` knobs no longer apply — your interceptor owns the
+policy end to end.
+:::

--- a/lib/engine/context/telegram-execution-context.spec.ts
+++ b/lib/engine/context/telegram-execution-context.spec.ts
@@ -1,5 +1,6 @@
 import { BotService } from '../../api';
 import { Message } from '../../events/message';
+import { CallbackQuery } from '../../events/callback-query';
 import { RawUpdate } from '../../events/raw-update.types';
 import { ContextFactory } from './context-factory';
 import { EventFactory } from './event-factory';
@@ -54,5 +55,54 @@ describe('TelegramExecutionContext.message', () => {
       },
     });
     expect(ctx.message).toBeUndefined();
+  });
+});
+
+describe('TelegramExecutionContext.callbackQuery', () => {
+  const callbackUpdate: RawUpdate = {
+    update_id: 1,
+    callback_query: {
+      id: 'q',
+      from: { id: 42, is_bot: false, first_name: 'Bob' },
+      chat_instance: 'c',
+      data: 'done/7',
+    },
+  };
+
+  it('exposes the rich CallbackQuery for a callback update', () => {
+    const ctx = wrap(callbackUpdate);
+    expect(ctx.callbackQuery).toBeInstanceOf(CallbackQuery);
+    expect(ctx.callbackQuery?.data).toBe('done/7');
+  });
+
+  it('is undefined for a message update', () => {
+    const ctx = wrap({
+      update_id: 1,
+      message: { message_id: 1, date: 1, chat: { id: 1, type: 'private' } },
+    });
+    expect(ctx.callbackQuery).toBeUndefined();
+  });
+});
+
+describe('TelegramExecutionContext.eventOf', () => {
+  it('narrows the event to the requested type, else undefined', () => {
+    const messageCtx = wrap({
+      update_id: 1,
+      message: { message_id: 1, date: 1, chat: { id: 1, type: 'private' } },
+    });
+    expect(messageCtx.eventOf(Message)).toBeInstanceOf(Message);
+    expect(messageCtx.eventOf(CallbackQuery)).toBeUndefined();
+
+    const callbackCtx = wrap({
+      update_id: 1,
+      callback_query: {
+        id: 'q',
+        from: { id: 42, is_bot: false, first_name: 'Bob' },
+        chat_instance: 'c',
+        data: 'x',
+      },
+    });
+    expect(callbackCtx.eventOf(CallbackQuery)).toBeInstanceOf(CallbackQuery);
+    expect(callbackCtx.eventOf(Message)).toBeUndefined();
   });
 });

--- a/lib/engine/context/telegram-execution-context.spec.ts
+++ b/lib/engine/context/telegram-execution-context.spec.ts
@@ -1,0 +1,58 @@
+import { BotService } from '../../api';
+import { Message } from '../../events/message';
+import { RawUpdate } from '../../events/raw-update.types';
+import { ContextFactory } from './context-factory';
+import { EventFactory } from './event-factory';
+import { TelegramExecutionContext } from './telegram-execution-context';
+
+function wrap(update: RawUpdate): TelegramExecutionContext {
+  const botService = { token: 'TEST' } as unknown as BotService;
+  const ctx = new ContextFactory(botService, new EventFactory()).wrap(update);
+  if (!ctx) {
+    throw new Error('expected a resolvable update');
+  }
+  return ctx;
+}
+
+describe('TelegramExecutionContext.message', () => {
+  it('exposes the rich Message for a message-family update', () => {
+    const ctx = wrap({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1,
+        chat: { id: 99, type: 'supergroup' },
+        from: { id: 7, is_bot: false, first_name: 'Alice' },
+        text: 'ping @my_bot',
+        entities: [{ type: 'mention', offset: 5, length: 7 }],
+      },
+    });
+
+    expect(ctx.message).toBeInstanceOf(Message);
+    // The whole point: a custom predicate reads entities off the rich event.
+    expect(ctx.message?.hasEntity({ type: 'mention', text: '@my_bot' })).toBe(
+      true,
+    );
+  });
+
+  it('returns the same cached event as `event` (no second build)', () => {
+    const ctx = wrap({
+      update_id: 1,
+      message: { message_id: 1, date: 1, chat: { id: 1, type: 'private' } },
+    });
+    expect(ctx.message).toBe(ctx.event);
+  });
+
+  it('is undefined for a non-message update', () => {
+    const ctx = wrap({
+      update_id: 1,
+      callback_query: {
+        id: 'q',
+        from: { id: 42, is_bot: false, first_name: 'Bob' },
+        chat_instance: 'c',
+        data: 'data',
+      },
+    });
+    expect(ctx.message).toBeUndefined();
+  });
+});

--- a/lib/engine/context/telegram-execution-context.ts
+++ b/lib/engine/context/telegram-execution-context.ts
@@ -3,6 +3,8 @@ import { ArgumentsHost } from '@nestjs/common';
 import { BotService } from '../../api';
 import { User } from '../../events/user';
 import { Message } from '../../events/message';
+import { CallbackQuery } from '../../events/callback-query';
+import { TelegramObject } from '../../events/telegram-object';
 import { RawChat, RawUpdate } from '../../events/raw-update.types';
 import { extractChat, extractSender } from '../execution/extractors';
 import { EventFactory, TelegramEvent } from './event-factory';
@@ -63,7 +65,29 @@ export class TelegramExecutionContext {
    * `event`, so touching it here doesn't build a second one.
    */
   get message(): Message | undefined {
-    return this.event instanceof Message ? this.event : undefined;
+    return this.eventOf(Message);
+  }
+
+  /**
+   * The rich {@link CallbackQuery} when this update is a callback query;
+   * `undefined` otherwise. The callback counterpart to {@link message} — reach
+   * for it in a custom predicate that routes on callback `data` or the attached
+   * `message`. (`@Action` already routes callbacks declaratively.)
+   */
+  get callbackQuery(): CallbackQuery | undefined {
+    return this.eventOf(CallbackQuery);
+  }
+
+  /**
+   * The rich event narrowed to `type`, or `undefined` if this update isn't one.
+   * The general form behind {@link message} / {@link callbackQuery}: for the
+   * less common kinds (`ctx.eventOf(InlineQuery)`, `ctx.eventOf(Poll)`) it hands
+   * back the concrete type the loosely-typed `event` union can't.
+   */
+  eventOf<T extends TelegramObject>(
+    type: new (...args: never[]) => T,
+  ): T | undefined {
+    return this.event instanceof type ? this.event : undefined;
   }
 
   /** The chat the update happened in, when one is present. */

--- a/lib/engine/context/telegram-execution-context.ts
+++ b/lib/engine/context/telegram-execution-context.ts
@@ -2,6 +2,7 @@ import { ArgumentsHost } from '@nestjs/common';
 
 import { BotService } from '../../api';
 import { User } from '../../events/user';
+import { Message } from '../../events/message';
 import { RawChat, RawUpdate } from '../../events/raw-update.types';
 import { extractChat, extractSender } from '../execution/extractors';
 import { EventFactory, TelegramEvent } from './event-factory';
@@ -50,6 +51,19 @@ export class TelegramExecutionContext {
   /** The user who triggered the update, when one is present. */
   get from(): User | undefined {
     return extractSender(this);
+  }
+
+  /**
+   * The rich {@link Message} when this update is a message-family update
+   * (message / edited / channel post / business / guest); `undefined` otherwise.
+   *
+   * The rich counterpart to reaching into `update.message` raw — a custom route
+   * predicate gets the same typed event a handler would, entity sugar
+   * (`message.hasEntity(...)`) and reply helpers included. Reuses the cached
+   * `event`, so touching it here doesn't build a second one.
+   */
+  get message(): Message | undefined {
+    return this.event instanceof Message ? this.event : undefined;
   }
 
   /** The chat the update happened in, when one is present. */

--- a/lib/engine/execution/extractors.ts
+++ b/lib/engine/execution/extractors.ts
@@ -1,11 +1,8 @@
 import { TelegramExecutionContext } from '../context/telegram-execution-context';
 import { UpdateKind } from '../context/update-kind';
 import { User } from '../../events/user';
-import {
-  RawChat,
-  RawMessage,
-  RawMessageEntity,
-} from '../../events/raw-update.types';
+import { messageEntities } from '../../events/message-entity';
+import { RawChat, RawMessage } from '../../events/raw-update.types';
 
 /**
  * Pure derivations of cross-cutting values from a wrapped update.
@@ -138,23 +135,6 @@ export function extractCaption(
   return messageOf(ctx)?.caption;
 }
 
-/** Slice the text of each `type` entity out of its source string. */
-function sliceEntities(
-  source: string | undefined,
-  entities: RawMessageEntity[] | undefined,
-  type: string,
-): string[] {
-  if (!source || !entities) {
-    return [];
-  }
-  // Entity offsets/lengths are UTF-16 code units, matching JS string indices.
-  return entities
-    .filter((entity) => entity.type === type)
-    .map((entity) =>
-      source.slice(entity.offset, entity.offset + entity.length),
-    );
-}
-
 /** The text of every entity of `type`, from both message text and caption. */
 export function extractEntities(
   ctx: TelegramExecutionContext,
@@ -164,10 +144,7 @@ export function extractEntities(
   if (!message) {
     return [];
   }
-  return [
-    ...sliceEntities(message.text, message.entities, type),
-    ...sliceEntities(message.caption, message.caption_entities, type),
-  ];
+  return messageEntities(message, type).map((entity) => entity.text);
 }
 
 /** The text of the first entity of `type`, if any. */

--- a/lib/events/events.spec.ts
+++ b/lib/events/events.spec.ts
@@ -387,4 +387,49 @@ describe('Message entities', () => {
       mentioning(bot).hasEntity({ type: 'mention', text: '@nobody' }),
     ).toBe(false);
   });
+
+  it('mentions() matches case-insensitively, with @ optional', () => {
+    const { bot } = fakeBot();
+    const message = new Message(bot, {
+      message_id: 5,
+      chat: { id: 1, type: 'supergroup' },
+      text: 'ping @My_Bot',
+      entities: [{ type: 'mention', offset: 5, length: 7 }],
+    });
+    expect(message.mentions('my_bot')).toBe(true); // no @, different case
+    expect(message.mentions('@MY_BOT')).toBe(true); // leading @, upper case
+    expect(message.mentions('someone_else')).toBe(false);
+  });
+
+  it('html/markdown render the message back from its entities', () => {
+    const { bot } = fakeBot();
+    const message = new Message(bot, {
+      message_id: 5,
+      chat: { id: 1, type: 'private' },
+      text: 'hello world',
+      entities: [{ type: 'bold', offset: 6, length: 5 }],
+    });
+    expect(message.html).toBe('hello <b>world</b>');
+    expect(message.markdown).toBe('hello *world*');
+  });
+
+  it('html renders from the caption for a media message', () => {
+    const { bot } = fakeBot();
+    const message = new Message(bot, {
+      message_id: 5,
+      chat: { id: 1, type: 'private' },
+      caption: 'nice pic',
+      caption_entities: [{ type: 'italic', offset: 5, length: 3 }],
+    });
+    expect(message.html).toBe('nice <i>pic</i>');
+  });
+
+  it('html is empty when there is no text or caption', () => {
+    const { bot } = fakeBot();
+    const message = new Message(bot, {
+      message_id: 5,
+      chat: { id: 1, type: 'private' },
+    });
+    expect(message.html).toBe('');
+  });
 });

--- a/lib/events/events.spec.ts
+++ b/lib/events/events.spec.ts
@@ -349,3 +349,42 @@ describe('CallbackQuery actions', () => {
     warn.mockRestore();
   });
 });
+
+describe('Message entities', () => {
+  function mentioning(bot: BotService): Message {
+    return new Message(bot, {
+      message_id: 5,
+      chat: { id: 1, type: 'supergroup' },
+      text: 'hey @my_bot and @someone_else',
+      entities: [
+        { type: 'mention', offset: 4, length: 7 },
+        { type: 'mention', offset: 16, length: 13 },
+      ],
+    });
+  }
+
+  it('entitiesOf() returns the entities of a type with their text sliced', () => {
+    const { bot } = fakeBot();
+    expect(
+      mentioning(bot)
+        .entitiesOf('mention')
+        .map((e) => e.text),
+    ).toEqual(['@my_bot', '@someone_else']);
+  });
+
+  it('hasEntity(type) is true when any entity of the type is present', () => {
+    const { bot } = fakeBot();
+    expect(mentioning(bot).hasEntity('mention')).toBe(true);
+    expect(mentioning(bot).hasEntity('hashtag')).toBe(false);
+  });
+
+  it('hasEntity({ type, text }) matches the exact entity text', () => {
+    const { bot } = fakeBot();
+    expect(
+      mentioning(bot).hasEntity({ type: 'mention', text: '@my_bot' }),
+    ).toBe(true);
+    expect(
+      mentioning(bot).hasEntity({ type: 'mention', text: '@nobody' }),
+    ).toBe(false);
+  });
+});

--- a/lib/events/index.ts
+++ b/lib/events/index.ts
@@ -7,6 +7,7 @@ export * from './media';
 // Rich event classes (one per update kind), built by the EventFactory and
 // handed to handlers as the typed positional event.
 export * from './message';
+export * from './message-entity';
 export * from './callback-query';
 export * from './inline-query';
 export * from './chosen-inline-result';

--- a/lib/events/message-entity.spec.ts
+++ b/lib/events/message-entity.spec.ts
@@ -1,0 +1,83 @@
+import { messageEntities } from './message-entity';
+
+describe('messageEntities', () => {
+  it('slices each entity of the requested type out of the text', () => {
+    const entities = messageEntities(
+      {
+        text: 'ping @alice and @bob',
+        entities: [
+          { type: 'mention', offset: 5, length: 6 },
+          { type: 'mention', offset: 16, length: 4 },
+        ],
+      },
+      'mention',
+    );
+    expect(entities.map((entity) => entity.text)).toEqual(['@alice', '@bob']);
+  });
+
+  it('draws from the text and the caption both', () => {
+    const entities = messageEntities({
+      text: 'see #news',
+      entities: [{ type: 'hashtag', offset: 4, length: 5 }],
+      caption: 'and #sport',
+      caption_entities: [{ type: 'hashtag', offset: 4, length: 6 }],
+    });
+    expect(entities.map((entity) => entity.text)).toEqual(['#news', '#sport']);
+  });
+
+  it('keeps only the requested type', () => {
+    const entities = messageEntities(
+      {
+        text: 'mail a@b.co about http://x.io',
+        entities: [
+          { type: 'email', offset: 5, length: 6 },
+          { type: 'url', offset: 18, length: 11 },
+        ],
+      },
+      'url',
+    );
+    expect(entities.map((entity) => entity.text)).toEqual(['http://x.io']);
+  });
+
+  it('returns every entity when no type is given', () => {
+    const entities = messageEntities({
+      text: '@a #b',
+      entities: [
+        { type: 'mention', offset: 0, length: 2 },
+        { type: 'hashtag', offset: 3, length: 2 },
+      ],
+    });
+    expect(entities.map((entity) => entity.type)).toEqual([
+      'mention',
+      'hashtag',
+    ]);
+  });
+
+  it('preserves the raw entity fields alongside the sliced text', () => {
+    const [entity] = messageEntities({
+      text: 'ping @bob',
+      entities: [{ type: 'mention', offset: 5, length: 4, url: 'x' }],
+    });
+    expect(entity).toEqual({
+      type: 'mention',
+      offset: 5,
+      length: 4,
+      url: 'x',
+      text: '@bob',
+    });
+  });
+
+  it('honors UTF-16 offsets past a surrogate-pair emoji', () => {
+    // '👍' is two UTF-16 code units, so '@bob' starts at offset 3 — the same
+    // units Telegram counts, and the same units JS `slice` indexes.
+    const [entity] = messageEntities({
+      text: '👍 @bob',
+      entities: [{ type: 'mention', offset: 3, length: 4 }],
+    });
+    expect(entity.text).toBe('@bob');
+  });
+
+  it('is empty when the message carries no entities', () => {
+    expect(messageEntities({ text: 'plain' })).toEqual([]);
+  });
+});

--- a/lib/events/message-entity.ts
+++ b/lib/events/message-entity.ts
@@ -1,0 +1,51 @@
+import { RawMessage, RawMessageEntity } from './raw-update.types';
+
+/**
+ * A message entity with its `text` resolved — the rich counterpart to
+ * {@link RawMessageEntity}, whose `offset`/`length` only index into the message
+ * text or caption. Every raw field is preserved; `text` is the substring the
+ * entity spans (e.g. the `@username` of a `mention`, the URL of a `url`).
+ */
+export type MessageEntity = RawMessageEntity & { text: string };
+
+/**
+ * A {@link Message.hasEntity} query: a bare entity `type` (any entity of that
+ * kind matches), or a `type` paired with the exact `text` the entity must span
+ * (e.g. `{ type: 'mention', text: '@my_bot' }`).
+ */
+export type EntityQuery = string | { type: string; text: string };
+
+/** The text (or caption) fields an entity can be sliced out of. */
+type EntityCarrier = Pick<
+  RawMessage,
+  'text' | 'entities' | 'caption' | 'caption_entities'
+>;
+
+/**
+ * The entities carried by `message` — from its text and its media caption both —
+ * each paired with the `text` it spans. Pass a `type` to keep only that kind.
+ *
+ * Entity `offset`/`length` are UTF-16 code units, which is exactly how JS indexes
+ * strings — so a plain `slice` is correct, no surrogate juggling needed.
+ */
+export function messageEntities(
+  message: EntityCarrier,
+  type?: string,
+): MessageEntity[] {
+  const sources: [string | undefined, RawMessageEntity[] | undefined][] = [
+    [message.text, message.entities],
+    [message.caption, message.caption_entities],
+  ];
+
+  return sources.flatMap(([source, entities]) => {
+    if (!source || !entities) {
+      return [];
+    }
+    return entities
+      .filter((entity) => type === undefined || entity.type === type)
+      .map((entity) => ({
+        ...entity,
+        text: source.slice(entity.offset, entity.offset + entity.length),
+      }));
+  });
+}

--- a/lib/events/message.ts
+++ b/lib/events/message.ts
@@ -23,12 +23,14 @@ import {
 import { UpdateType } from '../decorators';
 import { InputFile } from '../api/input-file';
 import { NestgramError } from '../exceptions';
+import { entitiesToHtml, entitiesToMarkdown } from '../formatting';
 import { EntityQuery, MessageEntity, messageEntities } from './message-entity';
 import type { StreamOptions, StreamSource } from '../streaming';
 import type {
   RawInlineQueryResult,
   RawInputRichMessage,
   RawMessage,
+  RawMessageEntity,
 } from './raw-update.types';
 import {
   Animation,
@@ -131,6 +133,44 @@ export class Message extends TelegramObject {
     return messageEntities(this, query.type).some(
       (entity) => entity.text === query.text,
     );
+  }
+
+  /**
+   * Whether this message `@mentions` the given username — case-insensitive, with
+   * the leading `@` optional. The correct test for a mention: Telegram usernames
+   * ignore case, where {@link hasEntity} matches the entity text exactly. Matches
+   * only `mention` entities (an `@handle`), not the `text_mention` of a user who
+   * has no username.
+   */
+  mentions(username: string): boolean {
+    const handle = `@${username.replace(/^@/, '').toLowerCase()}`;
+    return this.entitiesOf('mention').some(
+      (entity) => entity.text.toLowerCase() === handle,
+    );
+  }
+
+  /**
+   * This message's text (or media caption) rendered back to HTML from its
+   * entities — the inverse of sending with `parse_mode: 'HTML'`. Bold, links,
+   * spoilers and the rest survive, so a bot can quote or forward a message
+   * without dropping its formatting. Empty string when there is no text/caption.
+   */
+  get html(): string {
+    const [text, entities] = this.formattedSource();
+    return entitiesToHtml(text, entities);
+  }
+
+  /** Like {@link html}, rendered back to MarkdownV2. */
+  get markdown(): string {
+    const [text, entities] = this.formattedSource();
+    return entitiesToMarkdown(text, entities);
+  }
+
+  /** This message's text + entities, or — for media — its caption + caption_entities. */
+  private formattedSource(): [string, RawMessageEntity[] | undefined] {
+    return this.text !== undefined
+      ? [this.text, this.entities]
+      : [this.caption ?? '', this.caption_entities];
   }
 
   /**

--- a/lib/events/message.ts
+++ b/lib/events/message.ts
@@ -23,6 +23,7 @@ import {
 import { UpdateType } from '../decorators';
 import { InputFile } from '../api/input-file';
 import { NestgramError } from '../exceptions';
+import { EntityQuery, MessageEntity, messageEntities } from './message-entity';
 import type { StreamOptions, StreamSource } from '../streaming';
 import type {
   RawInlineQueryResult,
@@ -106,6 +107,30 @@ export class Message extends TelegramObject {
     if (raw.video_note)
       this.video_note = new VideoNote(botService, raw.video_note);
     if (raw.sticker) this.sticker = new Sticker(botService, raw.sticker);
+  }
+
+  /**
+   * The entities in this message — from its text and its media caption both —
+   * each with the `text` it spans resolved. Pass a `type` to keep only that
+   * kind (`message.entitiesOf('url')`). The object form of `@Entities()`.
+   */
+  entitiesOf(type?: string): MessageEntity[] {
+    return messageEntities(this, type);
+  }
+
+  /**
+   * Whether this message carries a matching entity: a bare `type`
+   * (`message.hasEntity('mention')`), or a `{ type, text }` also requiring the
+   * entity's text to match exactly (`{ type: 'mention', text: '@my_bot' }`).
+   * Checks the text and the caption.
+   */
+  hasEntity(query: EntityQuery): boolean {
+    if (typeof query === 'string') {
+      return messageEntities(this, query).length > 0;
+    }
+    return messageEntities(this, query.type).some(
+      (entity) => entity.text === query.text,
+    );
   }
 
   /**


### PR DESCRIPTION
Surface Telegram message entities as rich behaviour on the `Message` event, and
let custom predicate/guard authors read the rich event off the execution context
instead of the raw payload.

## Why

Reading entities meant dropping to `ctx.update.message` and hand-slicing
`offset`/`length` — the exact raw-payload work the rich events exist to avoid. A
predicate had no ergonomic path to the typed `Message` at all.

## API

**`Message`**

- `message.hasEntity(type | { type, text })` — presence, or exact entity-text
  match; checks the text and the caption.
- `message.entitiesOf(type?)` — the entities with their `text` sliced (the object
  form of `@Entities()`).
- `message.mentions(username)` — case-insensitive, `@`-optional mention check.
  Telegram usernames ignore case, where `hasEntity` matches text exactly, so this
  is the correct test.
- `message.html` / `message.markdown` — reconstruct the message's formatted
  source from its entities (the inverse of sending with a `parse_mode`), so a bot
  can quote or forward without flattening formatting.

**`TelegramExecutionContext`** (custom predicates / guards)

- `ctx.message` / `ctx.callbackQuery` — the cached rich event narrowed to the two
  dominant routable kinds.
- `ctx.eventOf(Type)` — generic narrowing to any event class. This is the
  deliberate ceiling: two named getters for the common kinds, one generic for the
  long tail (`ctx.eventOf(InlineQuery)`), so the context never grows a getter per
  update kind.

Internals: the slicing logic is now a shared pure `messageEntities()`; the
`@Mention` / `@Entities` param decorators route through it (behaviour unchanged),
and `html`/`markdown` reuse the existing `entitiesToHtml` / `entitiesToMarkdown`.

## Docs

- New `docs/entities.md` — routing on, injecting, and reading entities, plus the
  custom-predicate use of `ctx.message`.
- Rate-limiting split: the page at `/docs/rate-limiting` was actually the
  send-throttler guide wearing a "Rate limiting" label, so the inbound
  `@RateLimit` feature (`RateLimitModule`, `@RateLimit`/`@SkipRateLimit`) was
  undocumented. Renamed that page to `docs/throttling.md` and wrote a real
  `docs/rate-limiting.md` for the inbound feature.
- Listed the new accessors in the predicate and pipeline accessor tables.

## Verify

- `npm run build && npm run lint && npx jest` — green (956 tests).
- `cd website && npm run build` — docs render.
