### PR TITLE
fix(build): pin dist layout so the published entry resolves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist
 /node_modules
 *.tgz
+*.tsbuildinfo
 
 # Env
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestgram",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nestgram",
-      "version": "2.0.0-alpha.4",
+      "version": "2.0.0-alpha.5",
       "license": "MIT",
       "workspaces": [
         "examples/reminder-bot"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestgram",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0-alpha.5",
   "description": "Telegram bots, the NestJS way — typed events, the real Nest pipeline (guards, interceptors, pipes, filters), and a generated Bot API layer",
   "author": "Mykyta Voitsekhovskyi <mykyta@kodo.do>",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "generate": "ts-node --project tools/codegen/tsconfig.json tools/codegen/index.ts",
     "spec:update": "ts-node --project tools/codegen/tsconfig.json tools/codegen/spec-update.ts",
     "prepare": "husky",
-    "prepublishOnly": "npm run lint && npm run build && npm run test && npm run generate -- --check"
+    "verify:package": "node -e \"const p=require('./package.json'),fs=require('fs');for(const f of [p.main,p.types])if(!fs.existsSync(f))throw new Error('package entry missing: '+f+' - built dist layout is wrong, see rootDir in tsconfig.build.json');require('./'+p.main);console.log('package entry ok:',p.main)\"",
+    "prepublishOnly": "npm run lint && npm run build && npm run test && npm run generate -- --check && npm run verify:package"
   },
   "devDependencies": {
     "@fluent/bundle": "^0.19.1",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,7 +6,12 @@
     // common parent of everything it compiles, so a single stray `.ts` outside
     // `lib/` silently moves the whole package under `dist/lib/`. With it, such a
     // file is a loud build error instead of a broken publish.
-    "rootDir": "./lib"
+    "rootDir": "./lib",
+    // Must live INSIDE outDir: `nest-cli.json` sets `deleteOutDir`, so wiping
+    // `dist/` has to reset the incremental state too. Left outside (where
+    // `rootDir` would otherwise put it), a stale build-info survives the wipe and
+    // tsc emits nothing — leaving an empty `dist/`.
+    "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildinfo"
   },
   "include": ["lib/**/*"],
   "exclude": [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,14 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Pins the published layout: `dist/` mirrors `lib/`, so `main`
+    // (`dist/index.js`) always resolves. Without it tsc INFERS the root from the
+    // common parent of everything it compiles, so a single stray `.ts` outside
+    // `lib/` silently moves the whole package under `dist/lib/`. With it, such a
+    // file is a loud build error instead of a broken publish.
+    "rootDir": "./lib"
+  },
+  "include": ["lib/**/*"],
   "exclude": [
     "node_modules",
     "src",


### PR DESCRIPTION
## Problem

`nestgram@2.0.0-alpha.4` is unusable: `require('nestgram')` throws because the published tarball has no `dist/index.js`.

`tsconfig.build.json` set neither `rootDir` nor `include`, so tsc inferred the output root from the common parent of everything it compiled. A stray `.ts` in the repo root — uncommitted, but present in the working tree that `npm publish` builds from — moved that root from `lib/` to the repo root, emitting the whole package under `dist/lib/` while `main` / `types` / `exports` still point at `dist/index.js`.

Published `2.0.0-alpha.4` contents:

```
package/dist/_livetest.js     <- stray build artifact
package/dist/lib/index.js     <- real entry, one level too deep
package/dist/index.js         <- missing; `main` points here
```

## Change

- **`tsconfig.build.json`** — pin `rootDir: "./lib"` and `include: ["lib/**/*"]`. The published layout is now deterministic (`dist/` mirrors `lib/`), and any file outside `lib/` becomes a loud build error instead of silently restructuring the package. Also pin `tsBuildInfoFile` inside `dist/`: `nest-cli.json` sets `deleteOutDir`, so the incremental state must be wiped with the output — a build-info left outside survives the wipe and tsc then emits nothing into the empty `dist/`.
- **`package.json`** — add `verify:package`, wired into `prepublishOnly`: it asserts `main`/`types` exist on disk and `require()`s the entry, so a broken layout cannot be published again.
- **`.gitignore`** — ignore `*.tsbuildinfo`, a build artifact that shouldn't be committed from any config.
- Bump to `2.0.0-alpha.5`; npm will not accept a republish of `2.0.0-alpha.4`.

## Verify

```bash
npm run build
ls dist/index.js dist/index.d.ts   # both exist
ls dist/lib dist/_livetest.js      # both absent
npm run verify:package             # "package entry ok: dist/index.js"
npm pack --dry-run                 # dist/index.js present; no dist/lib/, no tsbuildinfo
```

Repeat the build — a second run must still emit an entry, which is what the `tsBuildInfoFile` pin buys:

```bash
npm run build && npm run verify:package   # still "package entry ok"
```

The guard fails as intended when the entry is missing:

```bash
mv dist/index.js /tmp/ && npm run verify:package   # exits 1
```
