### PR TITLE
i18n: render missing keys as a visible dev marker

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -196,7 +196,7 @@ export class ReminderRouter {
 
 1. `ReminderService` knows nothing about Telegram, locales, or i18n config — it calls `t()` and gets text in the right language, because it runs inside the same update's call chain that `I18nStage` seeded.
 2. The second argument is interpolation params: `{count}` in the template becomes the value you pass. An unmatched placeholder stays visible in the output (`{cuont}` is a bug you can see), never silently blanked — only names the params object actually owns get replaced.
-3. A key missing from every catalog comes back **as the key itself** — visible in chat, never a throw. A bot should still answer even when a translation is missing.
+3. A key missing from every catalog never throws — it comes back visibly (the raw key, or in development a debug marker; see [Spotting a missing key](#spotting-a-missing-key)). A bot should still answer even when a translation is missing.
 
 :::
 
@@ -207,11 +207,53 @@ the ambient store, so it works anywhere in the update's call chain — but only
 there. Outside an update, inject `I18nService` and call `i18n.t(key, 'uk')`
 instead (the queue section covers it).
 
+## Spotting a missing key
+
+In development, a missing key renders as a visible marker instead of silently
+reading as its key — the key, then one `name: value` line per param the call
+passed, so a miss with several params stays readable:
+
+```text
+⟨cart.summary
+  items: 3
+  total: 42⟩
+```
+
+A param-less miss is just `⟨cart.empty⟩`. In production it falls back to the
+bare key: never a throw, the bot always answers.
+
+This is the `devMode` flag. It defaults to `true` only when `NODE_ENV` is
+`'development'` — it fails _closed_, so an unset or misconfigured environment in
+production never surfaces a marker to real users. A bare `nest start` doesn't set
+`NODE_ENV`, so pass `devMode: true` to see markers locally without it:
+
+:::code[app.module.ts]
+
+```ts
+import { I18nModule } from 'nestgram';
+import { join } from 'path';
+
+I18nModule.forRoot({
+  source: join(__dirname, 'locales'),
+  defaultLocale: 'en',
+  devMode: true, // show markers locally even without NODE_ENV=development
+});
+```
+
+:::
+
+:::caution
+The marker is raw text spliced into the reply, so a bot on `MarkdownV2` (or
+`HTML`) parse mode can have Telegram reject one whose key or value holds a
+reserved character — a dotted key like `cart.empty` is enough. It's a
+development aid; `logMissingKeys` is the parse-mode-safe signal (below), and
+production returns the bare key regardless.
+:::
+
 :::tip
-Turn on `logMissingKeys: true` while developing to surface catalog gaps. A
-missing key warns once per locale+key and still returns the key verbatim, so
-the bot keeps answering. Off by default — returning the key is the deliberate,
-safe fallback in production.
+`logMissingKeys: true` is the complementary knob: it warns once per locale+key
+to the logger (handy in staging with a log aggregator), independent of what
+`devMode` renders into the chat. Off by default.
 :::
 
 ## When you need the locale, not a translation

--- a/lib/engine/matching/hears-key.predicate.spec.ts
+++ b/lib/engine/matching/hears-key.predicate.spec.ts
@@ -12,6 +12,7 @@ function manager(): I18nService {
   return new I18nService({
     backend: new FlatTranslatorBackend(TRANSLATIONS),
     defaultLocale: 'en',
+    devMode: false,
   });
 }
 

--- a/lib/i18n/i18n.module.ts
+++ b/lib/i18n/i18n.module.ts
@@ -105,7 +105,14 @@ export class I18nModule {
           : (translations as Translations),
       );
 
-    return { ...base, backend: resolvedBackend };
+    return {
+      ...base,
+      backend: resolvedBackend,
+      // Fail closed: markers show only for an explicit development env, so an
+      // unset or misconfigured NODE_ENV never surfaces them in production. Read
+      // once at boot, never on the per-miss hot path.
+      devMode: base.devMode ?? process.env.NODE_ENV === 'development',
+    };
   }
 
   /** A path means the built-in directory loader; anything else is already a source. */

--- a/lib/i18n/i18n.service.ts
+++ b/lib/i18n/i18n.service.ts
@@ -27,6 +27,11 @@ import type {
  */
 @Injectable()
 export class I18nService {
+  // Mathematical angle brackets (U+27E8/U+27E9): visually distinct and
+  // near-absent from real message text, so a dev-mode missing key stands out.
+  private static readonly MISSING_OPEN = '⟨';
+  private static readonly MISSING_CLOSE = '⟩';
+
   private readonly logger = new Logger('I18n');
   private readonly translators = new Map<string, TranslateFn>();
   private readonly missingWarned = new Set<string>();
@@ -108,17 +113,38 @@ export class I18nService {
         config.backend.format(locale, key, params) ??
         config.backend.format(fallback, key, params);
       if (text === undefined) {
-        // Returning the key is a safe, visible fallback; warn only when asked,
-        // so a genuine catalog gap is catchable without noise in production.
         if (config.logMissingKeys) {
           this.warnMissingKey(locale, key);
         }
-        return key;
+        // In dev, surface the gap in the chat; in prod, the bare key is the
+        // deliberate, safe fallback (never throw, always answer).
+        return config.devMode ? I18nService.renderMissing(key, params) : key;
       }
       return text;
     };
     this.translators.set(locale, translator);
     return translator;
+  }
+
+  /**
+   * A missing key as a visible dev marker: `⟨key⟩`, or the key followed by one
+   * `name: value` line per param the call passed — readable when there are
+   * several, where a comma-joined line runs together. The angle brackets are
+   * near-absent from real message text, so a miss is obvious at a glance; `: `
+   * (unlike `=`/`|`) is not reserved in MarkdownV2, so params add nothing to the
+   * parse-mode footprint — only the key can.
+   */
+  private static renderMissing(key: string, params?: TranslateParams): string {
+    const open = I18nService.MISSING_OPEN;
+    const close = I18nService.MISSING_CLOSE;
+    const entries = params ? Object.entries(params) : [];
+    if (entries.length === 0) {
+      return `${open}${key}${close}`;
+    }
+    const lines = entries
+      .map(([name, value]) => `  ${name}: ${String(value)}`)
+      .join('\n');
+    return `${open}${key}\n${lines}${close}`;
   }
 
   private warnMissingKey(locale: string, key: string): void {

--- a/lib/i18n/i18n.spec.ts
+++ b/lib/i18n/i18n.spec.ts
@@ -1,8 +1,10 @@
-import { Logger } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
 
 import { runAmbient } from '../ambient';
 import { TelegramExecutionContext } from '../engine/context';
 import { FlatTranslatorBackend } from './backends';
+import { I18nModule } from './i18n.module';
 import { I18nService } from './i18n.service';
 import { locale, t } from './translate';
 import type { ResolvedI18nOptions } from './i18n.types';
@@ -18,6 +20,7 @@ function manager(
   const config = extra && {
     backend: new FlatTranslatorBackend(TRANSLATIONS),
     defaultLocale: 'en',
+    devMode: false,
     ...extra,
   };
   return new I18nService(config);
@@ -191,6 +194,90 @@ describe('I18nService.t outside an update', () => {
 
   it('returns the key when i18n is off', () => {
     expect(manager(undefined).t('hi', 'uk')).toBe('hi');
+  });
+});
+
+describe('devMode missing-key rendering', () => {
+  it('renders a bare missing key as a visible marker', () => {
+    expect(manager({ devMode: true }).t('nope')).toBe('⟨nope⟩');
+  });
+
+  it('lists each param on its own line', () => {
+    expect(
+      manager({ devMode: true }).t('nope', { name: 'Ann', count: 3 }),
+    ).toBe('⟨nope\n  name: Ann\n  count: 3⟩');
+  });
+
+  it('renders a falsy param value rather than dropping it', () => {
+    expect(manager({ devMode: true }).t('nope', { count: 0 })).toBe(
+      '⟨nope\n  count: 0⟩',
+    );
+  });
+
+  it('renders through the free t() on the ambient rail too', () => {
+    runAmbient(() => {
+      manager({ devMode: true }).resolve(ctxWithLanguage('en'));
+      expect(t('nope', { id: 7 })).toBe('⟨nope\n  id: 7⟩');
+    });
+  });
+
+  it('returns the bare key when devMode is off', () => {
+    expect(manager({ devMode: false }).t('nope', { name: 'Ann' })).toBe('nope');
+  });
+
+  it('never touches a key that resolves — devMode changes only the miss path', () => {
+    expect(manager({ devMode: true }).t('hi', { name: 'Ann' })).toBe(
+      'Hello, Ann!',
+    );
+  });
+});
+
+describe('devMode default from NODE_ENV', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  async function missText(nodeEnv: string | undefined): Promise<string> {
+    if (nodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = nodeEnv;
+    }
+    @Module({
+      imports: [
+        I18nModule.forRoot({ translations: TRANSLATIONS, defaultLocale: 'en' }),
+      ],
+    })
+    class DevModeAppModule {}
+    const app = await NestFactory.createApplicationContext(DevModeAppModule, {
+      logger: false,
+    });
+    try {
+      return app.get(I18nService).t('nope');
+    } finally {
+      await app.close();
+    }
+  }
+
+  it('renders the debug marker only when NODE_ENV is development', async () => {
+    expect(await missText('development')).toBe('⟨nope⟩');
+  });
+
+  it('fails closed to the bare key when NODE_ENV is unset', async () => {
+    expect(await missText(undefined)).toBe('nope');
+  });
+
+  it('fails closed for a non-development env (e.g. staging)', async () => {
+    expect(await missText('staging')).toBe('nope');
+  });
+
+  it('returns the bare key when NODE_ENV is production', async () => {
+    expect(await missText('production')).toBe('nope');
   });
 });
 

--- a/lib/i18n/i18n.types.ts
+++ b/lib/i18n/i18n.types.ts
@@ -60,6 +60,16 @@ interface I18nBaseOptions {
    * output. Off by default (returning the key is a deliberate, safe fallback).
    */
   logMissingKeys?: boolean;
+  /**
+   * Render a missing key as a visible debug marker — `⟨greeting⟩`, plus one
+   * `name: value` line per param the call passed — instead of the bare key, so
+   * an untranslated string is obvious in the chat while developing. Defaults to
+   * `true` only when `NODE_ENV` is `'development'`: it fails closed, so an unset
+   * or misconfigured environment never surfaces the marker in production. Set it
+   * explicitly to override. Independent of {@link logMissingKeys}, which warns
+   * to the logger rather than changing the output.
+   */
+  devMode?: boolean;
 }
 
 /**
@@ -98,4 +108,6 @@ export interface I18nOptions extends I18nBaseOptions {
  */
 export interface ResolvedI18nOptions extends I18nBaseOptions {
   backend: TranslatorBackend;
+  /** Resolved once at boot: the option, else `NODE_ENV === 'development'`. */
+  devMode: boolean;
 }


### PR DESCRIPTION
## What was done

- Added a `devMode` option to `I18nModule.forRoot` / `forRootAsync`.
- With it on, a key missing from both the resolved locale and the fallback renders as a visible marker instead of the bare key.
- The marker lists one `name: value` line per interpolation param, so a miss carrying several stays readable:

```text
⟨cart.summary
  items: 3
  total: 42⟩
```

- A param-less miss renders as `⟨cart.empty⟩`.
- `devMode` defaults to `NODE_ENV === 'development'`, resolved once at boot; an explicit value always wins.
- Documented in `docs/i18n.md` under "Spotting a missing key".

## Why

A missing translation returns the raw key, which is a deliberate fallback — the bot must always answer, never throw. But a raw key reads like plausible copy (`cart.empty` looks like a label), so an untranslated string reaches a chat with no signal that anything is wrong, and the gap survives review. Rendering the key and the params it was called with makes the miss self-evident at the point it happens, and points straight at the call site.

## Notes

- Production behaviour is unchanged: the bare key, no throw.
- The default fails closed — only an exact `NODE_ENV` of `development` enables it. An unset or misspelled environment variable in production therefore keeps the bare key, which matters because the marker includes interpolated values. Note that `nest start` does not set `NODE_ENV`, so local runs need `NODE_ENV=development` or an explicit `devMode: true`.
- Independent of `logMissingKeys`, which warns to the logger and does not change output. Either, both, or neither can be on.
- Only the miss path is touched; a key that resolves, or one served by the fallback locale, is unaffected.
- Both call styles inherit it, since the free `t()` and the injected `i18n.t()` share one implementation.
- `ResolvedI18nOptions.devMode` is required rather than optional — the module always resolves a definite value before the service sees it. This is the internal post-resolution type, not the public option.
- The marker is raw text spliced into the reply, so a bot on `MarkdownV2`/`HTML` parse mode can have Telegram reject one whose key or value holds a reserved character (a dotted key is enough). `: ` is used as the separator rather than `=`/`|` precisely because it is not reserved, so params add nothing to that risk.
